### PR TITLE
Fold duplicated target setup into awen_add_qml_module and awen_add_executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ set(QT_QML_GENERATE_QMLLS_INI ON CACHE BOOL "Generate .qmlls.ini for qmlls" FORC
 
 include(cmake/qt-build-tree-conf.cmake)
 
+# awen_add_qml_module / awen_add_executable, the shared target patterns for
+# src/ and app/.
+include(cmake/awen-target.cmake)
+
 add_subdirectory(src)
 add_subdirectory(app)
 

--- a/app/awen/CMakeLists.txt
+++ b/app/awen/CMakeLists.txt
@@ -1,11 +1,6 @@
-qt_add_executable(awen)
-
-target_sources(${PROJECT_NAME}
-    PRIVATE
-        main.cpp
-)
-
-qt_add_qml_module(${PROJECT_NAME}
+# The framework sample app: a thin Qt bootstrap loading the AwenApp QML module.
+# On android it packages under Qt's default template identity.
+awen_add_executable(awen
     URI AwenApp
     VERSION 1.0
     QML_FILES
@@ -14,66 +9,12 @@ qt_add_qml_module(${PROJECT_NAME}
         awen.entity
 )
 
-# No QT_QML_DEBUG: the QML debug server bypasses the compiled units and demands
-# the optional qtquick2plugin the deploy step does not ship, failing startup.
+target_sources(awen
+    PRIVATE
+        main.cpp
+)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(awen
     PRIVATE
         awen-entity
-        Qt6::Quick
 )
-
-if(EMSCRIPTEN)
-    # Embed ":/qt/etc/qt.conf" so QLibraryInfo skips getRelocatablePrefix(), whose
-    # debug-only assert aborts this static wasm build at startup.
-    set_source_files_properties(
-        "${CMAKE_SOURCE_DIR}/cmake/wasm/qt.conf"
-        PROPERTIES QT_RESOURCE_ALIAS qt.conf
-    )
-    qt_add_resources(${PROJECT_NAME} awen_wasm_qt_conf
-        PREFIX "/qt/etc"
-        FILES "${CMAKE_SOURCE_DIR}/cmake/wasm/qt.conf"
-    )
-
-    # Qt is linked into the .js/.wasm, so ship the generated bundle.
-    install(FILES
-        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/awen.html"
-        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/awen.js"
-        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/awen.wasm"
-        DESTINATION web
-    )
-
-    install(FILES
-        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/qtloader.js"
-        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/awen.worker.js"
-        DESTINATION web
-        OPTIONAL
-    )
-
-    return()
-endif()
-
-if(ANDROID)
-    # The framework sample packages under Qt's default template identity.
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/android-build/awen.apk"
-        DESTINATION android
-    )
-
-    return()
-endif()
-
-install(TARGETS ${PROJECT_NAME}
-    BUNDLE DESTINATION .
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
-qt_generate_deploy_qml_app_script(
-    TARGET ${PROJECT_NAME}
-    OUTPUT_SCRIPT deploy_script
-    NO_UNSUPPORTED_PLATFORM_ERROR
-    NO_TRANSLATIONS
-)
-
-install(SCRIPT ${deploy_script})
-

--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -1,15 +1,9 @@
 # Briarthorn — the game, built in QML on the awen framework; own license, see
 # LICENSE.md. A thin Qt bootstrap (main.cpp) loads the QML module below.
-qt_add_executable(briarthorn)
-
-target_sources(briarthorn
-    PRIVATE
-        main.cpp
-)
 
 # IMPORTS tells the import scan (qmllint, deploy) that the QML files depend on
 # awen.entity and awen.gamepad; the types come from the linked modules below.
-qt_add_qml_module(briarthorn
+awen_add_executable(briarthorn
     URI Briarthorn
     VERSION 1.0
     QML_FILES
@@ -20,108 +14,45 @@ qt_add_qml_module(briarthorn
         awen.gamepad
 )
 
-# No QT_QML_DEBUG: the QML debug server bypasses the compiled units and demands
-# the optional qtquick2plugin the deploy step does not ship, failing startup.
+target_sources(briarthorn
+    PRIVATE
+        main.cpp
+)
 
 target_link_libraries(briarthorn
     PRIVATE
         awen-entity
         awen-gamepad
-        Qt6::Quick
 )
 
-# Windows: embed the application icon into the .exe.
+# Windows: embed the application icon into the .exe. enable_language is
+# file-scope-only, so this cannot move into the wrapper.
 if(WIN32)
     enable_language(RC)
     target_sources(briarthorn PRIVATE briarthorn.rc)
 endif()
 
-# qmlcachegen-generated code trips MSVC C4702 (unreachable return) inside Qt
-# headers, which /WX would turn into an error — disable just that warning.
-if(MSVC)
-    target_compile_options(briarthorn PRIVATE /wd4702)
-endif()
-
-# macOS needs an .app bundle for macdeployqt; a plain executable fails to launch
-# after install.
-set_target_properties(briarthorn PROPERTIES
-    MACOSX_BUNDLE TRUE
-)
-
 if(EMSCRIPTEN)
-    # Embed ":/qt/etc/qt.conf" so QLibraryInfo skips getRelocatablePrefix(), whose
-    # debug-only assert aborts this static wasm build at startup. wasm-only: on
-    # desktop a forced Prefix would break plugin/QML resolution.
-    set_source_files_properties(
-        "${CMAKE_SOURCE_DIR}/cmake/wasm/qt.conf"
-        PROPERTIES QT_RESOURCE_ALIAS qt.conf
-    )
-    qt_add_resources(briarthorn briarthorn_wasm_qt_conf
-        PREFIX "/qt/etc"
-        FILES "${CMAKE_SOURCE_DIR}/cmake/wasm/qt.conf"
-    )
-
-    # Qt is linked into the .js/.wasm, so ship the generated bundle; the install
-    # directory can then be served as-is.
-    install(FILES
-        "$<TARGET_FILE_DIR:briarthorn>/briarthorn.html"
-        "$<TARGET_FILE_DIR:briarthorn>/briarthorn.js"
-        "$<TARGET_FILE_DIR:briarthorn>/briarthorn.wasm"
-        DESTINATION web
-    )
-
-    # Only emitted for some configurations, so optional rather than predicted.
-    install(FILES
-        "$<TARGET_FILE_DIR:briarthorn>/qtloader.js"
-        "$<TARGET_FILE_DIR:briarthorn>/briarthorn.worker.js"
-        DESTINATION web
-        OPTIONAL
-    )
-
     # The briarthorn.game entry page, embedding the app in a bounded view; Qt's
     # generated briarthorn.html stays as a debug fallback.
     install(FILES web/index.html DESTINATION web)
-
-    return()
 endif()
 
 if(ANDROID)
-    # Package identity and launcher assets; androiddeployqt overlays android/ onto
-    # Qt's package template and a plain build assembles the APK (apk_all is in ALL).
+    # Package identity and launcher assets; androiddeployqt overlays android/
+    # onto Qt's package template.
     set_target_properties(briarthorn PROPERTIES
         QT_ANDROID_PACKAGE_NAME "com.funnansoftware.briarthorn"
         QT_ANDROID_VERSION_CODE 1
         QT_ANDROID_VERSION_NAME "1.0"
         QT_ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android"
     )
-
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/android-build/briarthorn.apk"
-        DESTINATION android
-    )
-
-    return()
 endif()
-
-install(TARGETS briarthorn
-    BUNDLE DESTINATION .
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
-# Deploy the Qt libraries, platform plugins and QML imports next to the installed app.
-qt_generate_deploy_qml_app_script(
-    TARGET briarthorn
-    OUTPUT_SCRIPT deploy_script
-    NO_UNSUPPORTED_PLATFORM_ERROR
-    NO_TRANSLATIONS
-)
-
-install(SCRIPT ${deploy_script})
 
 # Headless smoke test: run the real app (minimal platform, software scene graph)
 # and quit via the seam in main.cpp — a clean exit proves Main.qml and its
-# awen.gamepad import load.
-if(BUILD_TESTING)
+# awen.gamepad import load. Native only — a wasm/android binary isn't runnable here.
+if(BUILD_TESTING AND NOT EMSCRIPTEN AND NOT ANDROID)
     add_test(NAME tst_apploads COMMAND briarthorn)
     set_tests_properties(tst_apploads PROPERTIES ENVIRONMENT
         "BRIARTHORN_SMOKE_QUIT_MS=3000;QT_QPA_PLATFORM=minimal;QSG_RHI_BACKEND=software"

--- a/cmake/awen-target.cmake
+++ b/cmake/awen-target.cmake
@@ -1,0 +1,113 @@
+# The project's two target patterns: a framework QML module and a Qt Quick app
+# with its per-platform install/deploy story. Extra arguments forward to
+# qt_add_qml_module (URI, VERSION, QML_FILES, SOURCES, IMPORTS, ...).
+
+# A framework QML module: SHARED except on wasm (one static binary there) — a
+# static module has no loadable plugin, so a Release loadFromModule fails to
+# resolve the import.
+function(awen_add_qml_module target)
+    set(linkage "")
+    if(NOT EMSCRIPTEN)
+        set(linkage "SHARED")
+    endif()
+
+    qt_add_qml_module(${target}
+        ${linkage}
+        ${ARGN}
+    )
+
+    target_link_libraries(${target}
+        PUBLIC
+            Qt6::Core
+            Qt6::Quick
+    )
+
+    # qmlcachegen-generated code trips MSVC C4702 (unreachable return) inside Qt
+    # headers, which /WX would turn into an error — disable just that warning.
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /wd4702)
+    endif()
+endfunction()
+
+# A Qt Quick app: the executable+module pair plus per-platform install/deploy.
+# Callers add sources, awen-module links, and platform extras after the call —
+# Qt finalization is deferred to the end of the calling directory.
+function(awen_add_executable target)
+    qt_add_executable(${target})
+
+    qt_add_qml_module(${target}
+        ${ARGN}
+    )
+
+    # No QT_QML_DEBUG: the QML debug server bypasses the compiled units and
+    # demands the optional qtquick2plugin the deploy step does not ship, failing
+    # startup.
+
+    target_link_libraries(${target} PRIVATE Qt6::Quick)
+
+    # qmlcachegen-generated code trips MSVC C4702 (unreachable return) inside Qt
+    # headers, which /WX would turn into an error — disable just that warning.
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /wd4702)
+    endif()
+
+    # macOS needs an .app bundle for macdeployqt; a plain executable fails to
+    # launch after install. Ignored off-Apple.
+    set_target_properties(${target} PROPERTIES
+        MACOSX_BUNDLE TRUE
+    )
+
+    if(EMSCRIPTEN)
+        # Embed ":/qt/etc/qt.conf" so QLibraryInfo skips getRelocatablePrefix(),
+        # whose debug-only assert aborts this static wasm build at startup.
+        # wasm-only: on desktop a forced Prefix would break plugin/QML resolution.
+        set_source_files_properties(
+            "${CMAKE_SOURCE_DIR}/cmake/wasm/qt.conf"
+            PROPERTIES QT_RESOURCE_ALIAS qt.conf
+        )
+        qt_add_resources(${target} ${target}_wasm_qt_conf
+            PREFIX "/qt/etc"
+            FILES "${CMAKE_SOURCE_DIR}/cmake/wasm/qt.conf"
+        )
+
+        # Qt is linked into the .js/.wasm, so ship the generated bundle; the
+        # install directory can then be served as-is.
+        install(FILES
+            "$<TARGET_FILE_DIR:${target}>/${target}.html"
+            "$<TARGET_FILE_DIR:${target}>/${target}.js"
+            "$<TARGET_FILE_DIR:${target}>/${target}.wasm"
+            DESTINATION web
+        )
+
+        # Only emitted for some configurations, so optional rather than predicted.
+        install(FILES
+            "$<TARGET_FILE_DIR:${target}>/qtloader.js"
+            "$<TARGET_FILE_DIR:${target}>/${target}.worker.js"
+            DESTINATION web
+            OPTIONAL
+        )
+    elseif(ANDROID)
+        # androiddeployqt assembles the APK during a plain build (apk_all is in
+        # ALL); ship it from the build tree.
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/android-build/${target}.apk"
+            DESTINATION android
+        )
+    else()
+        install(TARGETS ${target}
+            BUNDLE DESTINATION .
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+
+        # Deploy the Qt libraries, platform plugins and QML imports next to the
+        # installed app.
+        qt_generate_deploy_qml_app_script(
+            TARGET ${target}
+            OUTPUT_SCRIPT deploy_script
+            NO_UNSUPPORTED_PLATFORM_ERROR
+            NO_TRANSLATIONS
+        )
+
+        install(SCRIPT ${deploy_script})
+    endif()
+endfunction()

--- a/src/awen/entity/CMakeLists.txt
+++ b/src/awen/entity/CMakeLists.txt
@@ -1,15 +1,6 @@
 # awen.entity — entity state and the System/Systems pair games derive their
 # per-frame logic from.
-
-# SHARED except on wasm (one static binary there): a static module has no loadable
-# plugin, so a Release loadFromModule fails to resolve `import awen.entity`.
-set(_awen_entity_linkage "")
-if(NOT EMSCRIPTEN)
-    set(_awen_entity_linkage "SHARED")
-endif()
-
-qt_add_qml_module(awen-entity
-    ${_awen_entity_linkage}
+awen_add_qml_module(awen-entity
     URI awen.entity
     VERSION 1.0
     QML_FILES
@@ -18,18 +9,6 @@ qt_add_qml_module(awen-entity
     SOURCES
         Entity.h
 )
-
-target_link_libraries(awen-entity
-    PUBLIC
-        Qt6::Core
-        Qt6::Quick
-)
-
-# qmlcachegen-generated code trips MSVC C4702 (unreachable return) inside Qt
-# headers, which /WX would turn into an error — disable just that warning.
-if(MSVC)
-    target_compile_options(awen-entity PRIVATE /wd4702)
-endif()
 
 # Tests run natively only; the web and android presets set BUILD_TESTING=OFF.
 if(BUILD_TESTING)

--- a/src/awen/gamepad/CMakeLists.txt
+++ b/src/awen/gamepad/CMakeLists.txt
@@ -2,27 +2,13 @@
 # by SDL3 on desktop and wasm. The Qt-free awen-gamepad-core below holds the
 # unit-tested translation logic; this module is the SDL/QML edge on top of it.
 
-# SHARED except on wasm (one static binary there): a static module has no loadable
-# plugin, so a Release loadFromModule fails to resolve `import awen.gamepad`.
-set(_awen_gamepad_linkage "")
-if(NOT EMSCRIPTEN)
-    set(_awen_gamepad_linkage "SHARED")
-endif()
-
-qt_add_qml_module(awen-gamepad
-    ${_awen_gamepad_linkage}
+awen_add_qml_module(awen-gamepad
     URI awen.gamepad
     VERSION 1.0
     QML_FILES
     SOURCES
         Gamepad.h
         Gamepad.cpp
-)
-
-target_link_libraries(awen-gamepad
-    PUBLIC
-        Qt6::Core
-        Qt6::Quick
 )
 
 if(ANDROID)


### PR DESCRIPTION
The two apps shared ~60 nearly identical lines (executable + QML module setup, the wasm qt.conf embed and bundle install, the android apk install, the desktop install + deploy-script tail), and the two framework modules shared the SHARED-except-wasm linkage selection and Qt link boilerplate. Both patterns now live once in `cmake/awen-target.cmake`:

- `awen_add_qml_module` — linkage selection, `PUBLIC Qt6::Core/Quick`, MSVC `/wd4702`. `awen-gamepad-core` deliberately stays a plain `add_library(STATIC)` outside it.
- `awen_add_executable` — executable + QML module pair, `PRIVATE Qt6::Quick`, `MACOSX_BUNDLE`, and the per-platform install/deploy as an `if(EMSCRIPTEN)/elseif(ANDROID)/else()` dispatch. Extra arguments forward to `qt_add_qml_module`; callers keep `URI`/`VERSION`, sources, and awen-module links.

Because `return()` inside a `function()` no longer skips the caller's file, briarthorn's retained blocks carry explicit platform guards now (`web/index.html`, `QT_ANDROID_*`, smoke test), and the RC icon block stays in its CMakeLists — `enable_language` is file-scope-only.

Deliberate unifications riding along:
- The awen sample app gains `MACOSX_BUNDLE`: its macOS deploy script previously no-op'd via `NO_UNSUPPORTED_PLATFORM_ERROR` (deploy requires a bundle), leaving the installed app unlaunchable; it now installs as `awen.app` and actually deploys.
- The awen app and awen-gamepad gain `/wd4702`, matching briarthorn and awen-entity under the global `/W4 /WX`.
- App files no longer link `Qt6::Quick` themselves or use `${PROJECT_NAME}` for the target name.

Verified: `windows-msvc-debug` configure + build + ctest, 17/17 passing including the briarthorn `tst_apploads` smoke test that exercises `loadFromModule` and the `awen.gamepad` import at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)