### PR TITLE
Add System/Systems per-frame runner to awen.entity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ Qt Quick is the sole rendering backend, on windows, linux, macos, web
 assembles the APK).
 
 - `src/` — the framework: QML modules built with `qt_add_qml_module` — `awen.entity`
-  (target `awen-entity`) and `awen.gamepad` (target `awen-gamepad`: an SDL3-backed
+  (target `awen-entity`: the `entity` value type plus the `System`/`Systems`
+  QML pair games derive per-frame logic from) and `awen.gamepad` (target `awen-gamepad`: an SDL3-backed
   gamepad attached-property type — one SDL backend on desktop and wasm (SDL wraps
   the browser Gamepad API there), an inert stub on android; its Qt-free
   `awen-gamepad-core` is the unit-tested, coverage-observed part).
@@ -52,6 +53,10 @@ assembles the APK).
 - **No non-const globals** — mutable state belongs to an object instance.
 - Accessor/mutator pairs are `getX()` / `setX()`; a lone getter keeps its bare
   name (`alpha()`, `entities()`).
+- **QML names go base-type-first.** A derived QML type's object and file name
+  lead with the type it derives from, then the specialization: `SystemMovement`
+  (a `System`), not `MovementSystem`. Briarthorn's systems live in
+  `app/briarthorn/qml/systems/`.
 - **Doc comments are Doxygen.** `///` with `@brief`, `@param`, `@return`;
   `@p name` for parameters; trailing `///<` for data members.
 - **Commit messages are one line.** A single short imperative summary — no body,

--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -7,14 +7,16 @@ target_sources(briarthorn
         main.cpp
 )
 
-# IMPORTS tells the import scan (qmllint, deploy) that Main.qml depends on
-# awen.gamepad; the types themselves come from linking awen-gamepad below.
+# IMPORTS tells the import scan (qmllint, deploy) that the QML files depend on
+# awen.entity and awen.gamepad; the types come from the linked modules below.
 qt_add_qml_module(briarthorn
     URI Briarthorn
     VERSION 1.0
     QML_FILES
         qml/Main.qml
+        qml/systems/SystemMovement.qml
     IMPORTS
+        awen.entity
         awen.gamepad
 )
 
