### PR TITLE
Deploy the briarthorn web bundle to Cloudflare from the web workflow

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -118,3 +118,28 @@ jobs:
         with:
           name: web-build
           path: build/web-release/installed/web
+
+  # Publish the verified bundle to Cloudflare so play.briarthorn.game serves
+  # the current main. The push trigger only fires for main (branches filter
+  # above), so PR runs stop at the artifact.
+  deploy:
+    runs-on: ubuntu-24.04
+    needs: web-build
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Land the artifact where wrangler.jsonc expects the docroot — the same
+      # path a local web-release install produces.
+      - uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: build/web-release/installed/web
+
+      - name: wrangler-deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ vcpkg_installed/
 # test output & cache
 Testing/
 .cache/
+
+# wrangler local state
+.wrangler/

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,18 @@
+// Cloudflare Workers config for the playable briarthorn web build: the
+// installed web/briarthorn docroot is served as static assets on
+// play.briarthorn.game. Deployed by the web workflow on pushes to main; a
+// local `wrangler deploy` works after a web-release install.
+{
+    "name": "briarthorn-game",
+    "compatibility_date": "2026-07-20",
+    "workers_dev": false,
+    "assets": {
+        "directory": "build/web-release/installed/web/briarthorn"
+    },
+    "routes": [
+        {
+            "pattern": "play.briarthorn.game",
+            "custom_domain": true
+        }
+    ]
+}


### PR DESCRIPTION
Adds a `deploy` job to the web workflow that publishes the verified wasm bundle to Cloudflare Workers as static assets, serving the briarthorn docroot at https://play.briarthorn.game.

- `wrangler.jsonc` at the repo root: worker `briarthorn-game`, assets from `build/web-release/installed/web/briarthorn` (the same path a local web-release install produces, so a local `wrangler deploy` also works), custom domain `play.briarthorn.game`, workers.dev disabled.
- The deploy job runs only on pushes to main (`pull_request` runs still stop at the artifact), downloads the `web-build` artifact into the install path, and deploys with `cloudflare/wrangler-action@v3`.
- Requires two new repo secrets before merging: `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. The token needs the "Edit Cloudflare Workers" template plus Zone / DNS / Edit on briarthorn.game so wrangler can attach the custom domain on first deploy.

briarthorn.wasm is 19.3 MB, under Cloudflare's 25 MiB per-asset limit; the single-threaded Qt build needs no COOP/COEP headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)