### PR TITLE
Add the awen.shapes instrument-primitive module

### DIFF
--- a/app/awen/CMakeLists.txt
+++ b/app/awen/CMakeLists.txt
@@ -5,6 +5,8 @@ awen_add_executable(awen
     VERSION 1.0
     QML_FILES
         Main.qml
+        StressScope.qml
     AWEN_MODULES
         entity
+        shapes
 )

--- a/app/awen/Main.qml
+++ b/app/awen/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import awen.entity
+import awen.shapes
 
 Window {
     id: window
@@ -54,26 +55,51 @@ Window {
         }
     }
 
-    Canvas {
-        anchors.centerIn: parent
-        width: parent.width
-        height: parent.height
+    // The range-ring pattern: a gapped ring with the app's label anchored on
+    // the exposed gapCenter readout.
+    ShapeRing {
+        id: ring
+        anchors.fill: parent
+        radius: parent.height * 0.4
+        gapAngle: 25
+        gapLength: 50
+        strokeColor: "white"
+        strokeWidth: 3
 
-        onPaint: {
-            var ctx = getContext("2d");
-            var centerX = width / 2;
-            var centerY = height / 2;
-            var radius = height * 0.4;
-            var startAngle = (30 - 90) * Math.PI / 180;
-            var endAngle = (30 + 10 - 90) * Math.PI / 180;
-
-            ctx.strokeStyle = "white";
-            ctx.lineWidth = 3;
-            ctx.lineCap = "round";
-
-            ctx.beginPath();
-            ctx.arc(centerX, centerY, radius, startAngle, endAngle + Math.PI * 2 - 20 * Math.PI / 180, false);
-            ctx.stroke();
+        Text {
+            x: ring.gapCenter.x - width / 2
+            y: ring.gapCenter.y - height / 2
+            text: "40"
+            color: "white"
+            font.bold: true
         }
+    }
+
+    // A gauge cycling its fill, as a living ShapeGauge example.
+    ShapeGauge {
+        width: 96
+        height: 96
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        anchors.margins: 24
+        fillColor: "#ffa100"
+
+        SequentialAnimation on value {
+            loops: Animation.Infinite
+            NumberAnimation { from: 0; to: 1; duration: 2000; easing.type: Easing.InOutQuad }
+            NumberAnimation { from: 1; to: 0; duration: 2000; easing.type: Easing.InOutQuad }
+        }
+    }
+
+    // The synthetic scope stress page; S toggles it over the sample scene.
+    StressScope {
+        id: stress
+        anchors.fill: parent
+        visible: false
+    }
+
+    Shortcut {
+        sequence: "S"
+        onActivated: stress.visible = !stress.visible
     }
 }

--- a/app/awen/StressScope.qml
+++ b/app/awen/StressScope.qml
@@ -1,0 +1,222 @@
+import QtQuick
+import awen.shapes
+
+// A synthetic scope stress page: one rotated world layer, pooled contact
+// symbols with dot trails, sweeping sector wedges and re-tessellating
+// detonation arcs, with live frame stats — the briarthorn scope architecture
+// under load before the port commits to it.
+Rectangle {
+    id: root
+    color: "#101418"
+
+    readonly property int contactCount: 30
+    readonly property int trailCount: 20
+
+    // The simulated clock in seconds; every animation below binds to it.
+    property real t: 0
+
+    // Ownship heading sweeps continuously to exercise the world rotation.
+    readonly property real heading: t * 20 % 360
+
+    // Frame statistics over a rolling window.
+    property real frameAvgMs: 0
+    property real frameP95Ms: 0
+    property var samples: []
+
+    FrameAnimation {
+        running: root.visible
+        onTriggered: {
+            root.t += frameTime;
+            const s = root.samples;
+            s.push(frameTime * 1000);
+            if (s.length >= 120) {
+                const sorted = s.slice().sort((a, b) => a - b);
+                let sum = 0;
+                for (let i = 0; i < sorted.length; ++i)
+                    sum += sorted[i];
+                root.frameAvgMs = sum / sorted.length;
+                root.frameP95Ms = sorted[Math.floor(sorted.length * 0.95)];
+                root.samples = [];
+            }
+        }
+    }
+
+    // Screen-fixed range rings; the outer one carries the label and the gap
+    // window the tick labels test against.
+    ShapeRing {
+        id: outerRing
+        anchors.fill: parent
+        radius: Math.min(width, height) * 0.4
+        gapAngle: 25
+        gapLength: 50
+        strokeColor: "#8899aa"
+        strokeWidth: 2.5
+
+        Text {
+            x: outerRing.gapCenter.x - width / 2
+            y: outerRing.gapCenter.y - height / 2
+            text: "40"
+            color: "white"
+            font.bold: true
+            font.pixelSize: 13
+        }
+    }
+
+    ShapeRing {
+        anchors.fill: parent
+        radius: Math.min(width, height) * 0.2
+        gapAngle: 25
+        gapLength: 50
+        strokeColor: "#668899aa"
+        strokeWidth: 2
+    }
+
+    // Heading-up bearing ticks; the marks re-tessellate as one PathSvg while
+    // the labels ride tickPoint and hide inside the ring gap without churn.
+    ShapeTicks {
+        id: ticks
+        anchors.fill: parent
+        radius: outerRing.radius + 8
+        length: 10
+        angleOffset: -root.heading
+        gapAngle: outerRing.gapAngle
+        gapHalfAngle: outerRing.gapHalfAngle
+        strokeColor: "#8899aa"
+    }
+
+    Repeater {
+        model: 12
+        Text {
+            id: tickLabel
+            required property int index
+            readonly property real bearing: index * 30
+            readonly property point p: ticks.tickPoint(bearing, ticks.radius + 18)
+            x: p.x - width / 2
+            y: p.y - height / 2
+            visible: !outerRing.inGap(bearing + ticks.angleOffset)
+            text: bearing === 0 ? "N" : bearing
+            color: "#aabbcc"
+            font.pixelSize: 11
+        }
+    }
+
+    // The rotated world: one matrix update per frame carries everything below.
+    Item {
+        id: world
+        anchors.fill: parent
+        rotation: -root.heading
+
+        // Sweeping SAM wedges: fixed sector geometry, only Item rotation
+        // animates — no re-tessellation.
+        Repeater {
+            model: 3
+            Item {
+                id: site
+                required property int index
+                x: world.width / 2 + Math.sin(index * 2.1) * 200 - width / 2
+                y: world.height / 2 - Math.cos(index * 2.1) * 200 - height / 2
+                width: 160
+                height: 160
+
+                ShapeArc {
+                    anchors.fill: parent
+                    strokeColor: "#55ff6644"
+                    strokeWidth: 1
+                }
+
+                ShapeSector {
+                    anchors.fill: parent
+                    angleSpan: 40
+                    fillColor: "#22ff6644"
+                    rotation: root.t * 115 + site.index * 120
+                }
+            }
+        }
+
+        // Pooled contacts, each a transform-driven symbol trailing a fading
+        // dot wake computed per frame.
+        Repeater {
+            model: root.contactCount
+            Item {
+                id: contact
+                required property int index
+                readonly property real phase: root.t * (0.2 + index % 5 * 0.06) + index * 1.7
+                readonly property real orbitR: 60 + index * 9
+                x: world.width / 2 + Math.sin(phase) * orbitR
+                y: world.height / 2 - Math.cos(phase) * orbitR
+
+                Repeater {
+                    model: root.trailCount
+                    Rectangle {
+                        required property int index
+                        readonly property real back: (index + 1) * 0.06
+                        width: 3
+                        height: 3
+                        radius: 1.5
+                        x: (Math.sin(contact.phase - back) - Math.sin(contact.phase)) * contact.orbitR
+                        y: (Math.cos(contact.phase) - Math.cos(contact.phase - back)) * contact.orbitR
+                        color: Qt.rgba(1, 0.63, 0, 0.9 * (1 - index / root.trailCount))
+                    }
+                }
+
+                ShapePolygon {
+                    anchors.centerIn: parent
+                    width: 18
+                    height: 18
+                    points: [Qt.point(0, -0.5), Qt.point(0.42, 0.42), Qt.point(0, 0.12), Qt.point(-0.42, 0.42)]
+                    fillColor: "#38ffa100"
+                    strokeColor: "#ffa100"
+                    rotation: contact.phase * 180 / Math.PI + 90
+                }
+
+                // The selected contact's health arc: counter-rotated so it
+                // stays screen-stable, its sweep re-tessellating as it drains.
+                ShapeGauge {
+                    anchors.centerIn: parent
+                    width: 30
+                    height: 30
+                    visible: contact.index === 0
+                    rotation: root.heading
+                    angleStart: 198
+                    angleSweep: 144
+                    radius: 13
+                    strokeWidth: 2
+                    value: 0.5 + 0.5 * Math.sin(root.t)
+                    trackColor: "#3300ff88"
+                    fillColor: "#00ff88"
+                }
+            }
+        }
+
+        // Expanding detonation rings — deliberate per-frame path changes.
+        Repeater {
+            model: 2
+            ShapeArc {
+                required property int index
+                readonly property real cycle: (root.t * 0.7 + index * 0.5) % 1
+                anchors.centerIn: parent
+                width: 300
+                height: 300
+                radius: 10 + cycle * 130
+                strokeColor: Qt.rgba(1, 0.85, 0.4, 1 - cycle)
+                strokeWidth: 2
+            }
+        }
+    }
+
+    ShapeReticle {
+        anchors.centerIn: parent
+        width: 40
+        height: 40
+        strokeColor: "#ffd24d"
+    }
+
+    Text {
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.margins: 16
+        color: "white"
+        font.pixelSize: 13
+        text: "frame avg " + root.frameAvgMs.toFixed(2) + " ms   p95 " + root.frameP95Ms.toFixed(2) + " ms   (S closes)"
+    }
+}

--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -9,6 +9,7 @@ awen_add_executable(briarthorn
     AWEN_MODULES
         entity
         gamepad
+        shapes
     WINDOWS_ICON briarthorn.ico
     # The briarthorn.game entry page, embedding the app in a bounded view; Qt's
     # generated briarthorn.html stays as a debug fallback.

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import awen.entity
 import awen.gamepad
+import awen.shapes
 import "systems"
 
 // Placeholder shell for the briarthorn game, pure QML: a marker steered with
@@ -103,22 +104,12 @@ Window {
                 }
             }
 
-            Canvas {
+            ShapePolygon {
                 anchors.centerIn: parent
                 width: 26
                 height: width
-
-                onPaint: {
-                    const ctx = getContext("2d");
-                    ctx.reset();
-                    ctx.fillStyle = "#ffa100";
-                    ctx.beginPath();
-                    ctx.moveTo(width / 2, 0);      // nose
-                    ctx.lineTo(width, height);     // tail right
-                    ctx.lineTo(0, height);         // tail left
-                    ctx.closePath();
-                    ctx.fill();
-                }
+                points: [Qt.point(0, -0.5), Qt.point(0.5, 0.5), Qt.point(-0.5, 0.5)]
+                fillColor: "#ffa100"
             }
         }
 

--- a/src/awen/CMakeLists.txt
+++ b/src/awen/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(app)
 add_subdirectory(entity)
 add_subdirectory(gamepad)
+add_subdirectory(shapes)

--- a/src/awen/shapes/CMakeLists.txt
+++ b/src/awen/shapes/CMakeLists.txt
@@ -1,0 +1,27 @@
+# awen.shapes — declarative instrument primitives on QtQuick.Shapes: arcs,
+# rings, gauges, polygons, ticks and connectors. Angles are bearing degrees
+# (0 = up, clockwise); text stays with the app, anchored on exposed readouts.
+awen_add_qml_module(awen-shapes
+    URI awen.shapes
+    VERSION 1.0
+    # Declared so the configure-time import scan links the Shapes plugin into
+    # static (wasm) apps; no app QML imports QtQuick.Shapes directly.
+    DEPENDENCIES
+        QtQuick.Shapes
+    QML_FILES
+        bearing.js
+        ShapeArc.qml
+        ShapeGauge.qml
+        ShapeLink.qml
+        ShapePolygon.qml
+        ShapeReticle.qml
+        ShapeRing.qml
+        ShapeSector.qml
+        ShapeSparkline.qml
+        ShapeTicks.qml
+)
+
+# Tests run natively only; the web and android presets set BUILD_TESTING=OFF.
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()

--- a/src/awen/shapes/ShapeArc.qml
+++ b/src/awen/shapes/ShapeArc.qml
@@ -1,0 +1,47 @@
+import QtQuick
+import QtQuick.Shapes
+import "bearing.js" as Bearing
+
+// A stroked arc in bearing degrees (0 = up, clockwise); the default sweep
+// draws a full circle. Stroke only — filled pies are ShapeSector's job.
+Shape {
+    id: root
+
+    // Arc radius; defaults to the largest circle that keeps the stroke inside
+    // the item's bounds.
+    property real radius: Math.min(width, height) / 2 - strokeWidth / 2
+
+    // Bearing of the arc's start, degrees clockwise from up.
+    property real angleStart: 0
+
+    // Arc extent in degrees, clockwise positive.
+    property real angleSweep: 360
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+    property alias capStyle: path.capStyle
+    property alias strokeStyle: path.strokeStyle
+    property alias dashPattern: path.dashPattern
+
+    // The point at bearing angleDeg and distance r from the item's centre.
+    function pointAt(angleDeg: real, r: real): point {
+        return Bearing.point(width / 2, height / 2, angleDeg, r);
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        id: path
+        fillColor: "transparent"
+        capStyle: ShapePath.RoundCap
+
+        PathAngleArc {
+            centerX: root.width / 2
+            centerY: root.height / 2
+            radiusX: root.radius
+            radiusY: root.radius
+            startAngle: root.angleStart - 90
+            sweepAngle: root.angleSweep
+        }
+    }
+}

--- a/src/awen/shapes/ShapeGauge.qml
+++ b/src/awen/shapes/ShapeGauge.qml
@@ -1,0 +1,78 @@
+import QtQuick
+import QtQuick.Shapes
+import "bearing.js" as Bearing
+
+// A track arc with a proportional fill arc — the dial-gauge primitive. The
+// defaults give a bottom-open 270° gauge; narrower spans make status arcs
+// (e.g. a health arc hugging one side of a symbol).
+Shape {
+    id: root
+
+    // Fill fraction, 0..1; values outside the range clamp.
+    property real value: 0
+
+    // Bearing of the track's start, degrees clockwise from up.
+    property real angleStart: 225
+
+    // Track extent in degrees, clockwise positive.
+    property real angleSweep: 270
+
+    // Gauge radius; defaults to the largest circle that keeps the stroke
+    // inside the item's bounds.
+    property real radius: Math.min(width, height) / 2 - strokeWidth / 2
+
+    // Stroke thickness shared by the track and fill arcs.
+    property real strokeWidth: 6
+
+    property color trackColor: "#33ffffff"
+    property color fillColor: "white"
+    property int capStyle: ShapePath.RoundCap
+
+    // The fill arc's extent in degrees.
+    readonly property real fillSweep: angleSweep * Math.max(0, Math.min(1, value))
+
+    // False at value 0, where a round cap would otherwise paint a stray dot.
+    readonly property bool fillVisible: value > 0
+
+    // The fill arc's end point — a tip-marker or label anchor.
+    readonly property point fillEnd: pointAt(angleStart + fillSweep, radius)
+
+    // The point at bearing angleDeg and distance r from the item's centre.
+    function pointAt(angleDeg: real, r: real): point {
+        return Bearing.point(width / 2, height / 2, angleDeg, r);
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        fillColor: "transparent"
+        strokeColor: root.trackColor
+        strokeWidth: root.strokeWidth
+        capStyle: root.capStyle
+
+        PathAngleArc {
+            centerX: root.width / 2
+            centerY: root.height / 2
+            radiusX: root.radius
+            radiusY: root.radius
+            startAngle: root.angleStart - 90
+            sweepAngle: root.angleSweep
+        }
+    }
+
+    ShapePath {
+        fillColor: "transparent"
+        strokeColor: root.fillVisible ? root.fillColor : "transparent"
+        strokeWidth: root.strokeWidth
+        capStyle: root.capStyle
+
+        PathAngleArc {
+            centerX: root.width / 2
+            centerY: root.height / 2
+            radiusX: root.radius
+            radiusY: root.radius
+            startAngle: root.angleStart - 90
+            sweepAngle: root.fillSweep
+        }
+    }
+}

--- a/src/awen/shapes/ShapeLink.qml
+++ b/src/awen/shapes/ShapeLink.qml
@@ -1,0 +1,105 @@
+import QtQuick
+import QtQuick.Shapes
+
+// A cubic connector between two points, with optional dashing, a glow
+// understroke and an arrowhead — the graph-edge primitive. Default controls
+// give horizontal end tangents; override them to route through corridors.
+// Qt dash patterns are in stroke-width units, not pixels: a 6-4 px dash at
+// width 1.5 is dashPattern: [4, 2.67].
+Shape {
+    id: root
+
+    property point from: Qt.point(0, 0)
+    property point to: Qt.point(0, 0)
+
+    // Horizontal-tangent reach of the default control points, as a fraction of
+    // the endpoints' x distance.
+    property real tangent: 0.45
+
+    property point fromControl: Qt.point(from.x + tangent * (to.x - from.x), from.y)
+    property point toControl: Qt.point(to.x - tangent * (to.x - from.x), to.y)
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+    property alias strokeStyle: path.strokeStyle
+    property alias dashPattern: path.dashPattern
+    property alias capStyle: path.capStyle
+
+    // The glow understroke's color; transparent draws none. It strokes the
+    // same cubic glowExtra wider than the main line.
+    property color glowColor: "transparent"
+    property real glowExtra: 4
+
+    property bool arrowhead: false
+    property real arrowSize: 6
+
+    // The arrowhead chevron, oriented along the arrival tangent; a degenerate
+    // tangent (toControl on the endpoint) falls back to the chord direction.
+    readonly property list<point> arrowPolyline: {
+        if (!arrowhead)
+            return [];
+        let dx = to.x - toControl.x;
+        let dy = to.y - toControl.y;
+        if (Math.hypot(dx, dy) < 0.001) {
+            dx = to.x - from.x;
+            dy = to.y - from.y;
+        }
+        const len = Math.hypot(dx, dy);
+        if (len < 0.001)
+            return [];
+        const ux = dx / len;
+        const uy = dy / len;
+        const bx = to.x - ux * arrowSize;
+        const by = to.y - uy * arrowSize;
+        const w = arrowSize * 2 / 3;
+        return [Qt.point(bx - uy * w, by + ux * w), to, Qt.point(bx + uy * w, by - ux * w)];
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        fillColor: "transparent"
+        strokeColor: root.glowColor
+        strokeWidth: path.strokeWidth + root.glowExtra
+        capStyle: ShapePath.RoundCap
+        startX: root.from.x
+        startY: root.from.y
+
+        PathCubic {
+            x: root.to.x
+            y: root.to.y
+            control1X: root.fromControl.x
+            control1Y: root.fromControl.y
+            control2X: root.toControl.x
+            control2Y: root.toControl.y
+        }
+    }
+
+    ShapePath {
+        id: path
+        fillColor: "transparent"
+        startX: root.from.x
+        startY: root.from.y
+
+        PathCubic {
+            x: root.to.x
+            y: root.to.y
+            control1X: root.fromControl.x
+            control1Y: root.fromControl.y
+            control2X: root.toControl.x
+            control2Y: root.toControl.y
+        }
+    }
+
+    ShapePath {
+        fillColor: "transparent"
+        strokeColor: root.arrowhead ? path.strokeColor : "transparent"
+        strokeWidth: path.strokeWidth
+        capStyle: ShapePath.RoundCap
+        joinStyle: ShapePath.RoundJoin
+
+        PathPolyline {
+            path: root.arrowPolyline
+        }
+    }
+}

--- a/src/awen/shapes/ShapePolygon.qml
+++ b/src/awen/shapes/ShapePolygon.qml
@@ -1,0 +1,53 @@
+import QtQuick
+import QtQuick.Shapes
+
+// A closed fill-plus-stroke polygon — the symbol primitive. With unitScale on,
+// points live in a [-0.5, 0.5] box and scale uniformly to the item (aspect
+// locked, centred); rotate and fade with the Item rotation/opacity properties.
+Shape {
+    id: root
+
+    // The polygon's corners, in declaration order; closure back to the first
+    // point is automatic.
+    property list<point> points
+
+    // Whether points are unit-box model coordinates (true) or item-space
+    // pixels (false).
+    property bool unitScale: true
+
+    property color fillColor: "transparent"
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+    property alias joinStyle: path.joinStyle
+
+    // The closed polygon in item-space pixels (n + 1 points, last == first) —
+    // also the input for area computations like liquid fills.
+    readonly property list<point> polyline: {
+        if (points.length === 0)
+            return [];
+        const s = unitScale ? Math.min(width, height) : 1;
+        const cx = unitScale ? width / 2 : 0;
+        const cy = unitScale ? height / 2 : 0;
+        const out = [];
+        for (let i = 0; i < points.length; ++i)
+            out.push(Qt.point(cx + points[i].x * s, cy + points[i].y * s));
+        out.push(out[0]);
+        return out;
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        id: path
+        fillColor: root.fillColor
+        // Transparent, not Qt's white default: a bare polygon draws fill only.
+        strokeColor: "transparent"
+        strokeWidth: 1
+        joinStyle: ShapePath.MiterJoin
+
+        PathPolyline {
+            path: root.polyline
+        }
+    }
+}

--- a/src/awen/shapes/ShapeReticle.qml
+++ b/src/awen/shapes/ShapeReticle.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import QtQuick.Shapes
+
+// A four-armed crosshair with an open centre — the cursor primitive. Each arm
+// runs from gap to gap + armLength along its axis.
+Shape {
+    id: root
+
+    // Radius of the open centre, in pixels.
+    property real gap: 5
+
+    // Length of each arm, drawn outward from the gap.
+    property real armLength: 9
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+    property alias capStyle: path.capStyle
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        id: path
+        fillColor: "transparent"
+        strokeWidth: 1.5
+
+        PathMove { x: root.width / 2; y: root.height / 2 - root.gap }
+        PathLine { x: root.width / 2; y: root.height / 2 - root.gap - root.armLength }
+
+        PathMove { x: root.width / 2 + root.gap; y: root.height / 2 }
+        PathLine { x: root.width / 2 + root.gap + root.armLength; y: root.height / 2 }
+
+        PathMove { x: root.width / 2; y: root.height / 2 + root.gap }
+        PathLine { x: root.width / 2; y: root.height / 2 + root.gap + root.armLength }
+
+        PathMove { x: root.width / 2 - root.gap; y: root.height / 2 }
+        PathLine { x: root.width / 2 - root.gap - root.armLength; y: root.height / 2 }
+    }
+}