@@ -23,6 +25,7 @@ qt_add_qml_module(briarthorn
 
 target_link_libraries(briarthorn
     PRIVATE
+        awen-entity
         awen-gamepad
         Qt6::Quick
 )

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -1,5 +1,7 @@
 import QtQuick
+import awen.entity
 import awen.gamepad
+import "systems"
 
 // Placeholder shell for the briarthorn game, pure QML: a marker steered with
 // WASD / arrow keys or a gamepad. The game grows from here.
@@ -21,39 +23,20 @@ Window {
         anchors.fill: parent
         focus: true // route the window's keys (WASD / arrows) here
 
-        readonly property real speed: 260 // px per second at full deflection
-        readonly property real deadzone: 0.15 // ignore stick jitter around rest
-
-        property real markerX: width / 2
-        property real markerY: height / 2
-
-        // Keyboard, left-stick and d-pad state, folded together in the frame loop.
-        property var held: ({})
-        property real padX: 0
-        property real padY: 0
-        property var dpad: ({})
         property bool padConnected: false
 
-        function down(...keys): bool {
-            return keys.some(key => scene.held[key] === true);
-        }
-        function padDown(...buttons): bool {
-            return buttons.some(button => scene.dpad[button] === true);
-        }
-        function deaden(v: real): real {
-            return Math.abs(v) < scene.deadzone ? 0 : v;
-        }
-
+        // The input handlers only capture state into the movement system; the
+        // runner below folds it into the game once per frame.
         Keys.onPressed: event => {
             if (event.isAutoRepeat)
                 return;
-            scene.held[event.key] = true;
+            movement.held[event.key] = true;
             event.accepted = true;
         }
         Keys.onReleased: event => {
             if (event.isAutoRepeat)
                 return;
-            scene.held[event.key] = false;
+            movement.held[event.key] = false;
             event.accepted = true;
         }
 
@@ -64,34 +47,26 @@ Window {
         Gamepad.onDisconnected: deviceId => scene.padConnected = false
         Gamepad.onAxisChanged: (deviceId, axis, value) => {
             if (axis === Gamepad.Axis.LeftX)
-                scene.padX = scene.deaden(value);
+                movement.padX = movement.deaden(value);
             else if (axis === Gamepad.Axis.LeftY)
-                scene.padY = scene.deaden(value);
+                movement.padY = movement.deaden(value);
         }
-        Gamepad.onButtonPressed: (deviceId, button) => scene.dpad[button] = true
-        Gamepad.onButtonReleased: (deviceId, button) => scene.dpad[button] = false
+        Gamepad.onButtonPressed: (deviceId, button) => movement.dpad[button] = true
+        Gamepad.onButtonReleased: (deviceId, button) => movement.dpad[button] = false
 
-        // The frame loop: fold keyboard, stick and d-pad into the marker position,
-        // scaled by frame time so the speed is framerate-independent.
-        FrameAnimation {
-            running: true
-            onTriggered: {
-                const dt = frameTime;
-                const kx = (scene.down(Qt.Key_D, Qt.Key_Right) ? 1 : 0) - (scene.down(Qt.Key_A, Qt.Key_Left) ? 1 : 0);
-                const ky = (scene.down(Qt.Key_S, Qt.Key_Down) ? 1 : 0) - (scene.down(Qt.Key_W, Qt.Key_Up) ? 1 : 0);
-                const px = (scene.padDown(Gamepad.Button.DpadRight) ? 1 : 0) - (scene.padDown(Gamepad.Button.DpadLeft) ? 1 : 0);
-                const py = (scene.padDown(Gamepad.Button.DpadDown) ? 1 : 0) - (scene.padDown(Gamepad.Button.DpadUp) ? 1 : 0);
-                const dx = Math.max(-1, Math.min(1, kx + scene.padX + px));
-                const dy = Math.max(-1, Math.min(1, ky + scene.padY + py));
-                scene.markerX = Math.max(0, Math.min(scene.width, scene.markerX + (dx * scene.speed * dt)));
-                scene.markerY = Math.max(0, Math.min(scene.height, scene.markerY + (dy * scene.speed * dt)));
+        // The game's systems, each updating its slice of state every frame.
+        Systems {
+            SystemMovement {
+                id: movement
+                xMax: scene.width
+                yMax: scene.height
             }
         }
 
         // The player marker: an orange triangle with a pulsing ring behind it.
         Item {
-            x: scene.markerX
-            y: scene.markerY
+            x: movement.markerX
+            y: movement.markerY
 
             Rectangle {
                 anchors.centerIn: parent

--- a/app/briarthorn/qml/systems/SystemMovement.qml
+++ b/app/briarthorn/qml/systems/SystemMovement.qml
@@ -1,0 +1,47 @@
+import awen.entity
+import awen.gamepad
+
+// Folds keyboard, left-stick and d-pad state into the marker position each
+// tick, scaled by frame time so the speed is framerate-independent.
+System {
+    id: movement
+
+    // Movement bounds: the marker is clamped to [0, xMax] x [0, yMax].
+    required property real xMax
+    required property real yMax
+
+    readonly property real speed: 260 // px per second at full deflection
+    readonly property real deadzone: 0.15 // ignore stick jitter around rest
+
+    // Keyboard, left-stick and d-pad state, written by the scene's input
+    // handlers and folded together in update().
+    property var held: ({})
+    property var dpad: ({})
+    property real padX: 0
+    property real padY: 0
+
+    // The marker position this system acts on; starts centered.
+    property real markerX: movement.xMax / 2
+    property real markerY: movement.yMax / 2
+
+    function down(...keys): bool {
+        return keys.some(key => movement.held[key] === true);
+    }
+    function padDown(...buttons): bool {
+        return buttons.some(button => movement.dpad[button] === true);
+    }
+    function deaden(v: real): real {
+        return Math.abs(v) < movement.deadzone ? 0 : v;
+    }
+
+    function update(dt: real) {
+        const kx = (movement.down(Qt.Key_D, Qt.Key_Right) ? 1 : 0) - (movement.down(Qt.Key_A, Qt.Key_Left) ? 1 : 0);
+        const ky = (movement.down(Qt.Key_S, Qt.Key_Down) ? 1 : 0) - (movement.down(Qt.Key_W, Qt.Key_Up) ? 1 : 0);
+        const px = (movement.padDown(Gamepad.Button.DpadRight) ? 1 : 0) - (movement.padDown(Gamepad.Button.DpadLeft) ? 1 : 0);
+        const py = (movement.padDown(Gamepad.Button.DpadDown) ? 1 : 0) - (movement.padDown(Gamepad.Button.DpadUp) ? 1 : 0);
+        const dx = Math.max(-1, Math.min(1, kx + movement.padX + px));
+        const dy = Math.max(-1, Math.min(1, ky + movement.padY + py));
+        movement.markerX = Math.max(0, Math.min(movement.xMax, movement.markerX + (dx * movement.speed * dt)));
+        movement.markerY = Math.max(0, Math.min(movement.yMax, movement.markerY + (dy * movement.speed * dt)));
+    }
+}

--- a/src/awen/entity/CMakeLists.txt
+++ b/src/awen/entity/CMakeLists.txt
@@ -1,7 +1,20 @@
+# awen.entity — entity state and the System/Systems pair games derive their
+# per-frame logic from.
+
+# SHARED except on wasm (one static binary there): a static module has no loadable
+# plugin, so a Release loadFromModule fails to resolve `import awen.entity`.
+set(_awen_entity_linkage "")
+if(NOT EMSCRIPTEN)
+    set(_awen_entity_linkage "SHARED")
+endif()
+
 qt_add_qml_module(awen-entity
+    ${_awen_entity_linkage}
     URI awen.entity
     VERSION 1.0
     QML_FILES
+        System.qml
+        Systems.qml
     SOURCES
         Entity.h
 )
@@ -11,3 +24,14 @@ target_link_libraries(awen-entity
         Qt6::Core
         Qt6::Quick
 )
+
+# qmlcachegen-generated code trips MSVC C4702 (unreachable return) inside Qt
+# headers, which /WX would turn into an error — disable just that warning.
+if(MSVC)
+    target_compile_options(awen-entity PRIVATE /wd4702)
+endif()
+
+# Tests run natively only; the web and android presets set BUILD_TESTING=OFF.
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()

--- a/src/awen/entity/System.qml
+++ b/src/awen/entity/System.qml
@@ -1,0 +1,13 @@
+import QtQml
+
+// Base type for a game system: derive in QML and override update() to act on
+// game state each tick. On its own a System does nothing — a Systems runner
+// drives the calls.
+QtObject {
+    // Skipped by the Systems runner while false.
+    property bool enabled: true
+
+    // Called by the Systems runner each tick; dt is the frame time in seconds.
+    function update(dt: real) {
+    }
+}

--- a/src/awen/entity/Systems.qml
+++ b/src/awen/entity/Systems.qml
@@ -1,0 +1,29 @@
+import QtQuick
+
+// Runs a list of systems against game state: each frame, every enabled
+// system's update() is called in declaration order with the frame time in
+// seconds. Set running to false and call tick() to step manually.
+QtObject {
+    id: root
+
+    // The systems to run, in run order; child System objects land here.
+    default property list<System> systems
+
+    // Whether the per-frame loop is active.
+    property bool running: true
+
+    // One update pass: forwards dt (seconds) to every enabled system.
+    function tick(dt: real) {
+        for (let i = 0; i < root.systems.length; ++i) {
+            const system = root.systems[i];
+            if (system.enabled)
+                system.update(dt);
+        }
+    }
+
+    // The frame clock driving the loop, in sync with scene rendering.
+    readonly property FrameAnimation clock: FrameAnimation {
+        running: root.running
+        onTriggered: root.tick(frameTime)
+    }
+}

--- a/src/awen/entity/test/.clang-tidy
+++ b/src/awen/entity/test/.clang-tidy
@@ -1,0 +1,10 @@
+---
+InheritParentConfig: true
+# Relax checks the gtest macros inherently trip (non-const globals, literal
+# assertion values, optional access guarded behind ASSERT_TRUE).
+Checks: "-cert-err58-cpp,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-magic-numbers,
+  -bugprone-unchecked-optional-access"

--- a/src/awen/entity/test/CMakeLists.txt
+++ b/src/awen/entity/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+find_package(GTest CONFIG REQUIRED)
+
+add_executable(awen-entity-test
+    main.cpp
+    System.test.cpp
+)
+
+# The tests import awen.entity through the QML engine, so the module is a
+# runtime dependency (via the import path below), not a link dependency.
+target_compile_definitions(awen-entity-test
+    PRIVATE
+        AWEN_QML_IMPORT_DIR="${QT_QML_OUTPUT_DIRECTORY}"
+)
+add_dependencies(awen-entity-test awen-entity)
+
+target_link_libraries(awen-entity-test
+    PRIVATE
+        GTest::gtest
+        Qt6::Gui
+        Qt6::Qml
+)
+
+include(GoogleTest)
+gtest_discover_tests(awen-entity-test)

--- a/src/awen/entity/test/System.test.cpp
+++ b/src/awen/entity/test/System.test.cpp
@@ -1,0 +1,131 @@
+#include <memory>
+
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using std::unique_ptr;
+
+namespace
+{
+    /// @brief Instantiates an inline QML harness; the awen.entity import
+    /// resolves via QML_IMPORT_PATH, set once in main(). Fails the running
+    /// test on component errors.
+    auto load(QQmlEngine& engine, const char* qml) -> unique_ptr<QObject>
+    {
+        auto component = QQmlComponent{&engine};
+        component.setData(qml, QUrl{QStringLiteral("qrc:/awen-entity-test/harness.qml")});
+
+        auto object = unique_ptr<QObject>{component.create()};
+        if (object == nullptr)
+        {
+            ADD_FAILURE() << component.errorString().toStdString();
+        }
+        return object;
+    }
+
+    /// @brief Calls the runner's tick(dt), as the frame clock would.
+    auto tick(QObject& runner, double dt) -> void
+    {
+        EXPECT_TRUE(QMetaObject::invokeMethod(&runner, "tick", Q_ARG(double, dt)));
+    }
+
+    // Derived systems record into the root through a property: an inline
+    // component does not share scope with its declaring file, so it cannot
+    // reach the root by id. The plain System in the middle proves the base
+    // update() is a callable no-op.
+    constexpr auto OrderedHarness = R"(
+import QtQml
+import awen.entity
+
+Systems {
+    id: root
+    running: false
+
+    property string calls
+    property real lastDt
+
+    component Recorder: System {
+        required property var log
+        required property string tag
+        function update(dt: real) {
+            log.calls += tag;
+            log.lastDt = dt;
+        }
+    }
+
+    Recorder { log: root; tag: "a" }
+    System {}
+    Recorder { log: root; tag: "b" }
+    Recorder { log: root; tag: "c" }
+}
+)";
+
+    constexpr auto DisabledHarness = R"(
+import QtQml
+import awen.entity
+
+Systems {
+    id: root
+    running: false
+
+    property string calls
+
+    component Recorder: System {
+        required property var log
+        required property string tag
+        function update(dt: real) {
+            log.calls += tag;
+        }
+    }
+
+    Recorder { log: root; tag: "a" }
+    Recorder { log: root; tag: "b"; enabled: false }
+    Recorder { log: root; tag: "c" }
+}
+)";
+}
+
+TEST(Systems, RunsDerivedUpdatesInDeclarationOrder)
+{
+    auto engine = QQmlEngine{};
+    const auto runner = load(engine, OrderedHarness);
+    ASSERT_NE(runner, nullptr);
+
+    tick(*runner, 0.016);
+    EXPECT_EQ(runner->property("calls").toString(), QStringLiteral("abc"));
+}
+
+TEST(Systems, ForwardsFrameSecondsToUpdate)
+{
+    auto engine = QQmlEngine{};
+    const auto runner = load(engine, OrderedHarness);
+    ASSERT_NE(runner, nullptr);
+
+    tick(*runner, 0.25);
+    EXPECT_DOUBLE_EQ(runner->property("lastDt").toDouble(), 0.25);
+}
+
+TEST(Systems, SkipsDisabledSystems)
+{
+    auto engine = QQmlEngine{};
+    const auto runner = load(engine, DisabledHarness);
+    ASSERT_NE(runner, nullptr);
+
+    tick(*runner, 0.016);
+    EXPECT_EQ(runner->property("calls").toString(), QStringLiteral("ac"));
+}
+
+TEST(Systems, DefaultsToRunning)
+{
+    auto engine = QQmlEngine{};
+    const auto runner = load(engine, R"(
+import awen.entity
+Systems {}
+)");
+    ASSERT_NE(runner, nullptr);
+
+    EXPECT_TRUE(runner->property("running").toBool());
+}

--- a/src/awen/entity/test/main.cpp
+++ b/src/awen/entity/test/main.cpp
@@ -1,0 +1,22 @@
+#include <QGuiApplication>
+
+#include <gtest/gtest.h>
+
+// gtest_discover_tests executes this binary at build time on headless CI, so
+// default to the minimal platform before QGuiApplication picks a real one.
+auto main(int argc, char** argv) -> int
+{
+    // Point every test's QQmlEngine at the in-project modules under the build
+    // output tree: each engine reads QML_IMPORT_PATH at construction, so this
+    // one line resolves `import awen.entity` for all tests without per-test setup.
+    qputenv("QML_IMPORT_PATH", AWEN_QML_IMPORT_DIR);
+
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
+    {
+        qputenv("QT_QPA_PLATFORM", "minimal");
+    }
+
+    auto app = QGuiApplication{argc, argv};
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/awen/gamepad/test/Gamepad.test.cpp
+++ b/src/awen/gamepad/test/Gamepad.test.cpp
@@ -5,133 +5,130 @@
 
 #include <gtest/gtest.h>
 
-namespace
+using awen::decodeEvent;
+using awen::GamepadEventKind;
+using awen::normalizeAxis;
+
+// --- normalizeAxis --------------------------------------------------------
+
+TEST(NormalizeAxis, RestReadsZero)
 {
-    using awen::decodeEvent;
-    using awen::GamepadEventKind;
-    using awen::normalizeAxis;
+    EXPECT_DOUBLE_EQ(normalizeAxis(0), 0.0);
+}
 
-    // --- normalizeAxis --------------------------------------------------------
+TEST(NormalizeAxis, PositiveExtremeIsOne)
+{
+    EXPECT_DOUBLE_EQ(normalizeAxis(32767), 1.0);
+}
 
-    TEST(NormalizeAxis, RestReadsZero)
-    {
-        EXPECT_DOUBLE_EQ(normalizeAxis(0), 0.0);
-    }
+TEST(NormalizeAxis, NegativeExtremeClampsToMinusOne)
+{
+    // SDL's stick low end (-32768) is one step past the +32767 extreme; it must
+    // clamp to -1 rather than landing at -1.00003.
+    EXPECT_DOUBLE_EQ(normalizeAxis(-32768), -1.0);
+    EXPECT_DOUBLE_EQ(normalizeAxis(-32767), -1.0);
+}
 
-    TEST(NormalizeAxis, PositiveExtremeIsOne)
-    {
-        EXPECT_DOUBLE_EQ(normalizeAxis(32767), 1.0);
-    }
+TEST(NormalizeAxis, MidRangeIsProportional)
+{
+    EXPECT_NEAR(normalizeAxis(16383), 0.5, 1e-4);
+    EXPECT_NEAR(normalizeAxis(-16383), -0.5, 1e-4);
+}
 
-    TEST(NormalizeAxis, NegativeExtremeClampsToMinusOne)
-    {
-        // SDL's stick low end (-32768) is one step past the +32767 extreme; it must
-        // clamp to -1 rather than landing at -1.00003.
-        EXPECT_DOUBLE_EQ(normalizeAxis(-32768), -1.0);
-        EXPECT_DOUBLE_EQ(normalizeAxis(-32767), -1.0);
-    }
+// --- decodeEvent ----------------------------------------------------------
 
-    TEST(NormalizeAxis, MidRangeIsProportional)
-    {
-        EXPECT_NEAR(normalizeAxis(16383), 0.5, 1e-4);
-        EXPECT_NEAR(normalizeAxis(-16383), -0.5, 1e-4);
-    }
+TEST(DecodeEvent, GamepadAddedIsConnected)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_GAMEPAD_ADDED;
+    event.gdevice.which = 7;
 
-    // --- decodeEvent ----------------------------------------------------------
+    const auto decoded = decodeEvent(event);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->kind, GamepadEventKind::Connected);
+    EXPECT_EQ(decoded->deviceId, 7);
+}
 
-    TEST(DecodeEvent, GamepadAddedIsConnected)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_GAMEPAD_ADDED;
-        event.gdevice.which = 7;
+TEST(DecodeEvent, GamepadRemovedIsDisconnected)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_GAMEPAD_REMOVED;
+    event.gdevice.which = 7;
 
-        const auto decoded = decodeEvent(event);
-        ASSERT_TRUE(decoded.has_value());
-        EXPECT_EQ(decoded->kind, GamepadEventKind::Connected);
-        EXPECT_EQ(decoded->deviceId, 7);
-    }
+    const auto decoded = decodeEvent(event);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->kind, GamepadEventKind::Disconnected);
+    EXPECT_EQ(decoded->deviceId, 7);
+}
 
-    TEST(DecodeEvent, GamepadRemovedIsDisconnected)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_GAMEPAD_REMOVED;
-        event.gdevice.which = 7;
+TEST(DecodeEvent, ButtonDownCarriesDeviceAndCode)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.which = 2;
+    event.gbutton.button = static_cast<Uint8>(SDL_GAMEPAD_BUTTON_SOUTH);
 
-        const auto decoded = decodeEvent(event);
-        ASSERT_TRUE(decoded.has_value());
-        EXPECT_EQ(decoded->kind, GamepadEventKind::Disconnected);
-        EXPECT_EQ(decoded->deviceId, 7);
-    }
+    const auto decoded = decodeEvent(event);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->kind, GamepadEventKind::ButtonPressed);
+    EXPECT_EQ(decoded->deviceId, 2);
+    EXPECT_EQ(decoded->code, static_cast<int>(SDL_GAMEPAD_BUTTON_SOUTH));
+}
 
