### PR TITLE
Add an ownship condition gauge and top status bar

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -29,6 +29,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/scenarios/Scenario.qml
         qml/scenarios/ScenarioDuel.qml
         qml/systems/SystemDetection.qml
+        qml/systems/SystemFuel.qml
         qml/systems/SystemMovement.qml
         qml/systems/SystemPursuit.qml
         qml/themes/Aurora.qml
@@ -37,6 +38,8 @@ awen_add_executable(${PROJECT_NAME}
         qml/ui/Symbol.qml
         qml/ui/ViewSituation.qml
         qml/ui/ViewSituationAttack.qml
+        qml/ui/ViewStatus.qml
+        qml/ui/ViewTopBar.qml
         qml/ui/ViewTracks.qml
         ${QML_SINGLETONS}
     AWEN_MODULES

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -161,6 +161,10 @@ Window {
                 entities: root.entities
             }
 
+            SystemFuel {
+                entity: game.ownship
+            }
+
             SystemDetection {
                 id: detection
                 observer: game.ownship
@@ -177,6 +181,31 @@ Window {
             projection: projection
             observer: game.ownship
             tracks: detection.tracks
+            symbolSize: height * 0.08
+        }
+
+        // The full-width top band: persistent meta-game state (the credit purse)
+        // and the build version. The corner instruments hang below it.
+        ViewTopBar {
+            id: topBar
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            credits: game.credits
+            version: "v" + BuildInfo.version
+        }
+
+        // Ownship condition readout, top-left: a round dual-arc gauge (hull +
+        // fuel) sized to the minimap opposite, so the two round instruments read
+        // as a matched, compact pair. Dropped below the top band.
+        ViewStatus {
+            width: Math.min(root.width, root.height) * 0.22
+            height: width
+            anchors.left: parent.left
+            anchors.leftMargin: 16
+            anchors.top: topBar.bottom
+            anchors.topMargin: 12
+            ownship: game.ownship
         }
 
         Text {
@@ -211,61 +240,49 @@ Window {
             }
         }
 
-        // The top-right corner group: the build version tucked into the corner,
-        // the corner minimap inboard beneath it, and the controller lamp below
-        // that (so a connecting pad never nudges the map). Stacked, not rowed, so
-        // the version keeps the actual corner while the map sits inward. Right
-        // anchors inside a Column are allowed (Column manages only the y axis).
-        Column {
+        // The corner minimap, top-right — mirroring the round condition gauge in
+        // the opposite corner. The same situation display, stripped to a clean
+        // overview. It shares the attack scope's projection, so it ranges with
+        // it. Off-scale contacts pin to the rim and an opaque disc backs the
+        // picture, masking anything outside the view from rendering over the
+        // scope beneath it.
+        ViewSituation {
+            id: minimap
+            width: Math.min(root.width, root.height) * 0.22
+            height: width
             anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.margins: 16
-            spacing: 8
+            anchors.rightMargin: 16
+            anchors.top: topBar.bottom
+            anchors.topMargin: 12
 
-            // The build's date-based version, stamped when the package is built.
-            Text {
-                anchors.right: parent.right
-                text: "v" + BuildInfo.version
-                color: "#66ffffff"
-                font.pixelSize: 12
-            }
+            projection: projection
+            observer: game.ownship
+            tracks: detection.tracks
 
-            // The corner minimap: the same situation display, stripped to a clean
-            // overview. It shares the attack scope's projection, so it ranges with
-            // it. Off-scale contacts pin to the rim and an opaque disc backs the
-            // picture, masking anything outside the view from rendering over the
-            // scope beneath it.
-            ViewSituation {
-                id: minimap
-                width: Math.min(root.width, root.height) * 0.22
-                height: width
+            radiusFraction: 0.45
+            symbolSize: height * 0.08
+            backgroundColor: Style.theme.windowBackground
+            rimClamp: true
+            closedRings: true
+            showNorth: true
+            showInnerRing: false
+            showTicks: false
+            showRadarCone: true
+            showOwnshipPulse: false
+            showTrackLabels: false
+        }
 
-                projection: projection
-                observer: game.ownship
-                tracks: detection.tracks
-
-                radiusFraction: 0.45
-                symbolSize: 18
-                backgroundColor: Style.theme.instrumentBackground
-                rimClamp: true
-                closedRings: true
-                showNorth: true
-                showInnerRing: false
-                showTicks: false
-                showRadarCone: true
-                showOwnshipPulse: false
-                showTrackLabels: false
-            }
-
-            // Lights up when a controller is connected, so the gamepad path is
-            // visible. Below the map, so connecting it doesn't shift the map.
-            Text {
-                anchors.right: parent.right
-                text: qsTr("controller connected")
-                color: "#66bfff"
-                font.pixelSize: 13
-                visible: scene.padConnected
-            }
+        // The controller lamp, tucked under the minimap on the right; lights up
+        // when a controller is connected, so the gamepad path is visible.
+        Text {
+            anchors.right: parent.right
+            anchors.rightMargin: 16
+            anchors.top: minimap.bottom
+            anchors.topMargin: 6
+            text: qsTr("controller connected")
+            color: "#66bfff"
+            font.pixelSize: 13
+            visible: scene.padConnected
         }
     }
 }

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -34,4 +34,12 @@ QtObject {
     property real compute: 0
     property real sensor: 0
     property real stealth: 0
+
+    // Condition: current and maximum hull integrity and fuel. Pure state — a
+    // damage system will write health, SystemFuel writes fuel, the view reads
+    // both. maxHealth derives from durable at spawn; both start full.
+    property real health: 0
+    property real maxHealth: 0
+    property real fuel: 0
+    property real maxFuel: 0
 }

--- a/app/briarthorn/qml/model/StoreGame.qml
+++ b/app/briarthorn/qml/model/StoreGame.qml
@@ -7,6 +7,11 @@ import "../commands"
 Store {
     id: store
 
+    // Campaign meta-state the top bar reads: the shared credit purse. A
+    // placeholder until an economy writes it; player-facing persistent state
+    // belongs on the store, not on any one entity.
+    property int credits: 1250
+
     // Ownship under player control.
     readonly property Entity ownship: Entity {
         classification: Classification.Kind.AircraftFighter
@@ -18,6 +23,12 @@ Store {
         compute: 6
         sensor: 60000
         stealth: 5
+        // Condition: hull scaled from durability, fuel a full tank. Both start
+        // topped off; SystemFuel draws the tank down as the player flies.
+        maxHealth: durable * 20
+        health: maxHealth
+        maxFuel: 100
+        fuel: maxFuel
     }
 
     CommandHandler {

--- a/app/briarthorn/qml/systems/SystemFuel.qml
+++ b/app/briarthorn/qml/systems/SystemFuel.qml
@@ -1,0 +1,21 @@
+import awen.entity
+import "../model"
+
+// Fuel burn: the entity's tank drains each tick — a steady idle draw plus more
+// under throttle — clamped at empty. The sole writer of fuel; the condition
+// readout reads it.
+System {
+    id: fuel
+
+    // The craft whose tank this drains.
+    required property Entity entity
+
+    // Units per second: the always-on draw and the extra at full throttle.
+    property real idleBurn: 0.5
+    property real throttleBurn: 4
+
+    function update(dt: real) {
+        const draw = fuel.idleBurn + fuel.throttleBurn * Math.max(0, fuel.entity.commandedThrottle);
+        fuel.entity.fuel = Math.max(0, fuel.entity.fuel - draw * dt);
+    }
+}

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -59,15 +59,21 @@ Item {
     // The range-label gap arc length, in px; 0 (closedRings) draws closed rings.
     readonly property real ringGapLength: closedRings ? 0 : Math.max(28, outerRadius * 0.1)
 
+    // North-marker size (shared with the backing disc below), floored so the
+    // 'N' stays legible when the map is small.
+    readonly property real northFontSize: Math.max(9, outerRadius * 0.16)
+
     // Compact-overview plumbing. rimClamp pins off-scale contacts to the outer
     // rim; backgroundColor paints an opaque disc behind the picture so it reads
-    // over whatever sits behind it. The disc reaches a symbol past the outer
-    // ring, so a rim-pinned mark can never spill past it — the mask that keeps
-    // objects outside the view from rendering under the minimap (briardart clips
-    // to this same disc, then pins off-scale tracks to its rim).
+    // over whatever sits behind it. The disc reaches just past the outer ring —
+    // to the north marker's outer edge when shown, else far enough to seat a
+    // rim-pinned symbol — and both margins scale with the map, so the disc no
+    // longer bloats past the picture as the minimap shrinks. This is the mask
+    // that keeps objects outside the view from rendering under the minimap
+    // (briardart clips to this same disc, then pins off-scale tracks to its rim).
     property bool rimClamp: false
     property color backgroundColor: "transparent"
-    readonly property real discRadius: outerRadius + symbolSize
+    readonly property real discRadius: outerRadius + Math.max(showNorth ? northFontSize * 1.15 : 0, symbolSize * 0.6)
 
     // The opaque backing disc (minimap only; transparent by default). A circle
     // centred on the scope, so the box's corners stay clear.
@@ -157,12 +163,12 @@ Item {
         text: "N"
         color: Style.theme.textBright
         font.bold: true
-        font.pixelSize: Math.max(9, view.outerRadius * 0.16)
+        font.pixelSize: view.northFontSize
 
         // North (true bearing 0) sits at screen angle viewRotation on a
         // heading-up scope; seat the label a little past the ring.
         readonly property real northRad: view.viewRotation * Math.PI / 180
-        readonly property real seatRadius: view.outerRadius + font.pixelSize * 0.7
+        readonly property real seatRadius: view.outerRadius + view.northFontSize * 0.7
         x: view.centerX + Math.sin(northRad) * seatRadius - width / 2
         y: view.centerY - Math.cos(northRad) * seatRadius - height / 2
     }

--- a/app/briarthorn/qml/ui/ViewStatus.qml
+++ b/app/briarthorn/qml/ui/ViewStatus.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import awen.shapes
+import "../model"
+import "../themes"
+
+// Ownship condition readout: a round instrument that mirrors the corner minimap
+// opposite it — same footprint, so the two read as a matched pair and the whole
+// thing stays compact on a phone. Two concentric arc dials around the ownship
+// symbol — HULL outer (cyan), FUEL inner (gold) — each sweeping 270° and opening
+// at the bottom, with the values seated in that open mouth. A low reading shifts
+// its ring and value to the warn colour. Reads live from the ownship entity.
+Item {
+    id: view
+
+    // The craft whose condition this shows.
+    property Entity ownship
+
+    implicitWidth: 150
+    implicitHeight: 150
+
+    readonly property real shortSide: Math.min(width, height)
+    readonly property real cx: width / 2
+    readonly property real cy: height / 2
+    readonly property real ringWidth: shortSide * 0.055
+
+    readonly property real healthFrac: ownship && ownship.maxHealth > 0 ? Math.max(0, Math.min(1, ownship.health / ownship.maxHealth)) : 0
+    readonly property real fuelFrac: ownship && ownship.maxFuel > 0 ? Math.max(0, Math.min(1, ownship.fuel / ownship.maxFuel)) : 0
+    readonly property bool hullLow: healthFrac <= 0.3
+    readonly property bool fuelLow: fuelFrac <= 0.2
+
+    // HULL — the outer dial.
+    ShapeGauge {
+        anchors.fill: parent
+        centerX: view.cx
+        centerY: view.cy
+        radius: view.shortSide * 0.44
+        strokeWidth: view.ringWidth
+        angleStart: 225
+        angleSweep: 270
+        value: view.healthFrac
+        trackColor: Style.theme.gaugeTrack
+        fillColor: view.hullLow ? Style.theme.warn : Style.theme.accent
+    }
+
+    // FUEL — the inner dial, concentric inside the hull ring.
+    ShapeGauge {
+        anchors.fill: parent
+        centerX: view.cx
+        centerY: view.cy
+        radius: view.shortSide * 0.355
+        strokeWidth: view.ringWidth
+        angleStart: 225
+        angleSweep: 270
+        value: view.fuelFrac
+        trackColor: Style.theme.gaugeTrack
+        fillColor: view.fuelLow ? Style.theme.warn : Style.theme.fuel
+    }
+
+    // Ownship symbol, nose up, lifted just above centre so it clears the mouth
+    // readouts below.
+    Symbol {
+        x: view.cx - width / 2
+        y: view.cy - height / 2 - view.shortSide * 0.09
+        symbolSize: view.shortSide * 0.26
+        classification: view.ownship ? view.ownship.classification : Classification.Kind.AircraftFighter
+        side: view.ownship ? view.ownship.side : Side.Kind.Ownship
+        showLabel: false
+    }
+
+    // Readouts in the open mouth at the bottom: hull number over fuel percent,
+    // colour-keyed to their rings.
+    Column {
+        anchors.horizontalCenter: parent.horizontalCenter
+        y: view.cy + view.shortSide * 0.08
+        spacing: -view.shortSide * 0.01
+
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: view.ownship ? Math.round(view.ownship.health) : "--"
+            color: view.hullLow ? Style.theme.warn : Style.theme.accent
+            font.pixelSize: view.shortSide * 0.15
+            font.family: "Consolas"
+            font.bold: true
+        }
+
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: view.ownship ? Math.round(view.fuelFrac * 100) + "%" : "--"
+            color: view.fuelLow ? Style.theme.warn : Style.theme.fuel
+            font.pixelSize: view.shortSide * 0.11
+            font.family: "Consolas"
+        }
+    }
+}

--- a/app/briarthorn/qml/ui/ViewTopBar.qml
+++ b/app/briarthorn/qml/ui/ViewTopBar.qml
@@ -1,0 +1,98 @@
+import QtQuick
+import "../themes"
+
+// The full-width top status band: a themed strip across the top edge carrying
+// persistent meta-game readouts — the credit purse now, with room for more — on
+// the left, and the build version on the right. The corner instruments sit below
+// it. Distinct from ViewStatus (the ownship's hull/fuel condition): this band is
+// campaign/meta state. Ports briardart's TopStatusBar (ui/panels/top_status_bar).
+Rectangle {
+    id: bar
+
+    // Persistent readouts.
+    property int credits: 0
+    property string version: ""
+
+    implicitHeight: 32
+    color: Style.theme.panelBackground
+
+    // A hairline along the bottom edge separates the band from the scope below.
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: 1
+        color: Style.theme.frameInner
+    }
+
+    // Persistent readouts, left-aligned. Add more as another Stat (with a
+    // Divider woven between) — e.g. Stat { label: "LVL"; value: level }.
+    Row {
+        anchors.left: parent.left
+        anchors.leftMargin: 16
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 10
+
+        Stat {
+            value: bar.credits.toLocaleString(Qt.locale(), 'f', 0)
+            unit: qsTr("CR")
+        }
+    }
+
+    // The build version, right-aligned and dim.
+    Text {
+        anchors.right: parent.right
+        anchors.rightMargin: 16
+        anchors.verticalCenter: parent.verticalCenter
+        text: bar.version
+        color: "#66ffffff"
+        font.pixelSize: 12
+    }
+
+    // One readout chip: an optional dim label, the bright value, and an optional
+    // dim unit (e.g. CR). The shared building block for every stat.
+    component Stat: Row {
+        property string label: ""
+        property string value: ""
+        property string unit: ""
+
+        spacing: 4
+
+        Text {
+            visible: text !== ""
+            anchors.verticalCenter: parent.verticalCenter
+            text: parent.label
+            color: Style.theme.textLabel
+            font.pixelSize: 10
+            font.bold: true
+            font.letterSpacing: 1
+        }
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: parent.value
+            color: Style.theme.textPrimary
+            font.pixelSize: 15
+            font.bold: true
+            font.family: "Consolas"
+        }
+
+        Text {
+            visible: text !== ""
+            anchors.verticalCenter: parent.verticalCenter
+            text: parent.unit
+            color: Style.theme.textLabel
+            font.pixelSize: 10
+            font.bold: true
+            font.letterSpacing: 1
+        }
+    }
+
+    // A thin vertical divider to weave between successive stats.
+    component Divider: Rectangle {
+        anchors.verticalCenter: parent.verticalCenter
+        width: 1
+        height: 16
+        color: Style.theme.frameInner
+    }
+}


### PR DESCRIPTION
Adds an ownship condition gauge and a top status bar to the briarthorn HUD, and polishes the corner minimap. All four corners now read as one instrument set: a full-width meta band up top, a round condition gauge top-left, and the round minimap top-right.

## New: ownship condition gauge (`ui/ViewStatus.qml`)

A round dual-arc dial that mirrors the corner minimap for a matched, compact pair (it scales with the screen — ~95px on a phone — instead of eating a fixed-width band):
- HULL as the outer arc (cyan), FUEL as the inner arc (gold), each a 270° dial around the ownship symbol, values seated in the open mouth.
- A ring and its value shift to the warn colour on a low reading (hull ≤ 30%, fuel ≤ 20%).

The gauge needed condition state, so:
- `model/Entity.qml` gains `health`/`maxHealth`/`fuel`/`maxFuel` (pure state).
- `model/StoreGame.qml` seeds the ownship full — `maxHealth: durable * 20`, a full tank.
- `systems/SystemFuel.qml` (new) is the sole fuel writer: an idle draw plus a throttle draw, clamped at empty, so the FUEL arc is live as you fly.

## New: top status bar (`ui/ViewTopBar.qml`)

A full-width band across the top for persistent meta-game state (ports briardart's `TopStatusBar`):
- The credit purse on the left (`1,250 CR`) via a reusable inline `Stat` chip (bright value + dim unit; a `Divider` component is ready for more readouts).
- The build version moved off the corner onto the right of the band.
- `credits` comes from a new `StoreGame.credits` (placeholder, for an economy to write later).

The two round instruments now hang below the band, matching briardart's layout.

## Minimap polish (`ui/ViewSituation.qml`)

- The backing disc now blends with the window (`windowBackground`) instead of a distinct panel tint.
- The disc radius was a fixed `outerRadius + symbolSize` margin that bloated as the map shrank; it now scales with the map, reaching the north marker's edge and no further.

## Notes

- Nothing consumes fuel/hull yet (empty tank doesn't cut thrust; no damage system drives hull) — the gauge is wired and ready for both. `credits` is likewise a placeholder value.
- Fixed a gauge-fill freeze along the way: a `Behavior on width` on a value that changes every sim frame cancelled and restarted its animation each frame before applying a step, pinning the bar; the fill now binds straight to the fraction.

## Verification

Clean `windows-msvc-debug` build, no QML runtime warnings. Captured desktop and phone-portrait layouts; verified the fuel arc tracks a live drain and the warn/CAUTION state renders (damaged-and-partial capture, then reverted to full).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