--- a/src/awen/shapes/ShapeRing.qml
+++ b/src/awen/shapes/ShapeRing.qml
@@ -1,0 +1,57 @@
+import QtQuick
+import QtQuick.Shapes
+import "bearing.js" as Bearing
+
+// A stroked circle with a fixed arc-length gap — the range-ring primitive.
+// The gap stays a constant on-screen size at any radius; place a label on
+// gapCenter and suppress ticks with inGap().
+Shape {
+    id: root
+
+    // Ring radius; defaults to the largest circle that keeps the stroke inside
+    // the item's bounds.
+    property real radius: Math.min(width, height) / 2 - strokeWidth / 2
+
+    // Arc length removed from the circle, in pixels; 0 draws a closed ring.
+    property real gapLength: 0
+
+    // Bearing of the gap's centre, degrees clockwise from up.
+    property real gapAngle: 0
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+    property alias capStyle: path.capStyle
+
+    // Half the gap's angular width in degrees, clamped to a half turn.
+    readonly property real gapHalfAngle: radius > 0 ? Math.min(gapLength / radius / 2, Math.PI) * 180 / Math.PI : 0
+
+    // The gap's centre on the ring — the label anchor.
+    readonly property point gapCenter: pointAt(gapAngle, radius)
+
+    // Whether a bearing falls inside the gap; wraparound-safe.
+    function inGap(angleDeg: real): bool {
+        return Bearing.distanceDeg(angleDeg, gapAngle) < gapHalfAngle;
+    }
+
+    // The point at bearing angleDeg and distance r from the item's centre.
+    function pointAt(angleDeg: real, r: real): point {
+        return Bearing.point(width / 2, height / 2, angleDeg, r);
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        id: path
+        fillColor: "transparent"
+        capStyle: ShapePath.RoundCap
+
+        PathAngleArc {
+            centerX: root.width / 2
+            centerY: root.height / 2
+            radiusX: root.radius
+            radiusY: root.radius
+            startAngle: root.gapAngle + root.gapHalfAngle - 90
+            sweepAngle: 360 - 2 * root.gapHalfAngle
+        }
+    }
+}

