### PR TITLE
Enable OpenSSL + QtWebSockets + QtNetworkAuth on both Qt paths

### DIFF
--- a/.github/actions/get-qt/action.yml
+++ b/.github/actions/get-qt/action.yml
@@ -18,6 +18,13 @@ inputs:
     description: Extra aqtinstall arguments (e.g. --autodesktop for cross kits).
     required: false
     default: ""
+  modules:
+    # Add-on Qt modules the base kit omits. QtNetworkAuth + QtWebSockets back the
+    # chat transport/OAuth; wasm overrides this to drop qtnetworkauth (no browser
+    # loopback, and the wasm kit doesn't offer it).
+    description: Space-separated Qt add-on modules to install alongside the base kit.
+    required: false
+    default: qtnetworkauth qtwebsockets
   install-deps:
     description: Let install-qt-action apt-install Qt's linux dependencies. Turn off in containers, where sudo is absent and the image already ships them.
     required: false
@@ -54,6 +61,7 @@ runs:
         host: ${{ inputs.host }}
         target: ${{ inputs.target }}
         arch: ${{ inputs.arch }}
+        modules: ${{ inputs.modules }}
         extra: ${{ steps.qt-version.outputs.extra }}
         cache: true
         install-deps: ${{ inputs.install-deps }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -59,6 +59,9 @@ jobs:
           host: all_os
           target: wasm
           arch: wasm_singlethread
+          # QtWebSockets only: the wasm kit doesn't offer QtNetworkAuth, whose
+          # loopback OAuth can't run in the browser anyway.
+          modules: qtwebsockets
           extra: --autodesktop
           install-deps: false
           setup-python: false

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,6 +26,17 @@
             "dependencies": [
                 "qtdeclarative",
                 {
+                    "$comment": "QtWebSockets backs the Twitch chat transport (IRC-over-WebSocket / EventSub), including on wasm where Qt maps QWebSocket onto the browser WebSocket API. On the prebuilt-Qt path the get-qt action installs the same module.",
+                    "name": "qtwebsockets",
+                    "default-features": false
+                },
+                {
+                    "$comment": "QtNetworkAuth drives the YouTube and Twitch OAuth2 sign-in flows. Excluded on emscripten: its loopback-redirect handler can't run in the browser sandbox, and neither the vcpkg port nor the wasm Qt kit provides it there.",
+                    "name": "qtnetworkauth",
+                    "default-features": false,
+                    "platform": "!emscripten"
+                },
+                {
                     "$comment": "Host-tool Qt (qmlcachegen, moc, ...) with default features stripped. thread + concurrent must stay: without them host qtdeclarative fails to configure ('Qt6::QmlLSPrivate ... target was not found').",
                     "name": "qtbase",
                     "host": true,
@@ -59,6 +70,11 @@
                         {
                             "$comment": "Without dnslookup the QtNetwork dylib fails to link on macOS/Linux (undefined _res_9_ninit). Excluded on emscripten, where it breaks Qt's configure (no resolver in the browser sandbox).",
                             "name": "dnslookup",
+                            "platform": "!emscripten"
+                        },
+                        {
+                            "$comment": "TLS backend for HTTPS/WSS (YouTube Data API, Twitch chat, OAuth token exchange). Excluded on emscripten, where the browser terminates TLS. The prebuilt-Qt kits ship their own TLS, so this only affects the vcpkg-built path.",
+                            "name": "openssl",
                             "platform": "!emscripten"
                         },
                         {


### PR DESCRIPTION
Enables the three Qt pieces a YouTube/Twitch chat app needs — **OpenSSL** (TLS for HTTPS/WSS), **QtWebSockets** (Twitch chat transport), and **QtNetworkAuth** (OAuth sign-in) — across **both** Qt provisioning paths introduced by #57. Nothing consumes them yet; this makes the toolchain provide them. `QtNetwork` already arrives via `qtdeclarative`.

Supersedes #56, which predated the prebuilt-Qt pivot and was built on the old flat manifest.

## Changes

- **vcpkg-built Qt path** (`vcpkg.json` `qt` feature): add `qtwebsockets`, `qtnetworkauth`, and the `openssl` feature on `qtbase`.
- **Prebuilt Qt path** (`.github/actions/get-qt`): new `modules` input, defaulting to `qtnetworkauth qtwebsockets`, passed to `install-qt-action`. Desktop (windows/macos/linux) and android inherit it.
- **web** (`web.yml`): overrides the wasm `get-qt` to `modules: qtwebsockets` only.
- **steamos** is unchanged — it stays on vcpkg Qt, so the `qt` feature covers it.

## Platform gating

`qtwebsockets` is enabled everywhere (Qt maps `QWebSocket` onto the browser WebSocket API on wasm). `qtnetworkauth` and `openssl` are excluded on **emscripten**: the loopback-redirect OAuth flow can't run in the browser sandbox, the browser terminates TLS itself, and aqt confirms the wasm kit doesn't even offer `qtnetworkauth`. This mirrors the exclusion that made #56 go green.

## Verification

- `vcpkg install --dry-run` on `x64-windows-release` resolves the `qt` feature with `openssl`, `qtwebsockets`, `qtnetworkauth`, and `qtbase[...,openssl,...]` — no conflicts.
- `aqt list-qt … --modules 6.11.0` confirms `qtwebsockets` + `qtnetworkauth` are valid **desktop** modules and `qtwebsockets` is a valid **wasm** module (and `qtnetworkauth` is correctly absent there).
- The vcpkg package set here is identical to #56, which built green on all seven platform workflows.
- `vcpkg.json` is valid JSON; both edited YAML files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
