### PR TITLE
Enable OpenSSL, QtWebSockets, and QtNetworkAuth in vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,13 +17,15 @@
         },
         "qtdeclarative",
         {
-            "$comment": "QtWebSockets backs the Twitch chat transport (IRC-over-WebSocket / EventSub); QtNetworkAuth drives the YouTube and Twitch OAuth2 sign-in flows. QtNetwork itself already arrives via qtdeclarative. Neither is wired into a target yet — this enables the toolchain to provide them.",
+            "$comment": "QtWebSockets backs the Twitch chat transport (IRC-over-WebSocket / EventSub), including in the browser where Qt maps QWebSocket onto the wasm WebSocket API. Not wired into a target yet; this enables the toolchain to provide it.",
             "name": "qtwebsockets",
             "default-features": false
         },
         {
+            "$comment": "QtNetworkAuth drives the YouTube and Twitch OAuth2 sign-in flows. Excluded on emscripten: its loopback-redirect handler can't run in the browser sandbox, and the port fails to build for wasm (ninja: unknown target 'install'). QtNetwork itself already arrives via qtdeclarative.",
             "name": "qtnetworkauth",
-            "default-features": false
+            "default-features": false,
+            "platform": "!emscripten"
         },
         {
             "$comment": "Host-tool Qt (qmlcachegen, moc, ...) with default features stripped. thread + concurrent must stay: without them host qtdeclarative fails to configure ('Qt6::QmlLSPrivate ... target was not found').",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,6 +17,15 @@
         },
         "qtdeclarative",
         {
+            "$comment": "QtWebSockets backs the Twitch chat transport (IRC-over-WebSocket / EventSub); QtNetworkAuth drives the YouTube and Twitch OAuth2 sign-in flows. QtNetwork itself already arrives via qtdeclarative. Neither is wired into a target yet — this enables the toolchain to provide them.",
+            "name": "qtwebsockets",
+            "default-features": false
+        },
+        {
+            "name": "qtnetworkauth",
+            "default-features": false
+        },
+        {
             "$comment": "Host-tool Qt (qmlcachegen, moc, ...) with default features stripped. thread + concurrent must stay: without them host qtdeclarative fails to configure ('Qt6::QmlLSPrivate ... target was not found').",
             "name": "qtbase",
             "host": true,
@@ -50,6 +59,11 @@
                 {
                     "$comment": "Without dnslookup the QtNetwork dylib fails to link on macOS/Linux (undefined _res_9_ninit). Excluded on emscripten, where it breaks Qt's configure (no resolver in the browser sandbox).",
                     "name": "dnslookup",
+                    "platform": "!emscripten"
+                },
+                {
+                    "$comment": "TLS backend for HTTPS/WSS (YouTube Data API, Twitch chat, OAuth token exchange). Windows also has native Schannel, but enabling OpenSSL gives every desktop and android build a consistent TLS backend. Excluded on emscripten, where the browser terminates TLS and OpenSSL has no sandbox build.",
+                    "name": "openssl",
                     "platform": "!emscripten"
                 },
                 {


### PR DESCRIPTION
## What

Enables the vcpkg dependencies needed to build a YouTube/Twitch chat client on top of Awen, without wiring anything into a target yet:

- **`openssl`** feature added to the target `qtbase` — a TLS backend for HTTPS/WSS (YouTube Data API, Twitch chat, OAuth token exchange). Gated `!emscripten`, matching the existing `dnslookup` exclusion: in the browser the runtime terminates TLS and OpenSSL has no sandbox build. Windows also has native Schannel, but enabling OpenSSL gives every desktop and android build a consistent backend.
- **`qtwebsockets`** — the Twitch chat transport (IRC-over-WebSocket / EventSub).
- **`qtnetworkauth`** — the YouTube and Twitch OAuth2 sign-in flows.

`QtNetwork` itself already arrives transitively via `qtdeclarative`, so it isn't added here.

Both new ports already exist in the vendored registry at **6.11.1**, matching `qtbase`/`qtdeclarative` — no registry changes needed.

## Why now, before any app code

This is intentionally a dependency-only change so the toolchain wiring can be reviewed and CI-validated on every platform in isolation, before the chat client itself lands. Enabling `openssl` forces a `qtbase` rebuild (its `ocsp` sub-feature flips on), which is the kind of thing worth de-risking on its own.

## Verification (Windows / MSVC, `windows-msvc-release`)

- vcpkg resolved the manifest and built `openssl@3.6.3`, rebuilt `qtbase[...,openssl,...]` + dependents, and installed `qtwebsockets@6.11.1` and `qtnetworkauth@6.11.1`.
- Clean reconfigure + full rebuild of all targets against the openssl-enabled Qt.
- `ctest`: **13/13 passed, 0 failed.**

The other six platform workflows will validate the cross-platform builds on this PR.

## Note for follow-up

On wasm, `QtWebSockets` works via the browser WebSocket API, but `QtNetworkAuth`'s loopback-redirect flow (`QOAuthHttpServerReplyHandler`) can't run in the browser sandbox — web sign-in will need a redirect-based approach. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