--- a/src/awen/shapes/ShapeSector.qml
+++ b/src/awen/shapes/ShapeSector.qml
@@ -1,0 +1,57 @@
+import QtQuick
+import QtQuick.Shapes
+import "bearing.js" as Bearing
+
+// A filled pie wedge from the item's centre — radar cones and beam sweeps.
+// Specified boresight-first: angleAt is the wedge's centre bearing and
+// angleSpan its total width.
+Shape {
+    id: root
+
+    // Wedge radius; defaults to the largest circle that keeps the stroke
+    // inside the item's bounds.
+    property real radius: Math.min(width, height) / 2 - strokeWidth / 2
+
+    // Bearing of the wedge's centre, degrees clockwise from up.
+    property real angleAt: 0
+
+    // Total angular width of the wedge, in degrees.
+    property real angleSpan: 60
+
+    property color fillColor: "white"
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+
+    // The point at bearing angleDeg and distance r from the item's centre.
+    function pointAt(angleDeg: real, r: real): point {
+        return Bearing.point(width / 2, height / 2, angleDeg, r);
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        id: path
+        fillColor: root.fillColor
+        strokeColor: "transparent"
+        startX: root.width / 2
+        startY: root.height / 2
+
+        // moveToStart off, so the path line-connects the centre to the arc's
+        // start instead of opening a new subpath.
+        PathAngleArc {
+            moveToStart: false
+            centerX: root.width / 2
+            centerY: root.height / 2
+            radiusX: root.radius
+            radiusY: root.radius
+            startAngle: root.angleAt - root.angleSpan / 2 - 90
+            sweepAngle: root.angleSpan
+        }
+
+        PathLine {
+            x: root.width / 2
+            y: root.height / 2
+        }
+    }
+}

