### PR TITLE
Add a shared ViewSituation scope with a corner minimap

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -35,6 +35,8 @@ awen_add_executable(${PROJECT_NAME}
         qml/ui/Joystick.qml
         qml/ui/RangeRing.qml
         qml/ui/Symbol.qml
+        qml/ui/ViewSituation.qml
+        qml/ui/ViewSituationAttack.qml
         qml/ui/ViewTracks.qml
         ${QML_SINGLETONS}
     AWEN_MODULES

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -4,7 +4,6 @@ import awen.command
 import awen.entity
 import awen.gamepad
 import awen.input
-import awen.shapes
 import "commands"
 import "model"
 import "scenarios"
@@ -42,44 +41,15 @@ Window {
         axisThrottle.invoke(0);
     }
 
-    // Scope geometry: the centre dropped toward the bottom so the forward
-    // sector gets the space. The view pins ownship here.
-    readonly property real scopeCenterX: width / 2
-    readonly property real scopeCenterY: height * 0.875
-
-    // How world metres project onto the scope: the outer ring's edge sits
-    // 0.8 shortSide from the centre and spans the projection's range.
-    readonly property real pxPerMeter: projection.pixelsPerMeter(Math.min(width, height) * 0.8)
-
     // Everything the simulation integrates: the player's craft plus the
     // current scenario's entities.
     readonly property list<Entity> entities: [game.ownship, ...scenario.entities]
 
+    // The one display projection both scopes share: ranging in or out moves the
+    // centre attack scope and the corner minimap together.
     RangeProjection {
         id: projection
         step: 2 // the 40 / 80 km picture
-    }
-
-    RangeRing {
-        anchors.fill: parent
-        centerY: root.scopeCenterY
-        radius: projection.innerRange * root.pxPerMeter
-        strokeWidth: 2
-        gapLength: parent.width * (1 / 32)
-        gapAngle: 20
-        range: projection.innerRangeKm
-        enableTicks: false
-    }
-
-    RangeRing {
-        anchors.fill: parent
-        centerY: root.scopeCenterY
-        radius: projection.range * root.pxPerMeter
-        strokeWidth: 2
-        gapLength: parent.width * (1 / 32)
-        gapAngle: 20
-        range: projection.rangeKm
-        tickOffset: -game.ownship.heading
     }
 
     Item {
@@ -198,75 +168,15 @@ Window {
             }
         }
 
-        // Ownship's radar volume: a wedge off the nose — always straight up
-        // on this heading-up scope — reaching the sensor's detection range.
-        ShapeSector {
+        // The attack scope: the game's main centre display. Rings, ownship's
+        // radar cone, the heading-up track picture and ownship pinned at the
+        // dropped centre — all composed by ViewSituation on the shared
+        // projection.
+        ViewSituationAttack {
             anchors.fill: parent
-            centerX: root.scopeCenterX
-            centerY: root.scopeCenterY
-            angleAt: 0
-            angleSpan: game.ownship.radarFov
-            radius: game.ownship.sensor * root.pxPerMeter
-            fillColor: Style.theme.gaugeTrack
-        }
-
-        // The track picture: every contact plotted at its azimuth and range,
-        // the whole picture rotated into ownship's heading-up frame.
-        ViewTracks {
-            anchors.fill: parent
-            centerX: root.scopeCenterX
-            centerY: root.scopeCenterY
-            pxPerMeter: root.pxPerMeter
-            viewRotation: -game.ownship.heading
+            projection: projection
+            observer: game.ownship
             tracks: detection.tracks
-        }
-
-        // Ownship, pinned at the scope centre, nose up by construction.
-        Symbol {
-            x: root.scopeCenterX - width / 2
-            y: root.scopeCenterY - height / 2
-            classification: game.ownship.classification
-            side: game.ownship.side
-            showLabel: false
-        }
-
-        // The pulsing ring marking ownship, fixed at the scope centre the
-        // camera pins it to.
-        Rectangle {
-            x: root.scopeCenterX - width / 2
-            y: root.scopeCenterY - height / 2
-            width: 48
-            height: width
-            radius: width / 2
-            color: "transparent"
-            border.color: Style.theme.factionOwnship
-            border.width: 2
-
-            SequentialAnimation on opacity {
-                loops: Animation.Infinite
-                NumberAnimation {
-                    from: 0.4
-                    to: 0.0
-                    duration: 1500
-                    easing.type: Easing.OutQuad
-                }
-
-                PauseAnimation {
-                    duration: 250
-                }
-            }
-            SequentialAnimation on scale {
-                loops: Animation.Infinite
-                NumberAnimation {
-                    from: 0.5
-                    to: 1.8
-                    duration: 1500
-                    easing.type: Easing.OutQuad
-                }
-                PauseAnimation {
-                    duration: 250
-                }
-            }
         }
 
         Text {
@@ -276,29 +186,6 @@ Window {
             text: qsTr("drag the stick, or W to thrust & A/D to turn — arrows, gamepad too")
             color: "#99ffffff"
             font.pixelSize: 14
-        }
-
-        // The build's date-based version, stamped when the package is built.
-        Text {
-            id: versionLabel
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.margins: 16
-            text: "v" + BuildInfo.version
-            color: "#66ffffff"
-            font.pixelSize: 12
-        }
-
-        // Lights up when a controller is connected, so the gamepad path is visible.
-        Text {
-            anchors.right: parent.right
-            anchors.top: versionLabel.bottom
-            anchors.rightMargin: 16
-            anchors.topMargin: 6
-            text: qsTr("controller connected")
-            color: "#66bfff"
-            font.pixelSize: 13
-            visible: scene.padConnected
         }
 
         // The on-screen stick: another source folding into the same axes — its x
@@ -321,6 +208,63 @@ Window {
             onActiveChanged: if (!active) {
                 axisSteer.invoke(0);
                 axisThrottle.invoke(0);
+            }
+        }
+
+        // The top-right corner group: the build version tucked into the corner,
+        // the corner minimap inboard beneath it, and the controller lamp below
+        // that (so a connecting pad never nudges the map). Stacked, not rowed, so
+        // the version keeps the actual corner while the map sits inward. Right
+        // anchors inside a Column are allowed (Column manages only the y axis).
+        Column {
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: 16
+            spacing: 8
+
+            // The build's date-based version, stamped when the package is built.
+            Text {
+                anchors.right: parent.right
+                text: "v" + BuildInfo.version
+                color: "#66ffffff"
+                font.pixelSize: 12
+            }
+
+            // The corner minimap: the same situation display, stripped to a clean
+            // overview. It shares the attack scope's projection, so it ranges with
+            // it. Off-scale contacts pin to the rim and an opaque disc backs the
+            // picture, masking anything outside the view from rendering over the
+            // scope beneath it.
+            ViewSituation {
+                id: minimap
+                width: Math.min(root.width, root.height) * 0.22
+                height: width
+
+                projection: projection
+                observer: game.ownship
+                tracks: detection.tracks
+
+                radiusFraction: 0.45
+                symbolSize: 18
+                backgroundColor: Style.theme.instrumentBackground
+                rimClamp: true
+                closedRings: true
+                showNorth: true
+                showInnerRing: false
+                showTicks: false
+                showRadarCone: true
+                showOwnshipPulse: false
+                showTrackLabels: false
+            }
+
+            // Lights up when a controller is connected, so the gamepad path is
+            // visible. Below the map, so connecting it doesn't shift the map.
+            Text {
+                anchors.right: parent.right
+                text: qsTr("controller connected")
+                color: "#66bfff"
+                font.pixelSize: 13
+                visible: scene.padConnected
             }
         }
     }

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -1,0 +1,207 @@
+import QtQuick
+import awen.shapes
+import "../model"
+import "../themes"
+
+// A tactical situation display: the range rings, ownship's radar cone, the
+// track picture and ownship at the scope centre, composed as one configurable
+// Item. The same component serves the full-size attack scope (see
+// ViewSituationAttack) and the corner minimap — features toggle off and the
+// picture masks to a disc for the compact overview. Both instances share one
+// RangeProjection, so ranging in/out moves them together. Ports briardart's
+// ScopeComponent (render/scope_component.dart), the Flame counterpart of this.
+Item {
+    id: view
+
+    // Shared display projection: the ring spans and the metres-to-pixels scale.
+    property RangeProjection projection
+
+    // The observer at the scope centre: its heading drives the heading-up
+    // rotation, its radar FOV + sensor range the cone, its class + side the
+    // ownship mark.
+    property Entity observer
+
+    // The contact picture, plotted at each track's azimuth and range.
+    property list<Track> tracks
+
+    // Geometry. The outer ring's radius is a fraction of the short side; the
+    // centre drops by verticalShift (and slides by horizontalShift) so the
+    // attack scope can push ownship down and crop the rear off the bottom edge.
+    property real radiusFraction: 0.4
+    property real verticalShift: 0
+    property real horizontalShift: 0
+
+    readonly property real shortSide: Math.min(width, height)
+    readonly property real outerRadius: shortSide * radiusFraction
+    readonly property real centerX: width * (0.5 + horizontalShift)
+    readonly property real centerY: height * (0.5 + verticalShift)
+    readonly property real pxPerMeter: projection ? projection.pixelsPerMeter(outerRadius) : 0
+
+    // Heading-up turns the whole picture so ownship's nose is 12 o'clock; false
+    // leaves it north-up. The rotation the track picture carries.
+    property bool headingUp: true
+    readonly property real viewRotation: headingUp && observer ? -observer.heading : 0
+
+    // Symbol size in px before each classification's own scale.
+    property real symbolSize: 36
+
+    // Feature toggles — the minimap turns most of these off for a clean
+    // overview. closedRings drops the range-label gap for a plain closed ring.
+    property bool showInnerRing: true
+    property bool showTicks: true
+    property bool showRadarCone: true
+    property bool showOwnship: true
+    property bool showOwnshipPulse: true
+    property bool showTrackLabels: true
+    property bool showNorth: false
+    property bool closedRings: false
+
+    // The range-label gap arc length, in px; 0 (closedRings) draws closed rings.
+    readonly property real ringGapLength: closedRings ? 0 : Math.max(28, outerRadius * 0.1)
+
+    // Compact-overview plumbing. rimClamp pins off-scale contacts to the outer
+    // rim; backgroundColor paints an opaque disc behind the picture so it reads
+    // over whatever sits behind it. The disc reaches a symbol past the outer
+    // ring, so a rim-pinned mark can never spill past it — the mask that keeps
+    // objects outside the view from rendering under the minimap (briardart clips
+    // to this same disc, then pins off-scale tracks to its rim).
+    property bool rimClamp: false
+    property color backgroundColor: "transparent"
+    readonly property real discRadius: outerRadius + symbolSize
+
+    // The opaque backing disc (minimap only; transparent by default). A circle
+    // centred on the scope, so the box's corners stay clear.
+    Rectangle {
+        visible: view.backgroundColor.a > 0
+        x: view.centerX - width / 2
+        y: view.centerY - height / 2
+        width: view.discRadius * 2
+        height: width
+        radius: width / 2
+        color: view.backgroundColor
+    }
+
+    // Outer range ring: carries the bearing ticks and its span label, the ticks
+    // offset to keep true bearings on the heading-up scope.
+    RangeRing {
+        anchors.fill: parent
+        centerX: view.centerX
+        centerY: view.centerY
+        radius: view.outerRadius
+        strokeWidth: 2
+        gapLength: view.ringGapLength
+        gapAngle: 20
+        range: view.projection ? view.projection.rangeKm : 0
+        enableTicks: view.showTicks
+        tickOffset: view.viewRotation
+    }
+
+    // Inner ring: half the span, label only.
+    RangeRing {
+        anchors.fill: parent
+        visible: view.showInnerRing
+        centerX: view.centerX
+        centerY: view.centerY
+        radius: view.outerRadius / 2
+        strokeWidth: 2
+        gapLength: view.ringGapLength
+        gapAngle: 20
+        range: view.projection ? view.projection.innerRangeKm : 0
+        enableTicks: false
+    }
+
+    // Ownship's radar volume: a wedge off the nose (straight up, heading-up),
+    // reaching the sensor's detection range, capped at the outer ring.
+    ShapeSector {
+        anchors.fill: parent
+        visible: view.showRadarCone && view.observer
+        centerX: view.centerX
+        centerY: view.centerY
+        angleAt: view.headingUp ? 0 : (view.observer ? view.observer.heading : 0)
+        angleSpan: view.observer ? view.observer.radarFov : 0
+        radius: view.observer ? Math.min(view.observer.sensor * view.pxPerMeter, view.outerRadius) : 0
+        fillColor: Style.theme.gaugeTrack
+    }
+
+    // The track picture: every contact at its azimuth and range, the whole
+    // picture rotated into the heading-up frame; rim-clamped for the minimap.
+    ViewTracks {
+        anchors.fill: parent
+        centerX: view.centerX
+        centerY: view.centerY
+        pxPerMeter: view.pxPerMeter
+        viewRotation: view.viewRotation
+        tracks: view.tracks
+        symbolSize: view.symbolSize
+        showLabels: view.showTrackLabels
+        clampRadius: view.rimClamp ? view.outerRadius : 0
+    }
+
+    // Ownship, pinned at the scope centre; nose up on a heading-up scope.
+    Symbol {
+        visible: view.showOwnship && view.observer
+        x: view.centerX - width / 2
+        y: view.centerY - height / 2
+        symbolSize: view.symbolSize
+        noseAngle: view.headingUp ? 0 : (view.observer ? view.observer.heading : 0)
+        classification: view.observer ? view.observer.classification : Classification.Kind.Unknown
+        side: view.observer ? view.observer.side : Side.Kind.Unknown
+        showLabel: false
+    }
+
+    // North marker: an 'N' seated just outside the rim at the north bearing,
+    // sweeping round the rim as ownship turns (heading-up). The minimap's stand-in
+    // for the suppressed bearing ticks.
+    Text {
+        visible: view.showNorth
+        text: "N"
+        color: Style.theme.textBright
+        font.bold: true
+        font.pixelSize: Math.max(9, view.outerRadius * 0.16)
+
+        // North (true bearing 0) sits at screen angle viewRotation on a
+        // heading-up scope; seat the label a little past the ring.
+        readonly property real northRad: view.viewRotation * Math.PI / 180
+        readonly property real seatRadius: view.outerRadius + font.pixelSize * 0.7
+        x: view.centerX + Math.sin(northRad) * seatRadius - width / 2
+        y: view.centerY - Math.cos(northRad) * seatRadius - height / 2
+    }
+
+    // The pulsing acquisition ring marking ownship, fixed at the scope centre.
+    Rectangle {
+        visible: view.showOwnshipPulse
+        x: view.centerX - width / 2
+        y: view.centerY - height / 2
+        width: 48
+        height: width
+        radius: width / 2
+        color: "transparent"
+        border.color: Style.theme.factionOwnship
+        border.width: 2
+
+        SequentialAnimation on opacity {
+            loops: Animation.Infinite
+            NumberAnimation {
+                from: 0.4
+                to: 0.0
+                duration: 1500
+                easing.type: Easing.OutQuad
+            }
+            PauseAnimation {
+                duration: 250
+            }
+        }
+        SequentialAnimation on scale {
+            loops: Animation.Infinite
+            NumberAnimation {
+                from: 0.5
+                to: 1.8
+                duration: 1500
+                easing.type: Easing.OutQuad
+            }
+            PauseAnimation {
+                duration: 250
+            }
+        }
+    }
+}

--- a/app/briarthorn/qml/ui/ViewSituationAttack.qml
+++ b/app/briarthorn/qml/ui/ViewSituationAttack.qml
@@ -1,0 +1,10 @@
+// The attack scope: the game's main centre display. A full-feature
+// ViewSituation with ownship dropped toward the bottom so the forward sector
+// dominates and the rear crops off the bottom edge, and the outer ring pushed
+// out near the short edge. Every option stays at its full-scope default; only
+// the geometry differs from the plain centred display.
+ViewSituation {
+    // Outer ring at 0.8 of the short side, centre at 0.875 of the height.
+    radiusFraction: 0.8
+    verticalShift: 0.375
+}

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -19,6 +19,16 @@ Item {
     // Screen rotation of the picture about the scope centre.
     property real viewRotation: 0
 
+    // Symbol size in px before the classification's own scale.
+    property real symbolSize: 36
+
+    // Whether track symbols carry their contact-id labels.
+    property bool showLabels: true
+
+    // When positive, off-scale contacts pin to this pixel radius (the outer
+    // rim) instead of plotting beyond it — the minimap's overview behaviour.
+    property real clampRadius: 0
+
     transform: Rotation {
         origin.x: view.centerX
         origin.y: view.centerY
@@ -31,14 +41,19 @@ Item {
             required property Track modelData
 
             readonly property real azimuthRad: modelData.azimuth * Math.PI / 180
-            readonly property real screenRange: modelData.range * view.pxPerMeter
+            readonly property real trueRange: modelData.range * view.pxPerMeter
+            // Clamp beyond-scale contacts to the rim when asked, so they read
+            // at the ring edge rather than off the display.
+            readonly property real screenRange: view.clampRadius > 0 ? Math.min(trueRange, view.clampRadius) : trueRange
 
             x: view.centerX + Math.sin(azimuthRad) * screenRange - width / 2
             y: view.centerY - Math.cos(azimuthRad) * screenRange - height / 2
+            symbolSize: view.symbolSize
             noseAngle: modelData.heading
             viewRotation: view.viewRotation
             classification: modelData.classification
             side: modelData.side
+            showLabel: view.showLabels
             label: modelData.classification === Classification.Kind.Unknown ? "" : modelData.contactId
         }
     }


### PR DESCRIPTION
Consolidates briarthorn's scope into one configurable `ViewSituation` display, shared by the main attack scope and a new corner minimap — porting briardart's `ScopeComponent` pattern (one component, two configurations, one projection).

## What's here

- **`ViewSituation.qml`** — the general situation display: range rings + `ViewTracks` + radar-FOV cone + ownship (with pulse), composed as one `Item` on a shared `RangeProjection`. Configurable via geometry knobs (`radiusFraction`, `verticalShift`, `horizontalShift`, `headingUp`, `symbolSize`) and feature toggles (`showInnerRing`, `showTicks`, `showRadarCone`, `showOwnship`, `showOwnshipPulse`, `showTrackLabels`, `showNorth`, `closedRings`).
- **`ViewSituationAttack.qml`** — the game's main centre display: a `ViewSituation` with the outer ring pushed near the short edge and ownship dropped to 0.875 height. Base-type-first naming, per the repo convention.
- **`ViewTracks.qml`** — gained `symbolSize`, `showLabels`, and `clampRadius` (pin off-scale contacts to the rim).
- **`Main.qml`** — declares **one** `RangeProjection` shared by both scopes (ranging in/out moves them together), and groups the build version + minimap + controller lamp into one top-right `Column`.

## Minimap masking

briardart clips the minimap to a circular path. Here the same visible result is achieved without pulling in `QtQuick.Effects`: `rimClamp` pins off-scale contacts to the outer ring, and an opaque disc sized to `outerRadius + symbolSize` backs the picture, so a rim-pinned mark can never spill past it and the disc's corners stay transparent over the attack scope. This keeps the multi-platform (wasm/android) build dependency-free; a true GPU clip is the path if the minimap ever grows labels/trails.

## Verification

- Clean build (`windows-msvc-debug`, all new QML AOT-compiled), no QML runtime warnings (including no positioner/anchor warnings).
- Captured the running window: both scopes render heading-up; the version sits in the top-right corner with the minimap inboard beneath it.
- Temporarily ranged the shared projection in to 20 km to force the 65 km bandit off-scale — it pinned to the minimap rim, stayed inside the disc, and nothing leaked onto the scope beneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
