### PR TITLE
Add gcc-15 and clang-22 to the devcontainers.

### DIFF
--- a/.devcontainer/android/Dockerfile
+++ b/.devcontainer/android/Dockerfile
@@ -18,7 +18,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 100
 
-# Clang 22 (available in Ubuntu 25.10 main archive)
+# Add the official LLVM apt repository so that clang-22 packages are available.
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+        -o /usr/share/keyrings/llvm-apt-key.asc \
+    && . /etc/os-release \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-apt-key.asc] http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" \
+       > /etc/apt/sources.list.d/llvm-22.list
+
+# Clang 22
 RUN apt-get update && apt-get install -y --no-install-recommends \
     clang-22 \
     clang-format-22 \

--- a/.devcontainer/linux/Dockerfile
+++ b/.devcontainer/linux/Dockerfile
@@ -24,7 +24,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 100
 
-# Clang 22 (available in Ubuntu 25.10 main archive)
+# Add the official LLVM apt repository so that clang-22 packages are available.
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+        -o /usr/share/keyrings/llvm-apt-key.asc \
+    && . /etc/os-release \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-apt-key.asc] http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" \
+       > /etc/apt/sources.list.d/llvm-22.list
+
+# Clang 22
 RUN apt-get update && apt-get install -y --no-install-recommends \
     clang-22 \
     clang-format-22 \


### PR DESCRIPTION
- [x] Investigate CI failures: `clang-22` packages not found in Ubuntu 25.10 Docker Hub image's default apt repos
- [x] Add LLVM apt repository to linux devcontainer Dockerfile before clang-22 install
- [x] Add LLVM apt repository to android devcontainer Dockerfile before clang-22 install
- [x] Verify fix addresses both failing workflows (linux and android)

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/funnansoftwarellc/awen/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