--- a/src/awen/shapes/ShapeSparkline.qml
+++ b/src/awen/shapes/ShapeSparkline.qml
@@ -1,0 +1,108 @@
+import QtQuick
+import QtQuick.Shapes
+
+// A compact time-series: a stroked trace over an optional area fill, with an
+// optional horizontal reference line. Values map left to right, oldest first;
+// the vertical scale pins to maxValue or autoscales over the data with the
+// reference value as a floor.
+Shape {
+    id: root
+
+    // The series, oldest first.
+    property list<real> values
+
+    // Fixed scale top; 0 autoscales from the data and referenceValue.
+    property real maxValue: 0
+
+    // Autoscale margin above the peak.
+    property real headroom: 1.15
+
+    // Height of the reference line; 0 draws none. Also the autoscale floor.
+    property real referenceValue: 0
+
+    property color strokeColor: "white"
+    property real strokeWidth: 1.5
+    property color fillColor: "transparent"
+    property color referenceColor: "#808080"
+
+    // The resolved scale top: maxValue when pinned, else the larger of the
+    // data peak and the reference floor, with headroom.
+    readonly property real scaleMax: {
+        if (maxValue > 0)
+            return maxValue;
+        let peak = referenceValue;
+        for (let i = 0; i < values.length; ++i)
+            peak = Math.max(peak, values[i]);
+        return peak > 0 ? peak * headroom : 1;
+    }
+
+    // Whether the reference line lands inside the scale.
+    readonly property bool referenceVisible: referenceValue > 0 && referenceValue < scaleMax
+
+    // The y for a value under the current scale — for app-side markers.
+    function yFor(v: real): real {
+        return height - v / scaleMax * height;
+    }
+
+    // The trace in item-space pixels.
+    readonly property list<point> tracePolyline: {
+        const n = values.length;
+        if (n === 0)
+            return [];
+        const out = [];
+        const dx = n > 1 ? width / (n - 1) : 0;
+        for (let i = 0; i < n; ++i)
+            out.push(Qt.point(i * dx, yFor(values[i])));
+        return out;
+    }
+
+    // The trace closed down to the baseline, for the area fill.
+    readonly property list<point> areaPolyline: {
+        const n = values.length;
+        if (n < 2)
+            return [];
+        const out = [];
+        const dx = width / (n - 1);
+        for (let i = 0; i < n; ++i)
+            out.push(Qt.point(i * dx, yFor(values[i])));
+        out.push(Qt.point(width, height));
+        out.push(Qt.point(0, height));
+        out.push(out[0]);
+        return out;
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        fillColor: root.fillColor
+        strokeColor: "transparent"
+
+        PathPolyline {
+            path: root.areaPolyline
+        }
+    }
+
+    ShapePath {
+        fillColor: "transparent"
+        strokeColor: root.strokeColor
+        strokeWidth: root.strokeWidth
+        joinStyle: ShapePath.RoundJoin
+
+        PathPolyline {
+            path: root.tracePolyline
+        }
+    }
+
+    ShapePath {
+        fillColor: "transparent"
+        strokeColor: root.referenceVisible ? root.referenceColor : "transparent"
+        strokeWidth: 1
+        startX: 0
+        startY: root.yFor(root.referenceValue)
+
+        PathLine {
+            x: root.width
+            y: root.yFor(root.referenceValue)
+        }
+    }
+}