-    TEST(DecodeEvent, ButtonDownCarriesDeviceAndCode)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
-        event.gbutton.which = 2;
-        event.gbutton.button = static_cast<Uint8>(SDL_GAMEPAD_BUTTON_SOUTH);
+TEST(DecodeEvent, ButtonUpIsReleased)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    event.gbutton.which = 2;
+    event.gbutton.button = static_cast<Uint8>(SDL_GAMEPAD_BUTTON_NORTH);
 
-        const auto decoded = decodeEvent(event);
-        ASSERT_TRUE(decoded.has_value());
-        EXPECT_EQ(decoded->kind, GamepadEventKind::ButtonPressed);
-        EXPECT_EQ(decoded->deviceId, 2);
-        EXPECT_EQ(decoded->code, static_cast<int>(SDL_GAMEPAD_BUTTON_SOUTH));
-    }
+    const auto decoded = decodeEvent(event);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->kind, GamepadEventKind::ButtonReleased);
+    EXPECT_EQ(decoded->code, static_cast<int>(SDL_GAMEPAD_BUTTON_NORTH));
+}
 
-    TEST(DecodeEvent, ButtonUpIsReleased)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
-        event.gbutton.which = 2;
-        event.gbutton.button = static_cast<Uint8>(SDL_GAMEPAD_BUTTON_NORTH);
+TEST(DecodeEvent, AxisMotionNormalisesToOne)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
+    event.gaxis.which = 1;
+    event.gaxis.axis = static_cast<Uint8>(SDL_GAMEPAD_AXIS_LEFTX);
+    event.gaxis.value = static_cast<Sint16>(32767);
 
