### PR TITLE
Port the steamos workflow from briarthorn to the Qt/vcpkg build

### DIFF
--- a/.devcontainer/steamos/Dockerfile
+++ b/.devcontainer/steamos/Dockerfile
@@ -70,6 +70,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxkbcommon-x11-dev libegl1-mesa-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Modern Autoconf. vcpkg's gperf port (a fontconfig build tool) autoreconfs a
+# configure.ac that requires Autoconf >= 2.70; Debian 11 ships 2.69 with no
+# backport, so build the upstream release into /usr/local, which shadows the
+# apt autoconf on PATH. automake/libtool stay the apt versions — vcpkg vendors
+# its own automake (vcpkg-make port) and only autoconf is too old.
+ARG AUTOCONF_VERSION=2.72
+RUN curl -fsSLo /tmp/autoconf.tar.xz \
+    "https://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.xz" \
+    && mkdir -p /tmp/autoconf \
+    && tar -xJf /tmp/autoconf.tar.xz -C /tmp/autoconf --strip-components=1 \
+    && cd /tmp/autoconf \
+    && ./configure --prefix=/usr/local \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf /tmp/autoconf /tmp/autoconf.tar.xz
+
 # Modern CMake. The presets use schema "version": 7 and CMakeLists requires
 # CMake >= 3.31; Debian 11 ships 3.18 and Kitware's apt repo is Ubuntu-only, so
 # install the official upstream binary release directly.