--- a/src/awen/shapes/ShapeTicks.qml
+++ b/src/awen/shapes/ShapeTicks.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import QtQuick.Shapes
+import "bearing.js" as Bearing
+
+// Radial ticks around a circle, drawn inward from radius every stepAngle
+// degrees. angleOffset rotates the assembly (heading-up displays); ticks whose
+// on-screen bearing falls inside the gap window are suppressed — bind gapAngle
+// and gapHalfAngle from a ShapeRing's readouts.
+Shape {
+    id: root
+
+    // Angular spacing between ticks, in degrees.
+    property real stepAngle: 30
+
+    // Screen rotation added to every tick bearing, in degrees.
+    property real angleOffset: 0
+
+    // Radius of the ticks' outer end; defaults to the largest circle that
+    // keeps the stroke inside the item's bounds.
+    property real radius: Math.min(width, height) / 2 - strokeWidth / 2
+
+    // Tick length, drawn inward from radius.
+    property real length: 14
+
+    // The suppression window's centre bearing and half-width, in screen
+    // degrees; a zero half-width suppresses nothing.
+    property real gapAngle: 0
+    property real gapHalfAngle: 0
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+    property alias capStyle: path.capStyle
+
+    // The visible ticks' fixed bearings (before angleOffset), gap-suppressed
+    // by their on-screen position.
+    readonly property list<real> tickAngles: {
+        const out = [];
+        if (stepAngle <= 0)
+            return out;
+        for (let a = 0; a < 360 - 1e-9; a += stepAngle) {
+            if (gapHalfAngle > 0 && Bearing.distanceDeg(a + angleOffset, gapAngle) < gapHalfAngle)
+                continue;
+            out.push(a);
+        }
+        return out;
+    }
+
+    // The on-screen point for a tick bearing at distance r — the label anchor;
+    // applies angleOffset.
+    function tickPoint(bearing: real, r: real): point {
+        return Bearing.point(width / 2, height / 2, bearing + angleOffset, r);
+    }
+
+    // All ticks as one multi-subpath SVG string, rebuilt as a single binding.
+    readonly property string tickPath: {
+        let d = "";
+        const cx = width / 2;
+        const cy = height / 2;
+        for (let i = 0; i < tickAngles.length; ++i) {
+            const a = tickAngles[i] + angleOffset;
+            const outer = Bearing.point(cx, cy, a, radius);
+            const inner = Bearing.point(cx, cy, a, radius - length);
+            d += "M " + outer.x + " " + outer.y + " L " + inner.x + " " + inner.y + " ";
+        }
+        return d;
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        id: path
+        fillColor: "transparent"
+        capStyle: ShapePath.RoundCap
+
+        // PathSvg must stay the sole element of its ShapePath.
+        PathSvg {
+            path: root.tickPath
+        }
+    }
+}

--- a/src/awen/shapes/bearing.js
+++ b/src/awen/shapes/bearing.js
@@ -1,0 +1,19 @@
+// Shared bearing-degree helpers: 0 = up (12 o'clock), positive clockwise.
+.pragma library
+
+// Wraps a bearing into [0, 360).
+function wrapDeg(deg) {
+    return ((deg % 360) + 360) % 360;
+}
+
+// Shortest angular distance between two bearings, in [0, 180].
+function distanceDeg(a, b) {
+    const d = Math.abs(wrapDeg(a) - wrapDeg(b));
+    return Math.min(d, 360 - d);
+}
+
+// The point at bearing angleDeg and distance r from (cx, cy).
+function point(cx, cy, angleDeg, r) {
+    const a = angleDeg * Math.PI / 180;
+    return Qt.point(cx + Math.sin(a) * r, cy - Math.cos(a) * r);
+}

--- a/src/awen/shapes/test/.clang-tidy
+++ b/src/awen/shapes/test/.clang-tidy
@@ -1,0 +1,10 @@
+---
+InheritParentConfig: true
+# Relax checks the gtest macros inherently trip (non-const globals, literal
+# assertion values, optional access guarded behind ASSERT_TRUE).
+Checks: "-cert-err58-cpp,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-magic-numbers,
+  -bugprone-unchecked-optional-access"

--- a/src/awen/shapes/test/CMakeLists.txt
+++ b/src/awen/shapes/test/CMakeLists.txt
@@ -1,0 +1,30 @@
+find_package(GTest CONFIG REQUIRED)
+
+add_executable(awen-shapes-test
+    main.cpp
+    ShapeArc.test.cpp
+    ShapeGauge.test.cpp
+    ShapeLink.test.cpp
+    ShapePolygon.test.cpp
+    ShapeRing.test.cpp
+    ShapeSparkline.test.cpp
+    ShapeTicks.test.cpp
+)
+
+# The tests import awen.shapes through the QML engine, so the module is a
+# runtime dependency (via the import path below), not a link dependency.
+target_compile_definitions(awen-shapes-test
+    PRIVATE
+        AWEN_QML_IMPORT_DIR="${QT_QML_OUTPUT_DIRECTORY}"
+)
+add_dependencies(awen-shapes-test awen-shapes)
+
+target_link_libraries(awen-shapes-test
+    PRIVATE
+        GTest::gtest
+        Qt6::Gui
+        Qt6::Qml
+)
+
+include(GoogleTest)
+gtest_discover_tests(awen-shapes-test)

--- a/src/awen/shapes/test/Harness.h
+++ b/src/awen/shapes/test/Harness.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <memory>
+
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+/// @brief Instantiates an inline QML harness; the awen.shapes import resolves
+/// via QML_IMPORT_PATH, set once in main(). Fails the running test on
+/// component errors.
+inline auto load(QQmlEngine& engine, const char* qml) -> std::unique_ptr<QObject>
+{
+    auto component = QQmlComponent{&engine};
+    component.setData(qml, QUrl{QStringLiteral("qrc:/awen-shapes-test/harness.qml")});
+
+    auto object = std::unique_ptr<QObject>{component.create()};
+    if (object == nullptr)
+    {
+        ADD_FAILURE() << component.errorString().toStdString();
+    }
+    return object;
+}

--- a/src/awen/shapes/test/ShapeArc.test.cpp
+++ b/src/awen/shapes/test/ShapeArc.test.cpp
@@ -13,15 +13,7 @@ namespace
     // Every type the module ships; the loop below proves each one resolves and
     // instantiates from a bare import.
     constexpr auto Components = std::array{
-        "ShapeArc",
-        "ShapeGauge",
-        "ShapeLink",
-        "ShapePolygon",
-        "ShapeReticle",
-        "ShapeRing",
-        "ShapeSector",
-        "ShapeSparkline",
-        "ShapeTicks",
+        "ShapeArc", "ShapeGauge", "ShapeLink", "ShapePolygon", "ShapeReticle", "ShapeRing", "ShapeSector", "ShapeSparkline", "ShapeTicks",
     };
 }
 
@@ -51,9 +43,7 @@ TEST(Shapes, EveryComponentInstantiates)
     auto engine = QQmlEngine{};
     for (const auto* name : Components)
     {
-        const auto qml = QStringLiteral("import awen.shapes\n%1 { width: 100; height: 100 }")
-                             .arg(QLatin1String{name})
-                             .toUtf8();
+        const auto qml = QStringLiteral("import awen.shapes\n%1 { width: 100; height: 100 }").arg(QLatin1String{name}).toUtf8();
         const auto item = load(engine, qml.constData());
         EXPECT_NE(item, nullptr) << name;
     }