-        const auto decoded = decodeEvent(event);
-        ASSERT_TRUE(decoded.has_value());
-        EXPECT_EQ(decoded->kind, GamepadEventKind::ButtonReleased);
-        EXPECT_EQ(decoded->code, static_cast<int>(SDL_GAMEPAD_BUTTON_NORTH));
-    }
+    const auto decoded = decodeEvent(event);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->kind, GamepadEventKind::AxisMotion);
+    EXPECT_EQ(decoded->deviceId, 1);
+    EXPECT_EQ(decoded->code, static_cast<int>(SDL_GAMEPAD_AXIS_LEFTX));
+    EXPECT_DOUBLE_EQ(decoded->value, 1.0);
+}
 
-    TEST(DecodeEvent, AxisMotionNormalisesToOne)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
-        event.gaxis.which = 1;
-        event.gaxis.axis = static_cast<Uint8>(SDL_GAMEPAD_AXIS_LEFTX);
-        event.gaxis.value = static_cast<Sint16>(32767);
+TEST(DecodeEvent, AxisMotionClampsNegativeExtreme)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
+    event.gaxis.which = 1;
+    event.gaxis.axis = static_cast<Uint8>(SDL_GAMEPAD_AXIS_LEFTY);
+    event.gaxis.value = static_cast<Sint16>(-32768);
 