--- a/.devcontainer/steamos/Dockerfile
+++ b/.devcontainer/steamos/Dockerfile
@@ -1,0 +1,83 @@
+# Steam Deck build container — Steam Linux Runtime 3.0 "sniper".
+#
+# This image exists for BINARY COMPATIBILITY with the Steam Deck, not for the
+# newest toolchain. The linux build is *native*: a binary's minimum glibc equals
+# the glibc of the container it was built in, and vcpkg builds Qt from source in
+# that same container, so the deployed Qt libraries inherit the same floor. The
+# main devcontainer is Ubuntu 25.10 with a bleeding-edge glibc; anything built
+# there fails on the Deck with "version `GLIBC_x.xx' not found".
+#
+# Sniper is Steam Linux Runtime 3.0 — the container Steam guarantees at game
+# launch on the Deck and every other Steam platform. It is Debian 11 based
+# (glibc 2.31), below the Deck's ~2.37, and glibc is forward-compatible, so a
+# binary built here runs both directly in SteamOS Desktop Mode and inside the
+# Steam runtime container. Pin a dated 3.0.* tag instead of :latest for stricter
+# reproducibility.
+#
+# Image ref: https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/sniper/README.md
+FROM registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base utilities and build tooling — the same set as the main Dockerfile (minus
+# cmake, handled below); binutils provides the objdump the CI glibc-floor check
+# runs over the installed tree. The sniper SDK ships most of this already; we
+# install explicitly so the image is self-describing and resilient to SDK drift.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    make \
+    ninja-build \
+    binutils \
+    pkg-config \
+    python3 \
+    zip \
+    unzip \
+    xz-utils \
+    tar \
+    && rm -rf /var/lib/apt/lists/*
+
+# GCC 14, Valve's backport in the sniper SDK repos. Debian 11's own gcc-10 /
+# clang-11 cannot compile C++23 (or Qt 6.11) — the backport is what makes a
+# modern build possible while keeping the glibc 2.31 floor. Its libstdc++ is
+# newer than the base system's, but that is the supported path: the Steam Linux
+# Runtime uses the newest libstdc++ of host vs runtime at game launch, and
+# SteamOS's own libstdc++ is newer still.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc-14 \
+    g++-14 \
+    && rm -rf /var/lib/apt/lists/*
+
+# CMake's compiler detection honors CC/CXX, and vcpkg's port builds go through
+# that detection — this is what points the whole dependency tree (Qt included)
+# at the gcc-14 backport instead of the SDK's default gcc-10, which plain
+# `cc`/`c++` still resolve to. The steamos preset pins the same pair for the
+# project itself.
+ENV CC=gcc-14 \
+    CXX=g++-14
+
+# Qt build dependencies — vcpkg builds Qt from source on linux (xcb windowing,
+# EGL, xkbcommon) and its meta-build needs the autotools family. Same set as
+# the main Dockerfile.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    autoconf-archive \
+    automake \
+    libtool \
+    '^libxcb.*-dev' \
+    libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev \
+    libxkbcommon-x11-dev libegl1-mesa-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Modern CMake. The presets use schema "version": 7 and CMakeLists requires
+# CMake >= 3.31; Debian 11 ships 3.18 and Kitware's apt repo is Ubuntu-only, so
+# install the official upstream binary release directly.
+ARG CMAKE_VERSION=3.31.12
+RUN curl -fsSLo /tmp/cmake.tar.gz \
+    "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz" \
+    && mkdir -p /opt \
+    && tar -xzf /tmp/cmake.tar.gz -C /opt \
+    && rm /tmp/cmake.tar.gz \
+    && ln -sf "/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cmake" /usr/local/bin/cmake \
+    && ln -sf "/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest" /usr/local/bin/ctest

--- a/.devcontainer/steamos/README.md
+++ b/.devcontainer/steamos/README.md
@@ -1,0 +1,69 @@
+# Steam Deck build container (Steam Linux Runtime "sniper")
+
+A second devcontainer whose only job is to produce `briarthorn` binaries that
+**run on the Steam Deck**. The default dev container (`.devcontainer/`) is Ubuntu
+25.10 with a bleeding-edge glibc; anything built there fails on the Deck with
+`version 'GLIBC_x.xx' not found`.
+
+## Why sniper
+
+The linux build is *native* — a binary's minimum glibc equals the glibc of the
+container it was built in, and vcpkg builds Qt from source in that same
+container, so the deployed Qt libraries inherit the same floor. "Sniper" is
+Steam Linux Runtime 3.0, the container Steam guarantees at game launch on the
+Deck and every other Steam platform. It is Debian 11 based (glibc 2.31), below
+the Deck's ~2.37, and glibc is forward-compatible — so binaries built here run
+both directly in SteamOS Desktop Mode and inside the Steam runtime container.
+
+|           | default dev container | this (sniper)      | Steam Deck (SteamOS 3.x) |
+| ---       | ---                   | ---                | ---                      |
+| base      | Ubuntu 25.10          | Debian 11 (sniper) | Arch / Holo              |
+| glibc     | ~2.42                 | **2.31**           | ~2.37–2.41               |
+| toolchain | gcc-15 / clang-22     | **gcc-14 backport**| —                        |
+
+Debian 11's own gcc-10/clang-11 cannot compile C++23 (or Qt 6.11). Valve
+backports gcc-14 into the sniper SDK for exactly this purpose: a modern compiler
+against the old glibc. The image exports `CC`/`CXX` pointing at it so vcpkg's
+dependency builds (Qt included) pick it up, and the `steamos` preset pins the
+same pair for the project.
+
+gcc-14 binaries want gcc-14's libstdc++ at runtime, which is newer than the base
+system's — that is the supported path: the Steam Linux Runtime uses the newest
+libstdc++ of host vs runtime at game launch, and SteamOS's own libstdc++ is
+newer still.
+
+## Open it
+
+VS Code → **Dev Containers: Reopen in Container** → pick **awen-steamos**.
+(With multiple `.devcontainer/*/devcontainer.json` files, VS Code prompts for
+which configuration to use.) The first launch pulls the sniper SDK image (a few
+GB), and the first configure builds Qt from source via vcpkg — slow once, then
+binary-cached.
+
+## Build
+
+```sh
+cmake --preset steamos                          # configure (first run builds Qt)
+cmake --build --preset steamos                  # build
+ctest --preset steamos                          # run the test suite
+cmake --build --preset steamos --target install # deploy into build/steamos/installed
+```
+
+The install step deploys the dynamic Qt libraries, platform plugins and QML
+imports next to the binary, so `build/steamos/installed/` is the complete,
+self-contained tree to ship.
+
+## Verify the glibc floor
+
+Before shipping, confirm nothing newer than the sniper floor leaked in (the CI
+steamos workflow runs the same check over the whole installed tree):
+
+```sh
+objdump -T build/steamos/installed/bin/briarthorn \
+  | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1
+# expect: GLIBC_2.31 (or lower)
+```
+
+Then copy `build/steamos/installed/` to the Deck and run `bin/briarthorn` from
+Desktop Mode, or add it to Steam as a non-Steam game so Steam wraps it in the
+Steam Linux Runtime.

--- a/.devcontainer/steamos/devcontainer.json
+++ b/.devcontainer/steamos/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "awen-steamos",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "llvm-vs-code-extensions.vscode-clangd",
+                "ms-vscode.cmake-tools",
+                "theqtcompany.qt-qml"
+            ]
+        }
+    },
+    "postCreateCommand": "${containerWorkspaceFolder}/vcpkg/bootstrap-vcpkg.sh -disableMetrics"
+}

--- a/.github/workflows/steamos.yml
+++ b/.github/workflows/steamos.yml
@@ -1,0 +1,101 @@
+name: steamos
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
+    outputs:
+      image: ${{ steps.docker-image.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/docker-image
+        id: docker-image
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-tag: steamos
+          context: .devcontainer/steamos
+          filters: |
+            changed:
+              - '.devcontainer/steamos/**'
+
+  # SteamOS is x86_64 glibc Linux, so a native build produces a Steam Deck
+  # binary — the sniper base (glibc 2.31) is what makes it run there. The
+  # sniper SDK's gcc-14 backport compiles the C++23 code, and vcpkg builds Qt
+  # from source in the same container, so the deployed Qt libraries share the
+  # binary's glibc floor.
+  steamos-build:
+    runs-on: ubuntu-24.04
+    needs: docker
+
+    container:
+      image: ${{ needs.docker.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/get-vcpkg
+
+      - name: cmake-configure
+        shell: bash
+        run: cmake --preset steamos
+
+      - name: cmake-build
+        shell: bash
+        run: cmake --build --preset steamos --parallel $(( $(nproc --all) + 1 ))
+
+      - name: cmake-test
+        shell: bash
+        run: ctest --preset steamos --parallel $(( $(nproc --all) + 1 ))
+
+      - name: cmake-install
+        shell: bash
+        run: cmake --build --preset steamos --target install
+
+      # The whole point of the sniper container is a low glibc floor. Assert
+      # that nothing in the installed tree — the binaries or the Qt libraries
+      # deployed next to them — references anything newer than sniper's
+      # GLIBC_2.31, so a regression (e.g. a base-image bump) that would break
+      # the Deck fails loudly here.
+      - name: verify-glibc-floor
+        shell: bash
+        run: |
+          test -x build/steamos/installed/bin/briarthorn
+          max=$(find build/steamos/installed -type f \( -name '*.so*' -o -path '*/bin/*' \) \
+            -exec objdump -T {} \; 2>/dev/null \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' | sort -uV | tail -1)
+          echo "highest glibc symbol required: ${max:-none}"
+          if [ -n "$max" ] && [ "$(printf '%s\nGLIBC_2.31\n' "$max" | sort -V | tail -1)" != "GLIBC_2.31" ]; then
+            echo "::error::installed tree requires $max, above the sniper floor GLIBC_2.31"
+            exit 1
+          fi
+
+      - name: upload-build
+        uses: actions/upload-artifact@v4
+        with:
+          name: steamos-build
+          path: build/steamos/installed

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
     "include": [
         "./cmake/preset/platform/linux.json",
         "./cmake/preset/platform/macos.json",
+        "./cmake/preset/platform/steamos.json",
         "./cmake/preset/platform/web.json",
         "./cmake/preset/platform/windows.json"
     ]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![macos](https://github.com/funnansoftware/awen/actions/workflows/macos.yml/badge.svg?branch=main)](https://github.com/funnansoftware/awen/actions/workflows/macos.yml)
 [![linux](https://github.com/funnansoftware/awen/actions/workflows/linux.yml/badge.svg?branch=main)](https://github.com/funnansoftware/awen/actions/workflows/linux.yml)
 [![coverage](https://github.com/funnansoftware/awen/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/funnansoftware/awen/actions/workflows/coverage.yml)
+[![steamos](https://github.com/funnansoftware/awen/actions/workflows/steamos.yml/badge.svg?branch=main)](https://github.com/funnansoftware/awen/actions/workflows/steamos.yml)
 
 A C++23 application framework built around Qt Quick. The framework's QML
 modules live under `src/`; the apps built on it live under `app/`:

--- a/cmake/preset/compiler/gcc-14.json
+++ b/cmake/preset/compiler/gcc-14.json
@@ -1,0 +1,16 @@
+{
+    "version": 7,
+    "configurePresets": [
+        {
+            "name": "compiler-gcc-14",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+                "CMAKE_CXX_COMPILER": "g++-14",
+                "CMAKE_C_COMPILER": "gcc-14",
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -pedantic",
+                "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -pedantic"
+            }
+        }
+    ]
+}

--- a/cmake/preset/platform/steamos.json
+++ b/cmake/preset/platform/steamos.json
@@ -1,7 +1,7 @@
 {
     "version": 7,
     "include": [
-        "../compiler/gcc.json",
+        "../compiler/gcc-14.json",
         "../config/binaryDir.json",
         "../config/ninja.json",
         "../config/release.json",
@@ -17,13 +17,9 @@
                 "config-release",
                 "config-ninja",
                 "config-vcpkg",
-                "compiler-gcc",
+                "compiler-gcc-14",
                 "target-linux"
-            ],
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc-14",
-                "CMAKE_CXX_COMPILER": "g++-14"
-            }
+            ]
         }
     ],
     "buildPresets": [

--- a/cmake/preset/platform/steamos.json
+++ b/cmake/preset/platform/steamos.json
@@ -1,0 +1,44 @@
+{
+    "version": 7,
+    "include": [
+        "../compiler/gcc.json",
+        "../config/binaryDir.json",
+        "../config/ninja.json",
+        "../config/release.json",
+        "../config/vcpkg.json",
+        "../target/linux.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "steamos",
+            "displayName": "steamos (Steam Deck release build, sniper gcc-14)",
+            "inherits": [
+                "config-binaryDir",
+                "config-release",
+                "config-ninja",
+                "config-vcpkg",
+                "compiler-gcc",
+                "target-linux"
+            ],
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc-14",
+                "CMAKE_CXX_COMPILER": "g++-14"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "steamos",
+            "configurePreset": "steamos"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "steamos",
+            "configurePreset": "steamos",
+            "output": {
+                "outputOnFailure": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Ports briarthorn's SteamOS CI over to awen's Qt implementation. Same shape as before — build inside the Steam Linux Runtime 3.0 "sniper" container so the result runs on the Steam Deck, assert the glibc 2.31 floor, upload the installed tree — but the toolchain story is new, because the zig-only rationale no longer applies to a Qt/vcpkg build.

## What changed vs the briarthorn original

- **Toolchain: sniper's gcc-14 backport instead of zig.** Debian 11's gcc-10/clang-11 can't compile C++23 or Qt 6.11; briarthorn solved that with zig, which can't drive the Qt/vcpkg build. Valve backports gcc-14 (14.2) into the sniper SDK for exactly this — modern compiler, old glibc. The image exports `CC=gcc-14 CXX=g++-14` so vcpkg's port builds (Qt included) pick it up through CMake's compiler detection (plain `cc`/`c++` in the SDK still resolve to gcc-10), and the new `steamos` preset pins the same pair for the project.
- **New `steamos` CMake preset** (`cmake/preset/platform/steamos.json`): `linux-gcc-release` in every respect except the compiler pins, giving a dedicated `build/steamos/` tree so a sniper-container build can't poison a main-devcontainer build dir.
- **The glibc-floor check scans the whole installed tree**, not just the game binary: Qt is deployed as shared libraries next to it (`qt_generate_deploy_qml_app_script`), and those are built in the same container, so they're held to the same GLIBC_2.31 floor.
- **Qt build deps in the sniper image** mirror the main devcontainer's set (autotools family, xcb/EGL/xkbcommon headers); CMake ≥ 3.31 comes from Kitware's binary tarball since Debian 11 ships 3.18 (same approach as briarthorn's container).
- **libstdc++:** gcc-14 binaries want gcc-14's libstdc++, newer than sniper's base. That's the supported path — the Steam Linux Runtime uses the newest libstdc++ of host vs runtime at launch, and SteamOS's own is newer still. Documented in the devcontainer README.

Also adds the steamos badge to the README (mirroring briarthorn's).

## Validation

Preset graph parses (`cmake --list-presets` walks all includes) and the workflow/JSON are syntax-checked, but the real proof is this PR's own CI run: the first `steamos` run builds Qt from source inside the sniper container (slow once, ~the same cost as the first linux run), then it's binary-cached under the workflow-keyed vcpkg cache. Docker wasn't available locally, so the sniper image build (package names, gcc-14 availability) is validated by the `docker` job here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)