--- a/src/awen/shapes/test/ShapeArc.test.cpp
+++ b/src/awen/shapes/test/ShapeArc.test.cpp
@@ -1,0 +1,102 @@
+#include <array>
+
+#include <QPointF>
+#include <QQmlEngine>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+namespace
+{
+    // Every type the module ships; the loop below proves each one resolves and
+    // instantiates from a bare import.
+    constexpr auto Components = std::array{
+        "ShapeArc",
+        "ShapeGauge",
+        "ShapeLink",
+        "ShapePolygon",
+        "ShapeReticle",
+        "ShapeRing",
+        "ShapeSector",
+        "ShapeSparkline",
+        "ShapeTicks",
+    };
+}
+
+TEST(Shapes, SectorDefaultsToBoresightWedge)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSector {
+    width: 200
+    height: 200
+    readonly property point up: pointAt(0, 50)
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("angleAt").toDouble(), 0.0);
+    EXPECT_DOUBLE_EQ(item->property("angleSpan").toDouble(), 60.0);
+
+    const auto up = item->property("up").toPointF();
+    EXPECT_NEAR(up.x(), 100.0, 1e-9);
+    EXPECT_NEAR(up.y(), 50.0, 1e-9);
+}
+
+TEST(Shapes, EveryComponentInstantiates)
+{
+    auto engine = QQmlEngine{};
+    for (const auto* name : Components)
+    {
+        const auto qml = QStringLiteral("import awen.shapes\n%1 { width: 100; height: 100 }")
+                             .arg(QLatin1String{name})
+                             .toUtf8();
+        const auto item = load(engine, qml.constData());
+        EXPECT_NE(item, nullptr) << name;
+    }
+}
+
+TEST(ShapeArc, DefaultsToFullCircleInsideBounds)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeArc { width: 200; height: 200; strokeWidth: 4 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("radius").toDouble(), 98.0);
+    EXPECT_DOUBLE_EQ(item->property("angleStart").toDouble(), 0.0);
+    EXPECT_DOUBLE_EQ(item->property("angleSweep").toDouble(), 360.0);
+}
+
+TEST(ShapeArc, PointAtMapsBearingsClockwiseFromUp)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeArc {
+    width: 200
+    height: 200
+    readonly property point up: pointAt(0, 50)
+    readonly property point east: pointAt(90, 50)
+    readonly property point down: pointAt(180, 50)
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto up = item->property("up").toPointF();
+    EXPECT_NEAR(up.x(), 100.0, 1e-9);
+    EXPECT_NEAR(up.y(), 50.0, 1e-9);
+
+    const auto east = item->property("east").toPointF();
+    EXPECT_NEAR(east.x(), 150.0, 1e-9);
+    EXPECT_NEAR(east.y(), 100.0, 1e-9);
+
+    const auto down = item->property("down").toPointF();
+    EXPECT_NEAR(down.x(), 100.0, 1e-9);
+    EXPECT_NEAR(down.y(), 150.0, 1e-9);
+}

--- a/src/awen/shapes/test/ShapeGauge.test.cpp
+++ b/src/awen/shapes/test/ShapeGauge.test.cpp
@@ -1,0 +1,70 @@
+#include <QPointF>
+#include <QQmlEngine>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+TEST(ShapeGauge, DefaultsToBottomOpenGauge)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeGauge { width: 200; height: 200 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("angleStart").toDouble(), 225.0);
+    EXPECT_DOUBLE_EQ(item->property("angleSweep").toDouble(), 270.0);
+    EXPECT_DOUBLE_EQ(item->property("fillSweep").toDouble(), 0.0);
+}
+
+TEST(ShapeGauge, FillSweepClampsValue)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeGauge { width: 200; height: 200; value: -1 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("fillSweep").toDouble(), 0.0);
+
+    item->setProperty("value", 2.0);
+    EXPECT_DOUBLE_EQ(item->property("fillSweep").toDouble(), 270.0);
+
+    item->setProperty("value", 0.5);
+    EXPECT_DOUBLE_EQ(item->property("fillSweep").toDouble(), 135.0);
+}
+
+TEST(ShapeGauge, FillHidesAtZeroValue)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeGauge { width: 200; height: 200 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // A zero-length arc with a round cap would paint a stray dot, so the fill
+    // reports invisible at rest.
+    EXPECT_FALSE(item->property("fillVisible").toBool());
+
+    item->setProperty("value", 0.1);
+    EXPECT_TRUE(item->property("fillVisible").toBool());
+}
+
+TEST(ShapeGauge, FillEndTracksValue)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeGauge { width: 200; height: 200; radius: 100; value: 0.5 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // 225 + 135 wraps to bearing 0 — straight up from the centre.
+    const auto end = item->property("fillEnd").toPointF();
+    EXPECT_NEAR(end.x(), 100.0, 1e-9);
+    EXPECT_NEAR(end.y(), 0.0, 1e-9);
+}

--- a/src/awen/shapes/test/ShapeLink.test.cpp
+++ b/src/awen/shapes/test/ShapeLink.test.cpp
@@ -1,0 +1,106 @@
+#include <QList>
+#include <QPointF>
+#include <QQmlEngine>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+TEST(ShapeLink, DefaultControlsGiveHorizontalTangents)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeLink { from: Qt.point(0, 0); to: Qt.point(100, 40) }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_EQ(item->property("fromControl").toPointF(), QPointF(45, 0));
+    EXPECT_EQ(item->property("toControl").toPointF(), QPointF(55, 40));
+}
+
+TEST(ShapeLink, ControlOverrideSticks)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeLink { from: Qt.point(0, 0); to: Qt.point(100, 40); toControl: Qt.point(1, 2) }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_EQ(item->property("toControl").toPointF(), QPointF(1, 2));
+}
+
+TEST(ShapeLink, ArrowheadAlignsWithArrivalTangent)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeLink { from: Qt.point(0, 0); to: Qt.point(100, 40); arrowhead: true }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // Arrival runs +x from toControl (55, 40), so the chevron opens backward
+    // from the tip with arrowSize depth and two-thirds half-width.
+    const auto chevron = item->property("arrowPolyline").value<QList<QPointF>>();
+    ASSERT_EQ(chevron.size(), 3);
+    EXPECT_NEAR(chevron[0].x(), 94.0, 1e-9);
+    EXPECT_NEAR(chevron[0].y(), 44.0, 1e-9);
+    EXPECT_EQ(chevron[1], QPointF(100, 40));
+    EXPECT_NEAR(chevron[2].x(), 94.0, 1e-9);
+    EXPECT_NEAR(chevron[2].y(), 36.0, 1e-9);
+}
+
+TEST(ShapeLink, NoArrowheadNoChevron)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeLink { from: Qt.point(0, 0); to: Qt.point(100, 40) }
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto chevron = item->property("arrowPolyline");
+    ASSERT_TRUE(chevron.isValid());
+    EXPECT_TRUE(chevron.value<QList<QPointF>>().isEmpty());
+}
+
+TEST(ShapeLink, VerticalLinkKeepsItsArrowhead)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeLink { from: Qt.point(50, 0); to: Qt.point(50, 100); arrowhead: true }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The default controls collapse onto the endpoints here, so the chevron
+    // falls back to the chord direction — straight down.
+    const auto chevron = item->property("arrowPolyline").value<QList<QPointF>>();
+    ASSERT_EQ(chevron.size(), 3);
+    EXPECT_NEAR(chevron[0].x(), 46.0, 1e-9);
+    EXPECT_NEAR(chevron[0].y(), 94.0, 1e-9);
+    EXPECT_EQ(chevron[1], QPointF(50, 100));
+    EXPECT_NEAR(chevron[2].x(), 54.0, 1e-9);
+    EXPECT_NEAR(chevron[2].y(), 94.0, 1e-9);
+}
+
+TEST(ShapeLink, DegenerateLinkDrawsNoChevron)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeLink { from: Qt.point(50, 50); to: Qt.point(50, 50); arrowhead: true }
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto chevron = item->property("arrowPolyline");
+    ASSERT_TRUE(chevron.isValid());
+    EXPECT_TRUE(chevron.value<QList<QPointF>>().isEmpty());
+}