-        const auto decoded = decodeEvent(event);
-        ASSERT_TRUE(decoded.has_value());
-        EXPECT_EQ(decoded->kind, GamepadEventKind::AxisMotion);
-        EXPECT_EQ(decoded->deviceId, 1);
-        EXPECT_EQ(decoded->code, static_cast<int>(SDL_GAMEPAD_AXIS_LEFTX));
-        EXPECT_DOUBLE_EQ(decoded->value, 1.0);
-    }
+    const auto decoded = decodeEvent(event);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_DOUBLE_EQ(decoded->value, -1.0);
+}
 
-    TEST(DecodeEvent, AxisMotionClampsNegativeExtreme)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
-        event.gaxis.which = 1;
-        event.gaxis.axis = static_cast<Uint8>(SDL_GAMEPAD_AXIS_LEFTY);
-        event.gaxis.value = static_cast<Sint16>(-32768);
+TEST(DecodeEvent, QuitEventIsIgnored)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_QUIT;
 
-        const auto decoded = decodeEvent(event);
-        ASSERT_TRUE(decoded.has_value());
-        EXPECT_DOUBLE_EQ(decoded->value, -1.0);
-    }
+    EXPECT_FALSE(decodeEvent(event).has_value());
+}
 
-    TEST(DecodeEvent, QuitEventIsIgnored)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_QUIT;
+TEST(DecodeEvent, KeyboardEventIsIgnored)
+{
+    auto event = SDL_Event{};
+    event.type = SDL_EVENT_KEY_DOWN;
 
-        EXPECT_FALSE(decodeEvent(event).has_value());
-    }
-
-    TEST(DecodeEvent, KeyboardEventIsIgnored)
-    {
-        auto event = SDL_Event{};
-        event.type = SDL_EVENT_KEY_DOWN;
-
-        EXPECT_FALSE(decodeEvent(event).has_value());
-    }
+    EXPECT_FALSE(decodeEvent(event).has_value());
 }


