### PR TITLE
Pin wrangler 4 in the web deploy job for assets-only workers

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -142,4 +142,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # The action's default wrangler is a 3.x, which predates assets-only
+          # workers and fails on the missing main script.
+          wranglerVersion: "4.112.0"
           command: deploy


### PR DESCRIPTION
The first main deploy failed: wrangler-action@v3 installs wrangler 3.90.0 by default, which predates assets-only workers and errors with "Missing entry-point" on a config whose worker is just an assets directory. Pin wranglerVersion to 4.112.0 — the version the config was dry-run-validated against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)