--- a/src/awen/shapes/test/ShapePolygon.test.cpp
+++ b/src/awen/shapes/test/ShapePolygon.test.cpp
@@ -1,0 +1,81 @@
+#include <QList>
+#include <QPointF>
+#include <QQmlEngine>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+namespace
+{
+    constexpr auto Triangle = R"(
+import QtQuick
+import awen.shapes
+ShapePolygon {
+    width: 100
+    height: 50
+    points: [Qt.point(0, -0.5), Qt.point(0.5, 0.5), Qt.point(-0.5, 0.5)]
+}
+)";
+}
+
+TEST(ShapePolygon, PolylineClosesTheOutline)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, Triangle);
+    ASSERT_NE(item, nullptr);
+
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_EQ(polyline.size(), 4);
+    EXPECT_EQ(polyline.first(), polyline.last());
+}
+
+TEST(ShapePolygon, UnitBoxScalesUniformlyAboutTheCentre)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, Triangle);
+    ASSERT_NE(item, nullptr);
+
+    // The 100x50 item scales by its short side, so x spans 25..75, not 0..100.
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_EQ(polyline.size(), 4);
+    EXPECT_EQ(polyline[0], QPointF(50, 0));
+    EXPECT_EQ(polyline[1], QPointF(75, 50));
+    EXPECT_EQ(polyline[2], QPointF(25, 50));
+}
+
+TEST(ShapePolygon, PixelModePassesPointsThrough)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapePolygon {
+    width: 100
+    height: 50
+    unitScale: false
+    points: [Qt.point(10, 20), Qt.point(30, 40)]
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_EQ(polyline.size(), 3);
+    EXPECT_EQ(polyline[0], QPointF(10, 20));
+    EXPECT_EQ(polyline[1], QPointF(30, 40));
+    EXPECT_EQ(polyline[2], QPointF(10, 20));
+}
+
+TEST(ShapePolygon, EmptyPointsMakeAnEmptyPolyline)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapePolygon { width: 100; height: 50 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto polyline = item->property("polyline");
+    ASSERT_TRUE(polyline.isValid());
+    EXPECT_TRUE(polyline.value<QList<QPointF>>().isEmpty());
+}

--- a/src/awen/shapes/test/ShapeRing.test.cpp
+++ b/src/awen/shapes/test/ShapeRing.test.cpp
@@ -1,0 +1,117 @@
+#include <QPointF>
+#include <QQmlEngine>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+TEST(ShapeRing, GapHalfAngleTracksFixedArcLength)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeRing { width: 200; height: 200; radius: 100; gapLength: 50 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // 50 px of arc on a 100 px ring is 0.25 rad either side of the gap centre.
+    EXPECT_NEAR(item->property("gapHalfAngle").toDouble(), 14.3239, 1e-3);
+}
+
+TEST(ShapeRing, ClampsOversizedGapToHalfTurn)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeRing { width: 200; height: 200; radius: 10; gapLength: 10000 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("gapHalfAngle").toDouble(), 180.0);
+}
+
+TEST(ShapeRing, GapCenterSitsOnTheRing)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeRing { width: 200; height: 200; radius: 100; gapLength: 50 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    auto center = item->property("gapCenter").toPointF();
+    EXPECT_NEAR(center.x(), 100.0, 1e-9);
+    EXPECT_NEAR(center.y(), 0.0, 1e-9);
+
+    item->setProperty("gapAngle", 90.0);
+    center = item->property("gapCenter").toPointF();
+    EXPECT_NEAR(center.x(), 200.0, 1e-9);
+    EXPECT_NEAR(center.y(), 100.0, 1e-9);
+}
+
+TEST(ShapeRing, InGapWrapsAroundNorth)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeRing {
+    width: 200
+    height: 200
+    radius: 100
+    gapLength: 50
+    readonly property bool nearWrap: inGap(350)
+    readonly property bool farWrap: inGap(340)
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The gap centred on 0 spans about ±14.32°, so 350 is inside and 340 out.
+    EXPECT_TRUE(item->property("nearWrap").toBool());
+    EXPECT_FALSE(item->property("farWrap").toBool());
+}
+
+TEST(ShapeRing, GapEdgeCountsAsOutside)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeRing {
+    width: 200
+    height: 200
+    radius: 100
+    gapLength: 50
+    readonly property bool onEdge: inGap(gapHalfAngle)
+    readonly property bool justInside: inGap(gapHalfAngle - 0.01)
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The comparison is strict, so the exact edge bearing stays visible.
+    EXPECT_FALSE(item->property("onEdge").toBool());
+    EXPECT_TRUE(item->property("justInside").toBool());
+}
+
+TEST(ShapeRing, ZeroRadiusHasNoGap)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeRing { width: 0; height: 0; gapLength: 50; strokeWidth: 0 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("gapHalfAngle").toDouble(), 0.0);
+}
+
+TEST(ShapeRing, DefaultRadiusKeepsStrokeInsideBounds)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeRing { width: 200; height: 200; strokeWidth: 4 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("radius").toDouble(), 98.0);
+    EXPECT_DOUBLE_EQ(item->property("gapHalfAngle").toDouble(), 0.0);
+}

--- a/src/awen/shapes/test/ShapeSparkline.test.cpp
+++ b/src/awen/shapes/test/ShapeSparkline.test.cpp
@@ -1,0 +1,155 @@
+#include <QList>
+#include <QPointF>
+#include <QQmlEngine>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+TEST(ShapeSparkline, AutoscaleUsesReferenceFloor)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline { width: 100; height: 100; values: [1, 2, 10]; referenceValue: 16.7 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The peak sits under the floor, so the floor scales: 16.7 * 1.15.
+    EXPECT_NEAR(item->property("scaleMax").toDouble(), 19.205, 1e-6);
+    EXPECT_TRUE(item->property("referenceVisible").toBool());
+}
+
+TEST(ShapeSparkline, AutoscaleTracksThePeak)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline { width: 100; height: 100; values: [1, 50]; referenceValue: 16.7 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_NEAR(item->property("scaleMax").toDouble(), 57.5, 1e-6);
+}
+
+TEST(ShapeSparkline, PinnedScaleWins)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline { width: 100; height: 100; values: [1, 50]; maxValue: 30 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("scaleMax").toDouble(), 30.0);
+}
+
+TEST(ShapeSparkline, YForMapsLinearly)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline {
+    width: 100
+    height: 100
+    maxValue: 20
+    readonly property real atZero: yFor(0)
+    readonly property real atMax: yFor(20)
+    readonly property real atMiddle: yFor(10)
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_DOUBLE_EQ(item->property("atZero").toDouble(), 100.0);
+    EXPECT_DOUBLE_EQ(item->property("atMax").toDouble(), 0.0);
+    EXPECT_DOUBLE_EQ(item->property("atMiddle").toDouble(), 50.0);
+}
+
+TEST(ShapeSparkline, EmptySeriesFallsBackToUnitScale)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline {
+    width: 100
+    height: 100
+    readonly property real baseY: yFor(0)
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The fallback keeps yFor's divisor nonzero with no data and no reference.
+    EXPECT_DOUBLE_EQ(item->property("scaleMax").toDouble(), 1.0);
+    EXPECT_DOUBLE_EQ(item->property("baseY").toDouble(), 100.0);
+
+    const auto trace = item->property("tracePolyline");
+    ASSERT_TRUE(trace.isValid());
+    EXPECT_TRUE(trace.value<QList<QPointF>>().isEmpty());
+    const auto area = item->property("areaPolyline");
+    ASSERT_TRUE(area.isValid());
+    EXPECT_TRUE(area.value<QList<QPointF>>().isEmpty());
+}
+
+TEST(ShapeSparkline, TraceSpansTheWidthOldestFirst)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline { width: 100; height: 100; maxValue: 10; values: [0, 10, 5] }
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto trace = item->property("tracePolyline").value<QList<QPointF>>();
+    ASSERT_EQ(trace.size(), 3);
+    EXPECT_EQ(trace[0], QPointF(0, 100));
+    EXPECT_EQ(trace[1], QPointF(50, 0));
+    EXPECT_EQ(trace[2], QPointF(100, 50));
+}
+
+TEST(ShapeSparkline, AreaClosesToTheBaseline)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline { width: 100; height: 100; maxValue: 10; values: [0, 10, 5] }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The trace plus bottom-right, bottom-left and the closing first point.
+    const auto area = item->property("areaPolyline").value<QList<QPointF>>();
+    ASSERT_EQ(area.size(), 6);
+    EXPECT_EQ(area[3], QPointF(100, 100));
+    EXPECT_EQ(area[4], QPointF(0, 100));
+    EXPECT_EQ(area[5], area[0]);
+}
+
+TEST(ShapeSparkline, SinglePointHasNoArea)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline { width: 100; height: 100; maxValue: 10; values: [5] }
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto trace = item->property("tracePolyline").value<QList<QPointF>>();
+    ASSERT_EQ(trace.size(), 1);
+    EXPECT_EQ(trace[0], QPointF(0, 50));
+    EXPECT_TRUE(item->property("areaPolyline").value<QList<QPointF>>().isEmpty());
+}
+
+TEST(ShapeSparkline, ReferenceHidesOffScale)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeSparkline { width: 100; height: 100; maxValue: 10; referenceValue: 16.7 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_FALSE(item->property("referenceVisible").toBool());
+
+    // Releasing the pin autoscales above the reference, revealing it again.
+    item->setProperty("maxValue", 0.0);
+    EXPECT_TRUE(item->property("referenceVisible").toBool());
+}