### PR DESCRIPTION
## What

Adds a small ECS-style **systems** layer to `awen.entity`: a `System` base type whose `update(dt)` derived QML types override, and a `Systems` runner that calls every enabled child system in declaration order once per frame. Briarthorn's marker movement is refactored to run through this layer as a first consumer.

## The framework (`awen.entity`)

- **`System.qml`** — `QtObject` base with `enabled` and an overridable `function update(dt: real)`. On its own it does nothing; a runner drives the calls.
- **`Systems.qml`** — default `list<System>` property (child systems land in it), a `running` flag, a `FrameAnimation` clock, and a public `tick(dt)` for manual/testable stepping. Runs enabled systems in declaration order with frame time in seconds.

**Why pure QML rather than C++ exposed to QML:** a C++ `System` base can't have its virtual overridden from a QML-derived type, and dispatching to a QML-defined `update` from C++ via `QMetaObject::invokeMethod` matches signatures fragilely across typed/untyped overrides. A QML base with JS dynamic dispatch gives exact override semantics.

## Briarthorn usage

`qml/systems/SystemMovement.qml` derives `System` and owns the movement state (speed, deadzone, input fold, marker position). `Main.qml` shrinks to input capture (Keys/Gamepad handlers writing into the system) and view bindings, with a `Systems { SystemMovement { ... } }` block replacing the old inline `FrameAnimation`. This is the pattern future radar/weapon/etc. systems will follow.

## Conventions established (CLAUDE.md)

- **QML names are base-type-first**: `SystemMovement` (a `System`), not `MovementSystem`. Briarthorn's systems live under `app/briarthorn/qml/systems/`.
- Test modules: a custom `main()` lives in its own `main.cpp`; `TEST` macros sit at file scope (anonymous namespaces are for helpers only); shared per-test setup is centralized in `main.cpp`. `Gamepad.test.cpp` was brought in line with the file-scope rule (hence its large but purely mechanical de-indent diff).

## Testing

New `awen-entity-test` (gtest + `QQmlEngine`, loading inline QML that derives `System` and drives `Systems.tick()`): verifies declaration-order execution, `dt` forwarding, disabled-skip, and the `running` default. No new vcpkg dependencies. The QML import path is set once via `QML_IMPORT_PATH` in the test's `main.cpp`.

Verified locally on Windows/MSVC (Debug and Release): **17/17 ctest pass** in both configs (including Release `tst_apploads`, which exercises the SHARED-module import from compiled resources), `clang-format-check` clean, and a live `qml.exe` harness confirms the frame clock genuinely drives a derived `update()` in a running event loop.

Entities/components beyond the existing `entity` value type are intentionally deferred to a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