--- a/src/awen/shapes/test/ShapeTicks.test.cpp
+++ b/src/awen/shapes/test/ShapeTicks.test.cpp
@@ -1,0 +1,111 @@
+#include <QList>
+#include <QPointF>
+#include <QQmlEngine>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+TEST(ShapeTicks, TwelveTicksByDefault)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeTicks { width: 200; height: 200 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto angles = item->property("tickAngles").value<QList<double>>();
+    ASSERT_EQ(angles.size(), 12);
+    EXPECT_EQ(angles.first(), 0.0);
+    EXPECT_EQ(angles.last(), 330.0);
+}
+
+TEST(ShapeTicks, SuppressesTicksInsideTheGap)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeTicks { width: 200; height: 200; gapAngle: 25; gapHalfAngle: 14.3239 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The gap spans (10.68, 39.32), so only the 30° tick vanishes.
+    const auto angles = item->property("tickAngles").value<QList<double>>();
+    EXPECT_EQ(angles.size(), 11);
+    EXPECT_TRUE(angles.contains(0.0));
+    EXPECT_FALSE(angles.contains(30.0));
+}
+
+TEST(ShapeTicks, SuppressionFollowsTheOnScreenBearing)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeTicks {
+    width: 200
+    height: 200
+    angleOffset: 90
+    gapAngle: 25
+    gapHalfAngle: 14.3239
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // With the assembly rotated 90°, the fixed 300° tick lands in the gap.
+    const auto angles = item->property("tickAngles").value<QList<double>>();
+    EXPECT_EQ(angles.size(), 11);
+    EXPECT_TRUE(angles.contains(30.0));
+    EXPECT_FALSE(angles.contains(300.0));
+}
+
+TEST(ShapeTicks, NonPositiveStepMakesNoTicks)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeTicks { width: 200; height: 200; stepAngle: 0 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto angles = item->property("tickAngles");
+    ASSERT_TRUE(angles.isValid());
+    EXPECT_TRUE(angles.value<QList<double>>().isEmpty());
+    EXPECT_TRUE(item->property("tickPath").toString().isEmpty());
+}
+
+TEST(ShapeTicks, PathDrawsOneSubpathPerTick)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeTicks { width: 200; height: 200 }
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_EQ(item->property("tickPath").toString().count(QLatin1Char('M')), 12);
+}
+
+TEST(ShapeTicks, OffsetMovesTickPointsNotBearings)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import awen.shapes
+ShapeTicks {
+    width: 200
+    height: 200
+    angleOffset: 90
+    readonly property point north: tickPoint(0, 100)
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // The bearing list ignores the rotation; the drawn point applies it.
+    const auto angles = item->property("tickAngles").value<QList<double>>();
+    EXPECT_EQ(angles.size(), 12);
+    EXPECT_TRUE(angles.contains(0.0));
+
+    const auto north = item->property("north").toPointF();
+    EXPECT_NEAR(north.x(), 200.0, 1e-9);
+    EXPECT_NEAR(north.y(), 100.0, 1e-9);
+}

--- a/src/awen/shapes/test/main.cpp
+++ b/src/awen/shapes/test/main.cpp
@@ -1,0 +1,22 @@
+#include <QGuiApplication>
+
+#include <gtest/gtest.h>
+
+// gtest_discover_tests executes this binary at build time on headless CI, so
+// default to the minimal platform before QGuiApplication picks a real one.
+auto main(int argc, char** argv) -> int
+{
+    // Point every test's QQmlEngine at the in-project modules under the build
+    // output tree: each engine reads QML_IMPORT_PATH at construction, so this
+    // one line resolves `import awen.shapes` for all tests without per-test setup.
+    qputenv("QML_IMPORT_PATH", AWEN_QML_IMPORT_DIR);
+
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
+    {
+        qputenv("QT_QPA_PLATFORM", "minimal");
+    }
+
+    auto app = QGuiApplication{argc, argv};
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Nine pure-QML instrument primitives on QtQuick.Shapes, in place ahead of the briardart (Flutter briarthorn) port: ShapeArc, ShapeRing (fixed-pixel gap with gapCenter/inGap readouts), ShapeGauge (track+fill, covers the 270-degree gauge and health arcs), ShapePolygon, ShapeSector, ShapeTicks, ShapeReticle, ShapeSparkline, and ShapeLink (dashed/glow/arrowhead cubic). Angles are bearing degrees (0 = up, clockwise); labels stay app-side, anchored on exposed geometry readouts; CurveRenderer is the default renderer.

- `DEPENDENCIES QtQuick.Shapes` makes the configure-time import scan link the Shapes plugin into the static wasm build (no app QML imports it directly).
- Both Canvas usages are retired: the awen sample's arc becomes a ShapeRing + label + animated ShapeGauge, and briarthorn's player triangle becomes a ShapePolygon.
- The awen sample gains a StressScope page (toggle with S): a synthetic heading-up scope with pooled contacts, trails, sweeping wedges and re-tessellating detonation arcs, with live frame stats.
- Tests follow the awen-entity gtest + QQmlEngine harness; the module suite pins the gap math, clamping, polyline closure, tick suppression, sparkline scaling and link control/arrowhead geometry.

## Verification

- windows-msvc-debug and windows-msvc-release: build clean, 58/58 tests pass (including both app smoke tests, so the Release loadFromModule path resolves the new module).
- web-release: builds; the import scan resolves QtQuick.Shapes -> Qt6::qmlshapesplugin and the linked briarthorn.wasm contains the Shapes code.
- Eyeballed on-screen: ring gap + label anchor and gauge track/fill render correctly in the sample app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)