### PR TITLE
Add the weapon system: abilities, missiles, flares and the engagement overlay

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -2,6 +2,7 @@ project(briarthorn)
 
 set(QML_SINGLETONS
     qml/commands/Verbs.qml
+    qml/model/Abilities.qml
     qml/model/Database.qml
     qml/themes/Style.qml
 )
@@ -17,25 +18,41 @@ awen_add_executable(${PROJECT_NAME}
     VERSION 1.0
     QML_FILES
         qml/Main.qml
+        qml/commands/CommandAbility.qml
         qml/commands/CommandSteer.qml
         qml/commands/CommandThrottle.qml
+        qml/model/Ability.qml
+        qml/model/AbilityFlare.qml
+        qml/model/AbilityLaunch.qml
+        qml/model/AbilitySlot.qml
         qml/model/Classification.qml
         qml/model/Data.qml
+        qml/model/DataWeapon.qml
+        qml/model/Detonation.qml
         qml/model/Entity.qml
         qml/model/RangeProjection.qml
         qml/model/Side.qml
         qml/model/StoreGame.qml
         qml/model/Track.qml
+        qml/model/Weapon.qml
+        qml/model/World.qml
         qml/scenarios/Scenario.qml
         qml/scenarios/ScenarioDuel.qml
+        qml/systems/SystemAbility.qml
+        qml/systems/SystemCountermeasure.qml
         qml/systems/SystemDetection.qml
+        qml/systems/SystemEngage.qml
         qml/systems/SystemFuel.qml
         qml/systems/SystemMovement.qml
         qml/systems/SystemPursuit.qml
+        qml/systems/SystemThreat.qml
+        qml/systems/SystemWeapon.qml
         qml/themes/Aurora.qml
         qml/ui/Joystick.qml
         qml/ui/RangeRing.qml
         qml/ui/Symbol.qml
+        qml/ui/SymbolFlare.qml
+        qml/ui/ViewEngagements.qml
         qml/ui/ViewSituation.qml
         qml/ui/ViewSituationAttack.qml
         qml/ui/ViewStatus.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -41,9 +41,17 @@ Window {
         axisThrottle.invoke(0);
     }
 
-    // Everything the simulation integrates: the player's craft plus the
-    // current scenario's entities.
-    readonly property list<Entity> entities: [game.ownship, ...scenario.entities]
+    // The world's roster is everything the simulation integrates: the
+    // player's craft and the scenario's entities are enrolled at startup,
+    // and the weapon systems spawn and reap missiles and decoys in it.
+    readonly property World world: World {}
+    readonly property list<Entity> entities: root.world.entities
+
+    Component.onCompleted: {
+        root.world.add(game.ownship);
+        for (let i = 0; i < scenario.entities.length; ++i)
+            root.world.add(scenario.entities[i]);
+    }
 
     // The one display projection both scopes share: ranging in or out moves the
     // centre attack scope and the corner minimap together.
@@ -70,6 +78,29 @@ Window {
             minimum: 0
         }
 
+        // Ability triggers: one 0..1 axis per ability, posting the intent on
+        // the rising edge so a held key fires once.
+        Axis {
+            id: axisFireGuided
+            minimum: 0
+            onValueChanged: if (value > 0.5)
+                fireGuided.post()
+        }
+
+        Axis {
+            id: axisFireKinetic
+            minimum: 0
+            onValueChanged: if (value > 0.5)
+                fireKinetic.post()
+        }
+
+        Axis {
+            id: axisFlare
+            minimum: 0
+            onValueChanged: if (value > 0.5)
+                popFlare.post()
+        }
+
         Actions {
             id: actions
 
@@ -94,6 +125,37 @@ Window {
                 control: axisThrottle
                 positive: [Gamepad.Button.DpadUp]
             }
+
+            ActionKey {
+                control: axisFireGuided
+                positive: [Qt.Key_Space]
+            }
+
+            ActionKey {
+                control: axisFireKinetic
+                positive: [Qt.Key_E]
+            }
+
+            ActionKey {
+                control: axisFlare
+                positive: [Qt.Key_F]
+            }
+
+            ActionButton {
+                control: axisFireGuided
+                positive: [Gamepad.Button.RightShoulder]
+            }
+
+            ActionButton {
+                control: axisFireKinetic
+                positive: [Gamepad.Button.West]
+            }
+
+            ActionButton {
+                control: axisFlare
+                positive: [Gamepad.Button.South]
+            }
+
             ActionAxis {
                 control: axisSteer
                 axis: Gamepad.Axis.LeftX
@@ -119,6 +181,24 @@ Window {
             onValueChanged: post()
         }
 
+        CommandAbility {
+            id: fireGuided
+            queue: bus
+            ability: "guided"
+        }
+
+        CommandAbility {
+            id: fireKinetic
+            queue: bus
+            ability: "kinetic"
+        }
+
+        CommandAbility {
+            id: popFlare
+            queue: bus
+            ability: "flare"
+        }
+
         // The input handlers only route events into the action map; only
         // mapped keys are consumed.
         Keys.onPressed: event => {
@@ -141,7 +221,9 @@ Window {
 
         // Run order is the lifetimes and the data flow: publish the batch,
         // consume player intent into the game store, run the scenario's own
-        // systems, then integrate poses and sweep the radar.
+        // systems (AI steering and trigger discipline), age ability clocks,
+        // integrate poses, then resolve weapons, countermeasures and the
+        // radar sweep — detection last, so tracks see the tick's outcome.
         Systems {
             CommandQueue {
                 id: bus
@@ -155,6 +237,11 @@ Window {
             ScenarioDuel {
                 id: scenario
                 ownship: game.ownship
+                world: root.world
+            }
+
+            SystemAbility {
+                world: root.world
             }
 
             SystemMovement {
@@ -163,6 +250,16 @@ Window {
 
             SystemFuel {
                 entity: game.ownship
+            }
+
+            SystemWeapon {
+                id: weapons
+                world: root.world
+                invulnerable: [game.ownship]
+            }
+
+            SystemCountermeasure {
+                world: root.world
             }
 
             SystemDetection {
@@ -199,7 +296,9 @@ Window {
             projection: projection
             observer: game.ownship
             tracks: detection.tracks
-            symbolSize: height * 0.08
+            entities: root.entities
+            detonations: weapons.detonations
+            symbolSize: height * 0.04
         }
 
         // Ownship condition readout, top-left: a round dual-arc gauge (hull +
@@ -219,7 +318,7 @@ Window {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 24
-            text: qsTr("drag the stick, or W to thrust & A/D to turn — arrows, gamepad too")
+            text: qsTr("W thrust · A/D turn · SPACE guided · E kinetic · F flare — arrows, gamepad too")
             color: "#99ffffff"
             font.pixelSize: 14
         }
@@ -277,6 +376,7 @@ Window {
             showRadarCone: true
             showOwnshipPulse: false
             showTrackLabels: false
+            showEngagements: false
         }
 
         // The controller lamp, tucked under the minimap on the right; lights up

--- a/app/briarthorn/qml/commands/CommandAbility.qml
+++ b/app/briarthorn/qml/commands/CommandAbility.qml
@@ -1,0 +1,16 @@
+import awen.command
+
+// Ability intent: invokes one of the flown entity's abilities by name —
+// launch a weapon, pop a flare. Discrete, so every press posts one record.
+Command {
+    id: command
+
+    name: Verbs.ability
+
+    // The ability name the record carries.
+    property string ability: ""
+
+    function payload(): var {
+        return { ability: command.ability };
+    }
+}

--- a/app/briarthorn/qml/commands/Verbs.qml
+++ b/app/briarthorn/qml/commands/Verbs.qml
@@ -6,4 +6,5 @@ import QtQml
 QtObject {
     readonly property string steer: "steer"
     readonly property string throttle: "throttle"
+    readonly property string ability: "ability"
 }

--- a/app/briarthorn/qml/model/Abilities.qml
+++ b/app/briarthorn/qml/model/Abilities.qml
@@ -1,0 +1,40 @@
+pragma Singleton
+
+import QtQuick
+
+// The ability registry: one definition row per invocable ability, keyed by
+// name — slots reference these rows and defFor() is the router's lookup.
+QtObject {
+    id: root
+
+    readonly property AbilityFlare flare: AbilityFlare {}
+
+    readonly property AbilityLaunch launchGuided: AbilityLaunch {
+        name: "guided"
+        label: qsTr("GUIDED")
+        cooldown: 2.5
+        charges: 6
+        weapon: Classification.Kind.MissileGuided
+    }
+
+    readonly property AbilityLaunch launchKinetic: AbilityLaunch {
+        name: "kinetic"
+        label: qsTr("KINETIC")
+        cooldown: 2
+        charges: 4
+        weapon: Classification.Kind.MissileKinetic
+    }
+
+    function defFor(name: string): Ability {
+        switch (name) {
+        case "flare":
+            return root.flare;
+        case "guided":
+            return root.launchGuided;
+        case "kinetic":
+            return root.launchKinetic;
+        default:
+            return null;
+        }
+    }
+}

--- a/app/briarthorn/qml/model/Ability.qml
+++ b/app/briarthorn/qml/model/Ability.qml
@@ -1,0 +1,19 @@
+import QtQml
+
+// Base definition row for one ability an entity can invoke: identity plus
+// the cooldown and charge tuning shared by every carrier. One instance per
+// kind lives in the Abilities registry; live per-entity state lives on an
+// AbilitySlot referencing the row.
+QtObject {
+    // The name ability commands and systems route on.
+    property string name: ""
+
+    // Player-facing label.
+    property string label: ""
+
+    // Seconds between invocations; 0 gates on charges alone.
+    property real cooldown: 0
+
+    // Rounds a fresh slot carries; -1 is unlimited.
+    property int charges: -1
+}

--- a/app/briarthorn/qml/model/AbilityFlare.qml
+++ b/app/briarthorn/qml/model/AbilityFlare.qml
@@ -1,0 +1,8 @@
+// Pops an expendable decoy at the invoker: a same-side contact so loud a
+// hostile seeker re-homes on it instead. SystemCountermeasure consumes the
+// raised intent and ages the decoy out.
+Ability {
+    name: "flare"
+    label: qsTr("FLARE")
+    charges: 10
+}

--- a/app/briarthorn/qml/model/AbilityLaunch.qml
+++ b/app/briarthorn/qml/model/AbilityLaunch.qml
@@ -1,0 +1,7 @@
+// Launches one weapon round: guided at the invoker's loudest illuminated
+// return, kinetic straight off the nose. SystemWeapon consumes the raised
+// intent and spawns the missile.
+Ability {
+    // The weapon kind a launch spawns.
+    property int weapon: Classification.Kind.Unknown
+}

--- a/app/briarthorn/qml/model/AbilitySlot.qml
+++ b/app/briarthorn/qml/model/AbilitySlot.qml
@@ -1,0 +1,27 @@
+import QtQml
+
+// One ability as carried by an entity: the definition row plus the live
+// cooldown, charge and intent state. activate() is the single entry point
+// player input and AI share — it raises pending for the consuming system
+// when the slot is ready, and does nothing otherwise.
+QtObject {
+    id: slot
+
+    // The ability definition this slot instantiates.
+    property Ability def: null
+
+    // Seconds until ready again and rounds left (-1 is unlimited); the
+    // consuming system spends both.
+    property real cooldownRemaining: 0
+    property int charges: def ? def.charges : -1
+
+    // The raised intent, cleared by the consuming system.
+    property bool pending: false
+
+    readonly property bool ready: cooldownRemaining <= 0 && charges !== 0
+
+    function activate() {
+        if (slot.ready)
+            slot.pending = true;
+    }
+}

--- a/app/briarthorn/qml/model/Classification.qml
+++ b/app/briarthorn/qml/model/Classification.qml
@@ -7,6 +7,9 @@ QtObject {
     enum Kind {
         Unknown,
         AircraftFighter,
+        MissileGuided,
+        MissileKinetic,
+        Decoy,
         Count
     }
 }

--- a/app/briarthorn/qml/model/DataWeapon.qml
+++ b/app/briarthorn/qml/model/DataWeapon.qml
@@ -1,0 +1,24 @@
+import QtQml
+
+// One weapon kind's definition row: the munition tuning SystemWeapon reads —
+// flight envelope, seeker and warhead — on top of the base render fields.
+// All direct game quantities: m/s, deg/s, metres, seconds.
+Data {
+    // Flight: cruise speed, turn rate at full deflection and the
+    // time-of-flight after which the round self-destructs.
+    property real speed: 0
+    property real turnRate: 0
+    property real duration: 0
+
+    // Seeker: a guided round re-homes every tick on the loudest return its
+    // owner's radar illuminates, considering returns inside seekerRange.
+    property bool guided: false
+    property real seekerRange: 0
+
+    // Warhead: the proximity-fuze trigger range, the delay from fuze to
+    // detonation and the flat damage applied inside blastRadius.
+    property real fuzeRange: 0
+    property real fuzeTime: 0
+    property real damage: 0
+    property real blastRadius: 0
+}

--- a/app/briarthorn/qml/model/Database.qml
+++ b/app/briarthorn/qml/model/Database.qml
@@ -19,12 +19,69 @@ QtObject {
         label: qsTr("FIGHTER")
     }
 
+    // Weapon rows: briardart's missile tuning carried over as direct
+    // quantities. The guided round outruns the kinetic but hits softer; the
+    // kinetic's big warhead makes up for the dumb fuze.
+    readonly property DataWeapon missileGuided: DataWeapon {
+        classification: Classification.Kind.MissileGuided
+        outline: [Qt.point(0, -0.5), Qt.point(0.15, 0.5), Qt.point(-0.15, 0.5)]
+        label: qsTr("MSL")
+        symbolScale: 0.55
+        speed: 1800
+        turnRate: 24
+        duration: 24
+        guided: true
+        seekerRange: 90000
+        fuzeRange: 500
+        fuzeTime: 0.3
+        damage: 55
+        blastRadius: 900
+    }
+
+    readonly property DataWeapon missileKinetic: DataWeapon {
+        classification: Classification.Kind.MissileKinetic
+        outline: [Qt.point(0, -0.5), Qt.point(0.15, 0.5), Qt.point(-0.15, 0.5)]
+        label: qsTr("MSL")
+        symbolScale: 0.55
+        speed: 1000
+        duration: 18
+        fuzeRange: 1200
+        fuzeTime: 0.3
+        damage: 80
+        blastRadius: 2500
+    }
+
+    readonly property Data decoy: Data {
+        classification: Classification.Kind.Decoy
+        outline: [Qt.point(0, -0.35), Qt.point(0.35, 0), Qt.point(0, 0.35), Qt.point(-0.35, 0)]
+        label: qsTr("CM")
+        symbolScale: 0.45
+    }
+
     function dataFor(classification: int): Data {
         switch (classification) {
         case Classification.Kind.AircraftFighter:
             return root.aircraftFighter;
+        case Classification.Kind.MissileGuided:
+            return root.missileGuided;
+        case Classification.Kind.MissileKinetic:
+            return root.missileKinetic;
+        case Classification.Kind.Decoy:
+            return root.decoy;
         default:
             return root.unknown;
+        }
+    }
+
+    // The weapon row behind a launchable classification, or null.
+    function weaponDataFor(classification: int): DataWeapon {
+        switch (classification) {
+        case Classification.Kind.MissileGuided:
+            return root.missileGuided;
+        case Classification.Kind.MissileKinetic:
+            return root.missileKinetic;
+        default:
+            return null;
         }
     }
 }

--- a/app/briarthorn/qml/model/Detonation.qml
+++ b/app/briarthorn/qml/model/Detonation.qml
@@ -1,0 +1,12 @@
+import QtQml
+
+// One blast in progress: recorded by SystemWeapon at detonation and aged
+// out. The view expands a ring toward blastRadius as life runs down and
+// fades it with the remaining fraction.
+QtObject {
+    property real worldX: 0
+    property real worldY: 0
+    property real blastRadius: 0
+    property real life: 0
+    property real maxLife: 1
+}

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -25,9 +25,11 @@ QtObject {
     property real commandedSteer: 0
 
     // The six stats, as direct game quantities: kinetic is the full-throttle
-    // speed in m/s, maneuver the full-deflection turn rate in deg/s and
-    // sensor the radar detection range in metres; the other three wait on
-    // the systems that will read them.
+    // speed in m/s, maneuver the full-deflection turn rate in deg/s, sensor
+    // the radar detection range in metres, durable scales maxHealth at spawn
+    // and stealth is the emission signature — lower is louder, and a guided
+    // seeker homes on the loudest illuminated return; compute waits on the
+    // system that will read it.
     property real kinetic: 0
     property real maneuver: 0
     property real durable: 0
@@ -35,11 +37,22 @@ QtObject {
     property real sensor: 0
     property real stealth: 0
 
-    // Condition: current and maximum hull integrity and fuel. Pure state — a
-    // damage system will write health, SystemFuel writes fuel, the view reads
-    // both. maxHealth derives from durable at spawn; both start full.
+    // Condition: current and maximum hull integrity and fuel. Pure state —
+    // SystemWeapon's blasts write health, SystemFuel writes fuel, the view
+    // reads both. maxHealth derives from durable at spawn; both start full.
     property real health: 0
     property real maxHealth: 0
     property real fuel: 0
     property real maxFuel: 0
+
+    // The entity that launched or deployed this one; null for craft. Fuzes
+    // ignore anything the owner also owns, the blast spares the owner and a
+    // guided seeker sees only what the owner's radar illuminates.
+    property Entity owner: null
+
+    // The abilities this entity can invoke, as live slots.
+    property list<AbilitySlot> abilities
+
+    // The munition role state; non-null only when this entity is a missile.
+    property Weapon weapon: null
 }

--- a/app/briarthorn/qml/model/StoreGame.qml
+++ b/app/briarthorn/qml/model/StoreGame.qml
@@ -29,6 +29,19 @@ Store {
         health: maxHealth
         maxFuel: 100
         fuel: maxFuel
+
+        // The invocable loadout: both missile kinds and a flare pod.
+        abilities: [
+            AbilitySlot {
+                def: Abilities.launchGuided
+            },
+            AbilitySlot {
+                def: Abilities.launchKinetic
+            },
+            AbilitySlot {
+                def: Abilities.flare
+            }
+        ]
     }
 
     CommandHandler {
@@ -39,5 +52,20 @@ Store {
     CommandHandler {
         name: Verbs.throttle
         onHandle: payload => store.ownship.commandedThrottle = payload.value
+    }
+
+    // Ability invocation routes to the named slot; activation is a no-op
+    // while the slot is cooling or out of charges.
+    CommandHandler {
+        name: Verbs.ability
+        onHandle: payload => {
+            const slots = store.ownship.abilities;
+            for (let i = 0; i < slots.length; ++i) {
+                if (slots[i].def.name === payload.ability) {
+                    slots[i].activate();
+                    return;
+                }
+            }
+        }
     }
 }

--- a/app/briarthorn/qml/model/Weapon.qml
+++ b/app/briarthorn/qml/model/Weapon.qml
@@ -1,0 +1,29 @@
+import QtQml
+
+// The munition role state carried by a missile entity: its definition row,
+// seeker lock and the fuze state machine SystemWeapon drives. Non-null only
+// on entities that are missiles; the launcher lives on Entity.owner.
+QtObject {
+    enum State {
+        Flying,
+        Fuzing
+    }
+
+    // The weapon row this round was spawned from.
+    property DataWeapon def: null
+
+    // The seeker's current lock; null on kinetic rounds and while no return
+    // is illuminated.
+    property Entity target: null
+
+    property int state: Weapon.State.Flying
+
+    // Seconds since launch; reaching the definition's duration forces the
+    // fuze (self-destruct).
+    property real elapsed: 0
+
+    // The entity the fuze tripped on and the seconds since it tripped; the
+    // view draws the fuzing line to fuzeTarget. Null on a timeout fuze.
+    property Entity fuzeTarget: null
+    property real fuzeElapsed: 0
+}

--- a/app/briarthorn/qml/model/World.qml
+++ b/app/briarthorn/qml/model/World.qml
@@ -1,0 +1,42 @@
+import QtQml
+
+// The world's entity roster and its spawn authority: the one mutable list
+// every system iterates and every view binds. Declared entities (ownship, a
+// scenario's craft) are added and removed but never destroyed; entities
+// spawned here (missiles, decoys) are destroyed again on despawn.
+QtObject {
+    id: world
+
+    // Every live entity, in no meaningful order.
+    property list<Entity> entities
+
+    // Entities this world created and therefore destroys.
+    property var spawned: new Set()
+
+    // Serial for generated callsigns, so track ids stay unique.
+    property int serial: 0
+
+    readonly property Component entityFactory: Component {
+        Entity {}
+    }
+
+    function add(entity: Entity) {
+        world.entities = [...world.entities, entity];
+    }
+
+    // Builds an entity from properties and enrolls it; prefix names it
+    // ("MSL" becomes callsign "MSL 1").
+    function spawn(prefix: string, props: var): Entity {
+        props.callsign = prefix + " " + (++world.serial);
+        const entity = world.entityFactory.createObject(world, props);
+        world.spawned.add(entity);
+        world.add(entity);
+        return entity;
+    }
+
+    function despawn(entity: Entity) {
+        world.entities = world.entities.filter(e => e !== entity);
+        if (world.spawned.delete(entity))
+            entity.destroy();
+    }
+}

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -2,12 +2,17 @@ import "../model"
 import "../systems"
 
 // The 1v1 duel: one hostile fighter boring in from the north, spawned just
-// past sensor range so it opens as an Unknown contact.
+// past sensor range so it opens as an Unknown contact. The bandit shoots
+// back — guided rounds inside its engage envelope — and pops flares when a
+// missile homes in on it.
 Scenario {
     id: scenario
 
     // The player's craft, for the bandit to pursue; the game store owns it.
     required property Entity ownship
+
+    // The world the bandit's defensive scan reads.
+    required property World world
 
     readonly property Entity bandit: Entity {
         callsign: "BANDIT 1"
@@ -22,6 +27,18 @@ Scenario {
         compute: 6
         sensor: 60000
         stealth: 5
+        maxHealth: durable * 20
+        health: maxHealth
+
+        abilities: [
+            AbilitySlot {
+                def: Abilities.launchGuided
+            },
+            AbilitySlot {
+                def: Abilities.flare
+                charges: 6
+            }
+        ]
     }
 
     entities: [scenario.bandit]
@@ -29,5 +46,15 @@ Scenario {
     SystemPursuit {
         entity: scenario.bandit
         target: scenario.ownship
+    }
+
+    SystemEngage {
+        entity: scenario.bandit
+        target: scenario.ownship
+    }
+
+    SystemThreat {
+        entity: scenario.bandit
+        world: scenario.world
     }
 }

--- a/app/briarthorn/qml/systems/SystemAbility.qml
+++ b/app/briarthorn/qml/systems/SystemAbility.qml
@@ -1,0 +1,22 @@
+import awen.entity
+import "../model"
+
+// Ability timekeeping: runs every entity's slot cooldowns down toward
+// ready. The consuming systems (weapon, countermeasure) spend charges and
+// wind the cooldowns back up.
+System {
+    id: ability
+
+    // The world whose entities carry the slots.
+    required property World world
+
+    function update(dt: real) {
+        for (let i = 0; i < ability.world.entities.length; ++i) {
+            const slots = ability.world.entities[i].abilities;
+            for (let j = 0; j < slots.length; ++j) {
+                if (slots[j].cooldownRemaining > 0)
+                    slots[j].cooldownRemaining = Math.max(0, slots[j].cooldownRemaining - dt);
+            }
+        }
+    }
+}

--- a/app/briarthorn/qml/systems/SystemCountermeasure.qml
+++ b/app/briarthorn/qml/systems/SystemCountermeasure.qml
@@ -1,0 +1,75 @@
+import awen.entity
+import "../model"
+
+// Countermeasures, ported from briardart: consumes raised flare intents
+// into same-side decoy entities at the deployer — stealth 0, the loudest
+// possible return, so a hostile seeker re-homes on the decoy instead — and
+// ages each decoy out again. Runs after SystemWeapon, so a popped flare is
+// in play from the next tick.
+System {
+    id: countermeasure
+
+    // The world decoys spawn into.
+    required property World world
+
+    // Seconds a decoy burns before it despawns.
+    property real flareLife: 10
+
+    // Live decoys, as {entity, life} entries.
+    property var flares: []
+
+    function update(dt: real) {
+        countermeasure.deploy();
+        countermeasure.age(dt);
+    }
+
+    function deploy() {
+        const roster = countermeasure.world.entities.slice();
+        for (let i = 0; i < roster.length; ++i) {
+            const carrier = roster[i];
+            for (let j = 0; j < carrier.abilities.length; ++j) {
+                const slot = carrier.abilities[j];
+                if (!(slot.def instanceof AbilityFlare) || !slot.pending)
+                    continue;
+                slot.pending = false;
+                if (!slot.ready)
+                    continue;
+                slot.charges = slot.charges > 0 ? slot.charges - 1 : slot.charges;
+                const decoy = countermeasure.world.spawn("CM", {
+                    classification: Classification.Kind.Decoy,
+                    side: carrier.side,
+                    owner: carrier,
+                    posX: carrier.posX,
+                    posY: carrier.posY,
+                    heading: carrier.heading,
+                    stealth: 0,
+                    maxHealth: 1,
+                    health: 1
+                });
+                countermeasure.flares.push({
+                    entity: decoy,
+                    life: countermeasure.flareLife
+                });
+            }
+        }
+    }
+
+    // Burns each decoy down, despawning it at zero; entries whose decoy a
+    // blast already removed just drop.
+    function age(dt: real) {
+        let changed = false;
+        for (let i = 0; i < countermeasure.flares.length; ++i) {
+            const entry = countermeasure.flares[i];
+            entry.life -= dt;
+            if (!countermeasure.world.entities.includes(entry.entity)) {
+                changed = true;
+                entry.life = 0;
+            } else if (entry.life <= 0) {
+                countermeasure.world.despawn(entry.entity);
+                changed = true;
+            }
+        }
+        if (changed)
+            countermeasure.flares = countermeasure.flares.filter(entry => entry.life > 0);
+    }
+}

--- a/app/briarthorn/qml/systems/SystemDetection.qml
+++ b/app/briarthorn/qml/systems/SystemDetection.qml
@@ -7,6 +7,8 @@ import "../model"
 // inside the radar volume (within half of radarFov off the nose and inside
 // sensor range) resolves to its true classification, side and heading,
 // anything else stays Unknown with the heading held at its last seen value.
+// The observer's own launches (missiles, decoys) are datalinked: always
+// resolved, no radar volume needed.
 // Tracks update in place — the list itself changes only when a contact first
 // appears, so views keyed on it stay stable.
 System {
@@ -29,10 +31,12 @@ System {
 
     function update(dt: real) {
         let changed = false;
+        const present = new Set();
         for (let i = 0; i < detection.entities.length; ++i) {
             const entity = detection.entities[i];
             if (entity === detection.observer)
                 continue;
+            present.add(entity.callsign);
             let track = detection.held[entity.callsign];
             if (track === undefined) {
                 track = detection.trackFactory.createObject(detection, {
@@ -45,11 +49,20 @@ System {
             const dy = entity.posY - detection.observer.posY;
             track.range = Math.hypot(dx, dy);
             track.azimuth = ((Math.atan2(dx, -dy) * 180 / Math.PI) % 360 + 360) % 360;
-            const seen = detection.detected(track);
+            const seen = entity.owner === detection.observer || detection.detected(track);
             track.classification = seen ? entity.classification : Classification.Kind.Unknown;
             track.side = seen ? entity.side : Side.Kind.Unknown;
             if (seen)
                 track.heading = entity.heading;
+        }
+        // Contacts gone from the world (detonated, killed, burned out) drop
+        // from the picture with their entity.
+        for (const contactId in detection.held) {
+            if (!present.has(contactId)) {
+                detection.held[contactId].destroy();
+                delete detection.held[contactId];
+                changed = true;
+            }
         }
         if (changed)
             detection.tracks = Object.values(detection.held);

--- a/app/briarthorn/qml/systems/SystemEngage.qml
+++ b/app/briarthorn/qml/systems/SystemEngage.qml
@@ -1,0 +1,47 @@
+import awen.entity
+import "../model"
+
+// AI trigger discipline: invokes the entity's named launch ability when its
+// target is alive, inside the radar cone and within engageRange — with a
+// holdoff between invocations on top of the ability's own cooldown, so the
+// magazine is not dumped in one pass.
+System {
+    id: engage
+
+    // The shooter and what it shoots at.
+    required property Entity entity
+    required property Entity target
+
+    // The launch ability invoked, by registry name.
+    property string ability: "guided"
+
+    // Maximum firing range, metres.
+    property real engageRange: 45000
+
+    // Minimum seconds between invocations.
+    property real holdoff: 6
+
+    property real timer: 0
+
+    function update(dt: real) {
+        engage.timer = Math.max(0, engage.timer - dt);
+        if (engage.timer > 0 || engage.target === null || engage.target.health <= 0)
+            return;
+        const dx = engage.target.posX - engage.entity.posX;
+        const dy = engage.target.posY - engage.entity.posY;
+        if (Math.hypot(dx, dy) > engage.engageRange)
+            return;
+        const bearing = Math.atan2(dx, -dy) * 180 / Math.PI;
+        const off = (((bearing - engage.entity.heading) % 360) + 540) % 360 - 180;
+        if (Math.abs(off) > engage.entity.radarFov / 2)
+            return;
+        for (let i = 0; i < engage.entity.abilities.length; ++i) {
+            const slot = engage.entity.abilities[i];
+            if (slot.def.name === engage.ability && slot.ready) {
+                slot.activate();
+                engage.timer = engage.holdoff;
+                return;
+            }
+        }
+    }
+}

--- a/app/briarthorn/qml/systems/SystemThreat.qml
+++ b/app/briarthorn/qml/systems/SystemThreat.qml
@@ -1,0 +1,45 @@
+import awen.entity
+import "../model"
+
+// Defensive reflex: pops the entity's flare once a hostile missile homing
+// on it closes inside threatRange, with a holdoff so consecutive pops give
+// each decoy a chance to steal the lock before the next one burns.
+System {
+    id: threat
+
+    // The defended entity and the world scanned for inbound rounds.
+    required property Entity entity
+    required property World world
+
+    // Metres at which an inbound homing round triggers a pop.
+    property real threatRange: 9000
+
+    // Minimum seconds between pops.
+    property real holdoff: 1.5
+
+    property real timer: 0
+
+    function update(dt: real) {
+        threat.timer = Math.max(0, threat.timer - dt);
+        if (threat.timer > 0)
+            return;
+        for (let i = 0; i < threat.world.entities.length; ++i) {
+            const missile = threat.world.entities[i];
+            if (missile.weapon === null || missile.weapon.target !== threat.entity)
+                continue;
+            const dx = missile.posX - threat.entity.posX;
+            const dy = missile.posY - threat.entity.posY;
+            if (Math.hypot(dx, dy) > threat.threatRange)
+                continue;
+            for (let j = 0; j < threat.entity.abilities.length; ++j) {
+                const slot = threat.entity.abilities[j];
+                if (slot.def instanceof AbilityFlare && slot.ready) {
+                    slot.activate();
+                    threat.timer = threat.holdoff;
+                    return;
+                }
+            }
+            return;
+        }
+    }
+}

--- a/app/briarthorn/qml/systems/SystemWeapon.qml
+++ b/app/briarthorn/qml/systems/SystemWeapon.qml
@@ -1,0 +1,256 @@
+import QtQml
+import awen.entity
+import "../model"
+
+// The weapon engine, ported from briardart's SystemWeapon: consumes raised
+// launch intents into missile entities, runs the guided seeker, trips the
+// proximity fuze, detonates — flat damage inside the blast radius — and
+// reaps spent rounds and killed entities. Runs after SystemMovement so fuze
+// checks see fresh poses; seeker steer lands next tick.
+System {
+    id: weapons
+
+    // The world this engine spawns into and reaps from.
+    required property World world
+
+    // Entities never despawned on zero health (the player's craft).
+    property list<Entity> invulnerable
+
+    // Blasts in progress, for the detonation animation.
+    property list<Detonation> detonations
+
+    // Seconds a recorded blast lives on screen.
+    property real detonationLife: 0.7
+
+    // Bearing error, in degrees, at which a seeker steers full deflection.
+    readonly property real cutAngle: 30
+
+    readonly property Component weaponFactory: Component {
+        Weapon {}
+    }
+
+    readonly property Component detonationFactory: Component {
+        Detonation {}
+    }
+
+    function update(dt: real) {
+        const spent = [];
+        const roster = weapons.world.entities.slice();
+        for (let i = 0; i < roster.length; ++i) {
+            if (roster[i].weapon !== null)
+                weapons.advance(roster[i], dt, spent);
+        }
+        weapons.consumeLaunches();
+        weapons.reap(spent);
+        weapons.ageDetonations(dt);
+    }
+
+    // One round's tick: seek, trip the fuze on a near non-owning entity (or
+    // on flight-time running out), and detonate once the fuze delay elapses.
+    function advance(missile: Entity, dt: real, spent: var) {
+        const w = missile.weapon;
+        w.elapsed += dt;
+        if (w.state === Weapon.State.Flying) {
+            if (w.def.guided)
+                weapons.seek(missile);
+            const near = w.def.guided ? w.target : weapons.nearestNonOwning(missile, w.def.fuzeRange);
+            const tripped = near !== null && near.health > 0 && weapons.dist(missile, near) <= w.def.fuzeRange;
+            if (tripped || w.elapsed >= w.def.duration) {
+                w.state = Weapon.State.Fuzing;
+                w.fuzeTarget = tripped ? near : null;
+                w.fuzeElapsed = 0;
+                missile.commandedSteer = 0;
+            }
+        } else {
+            w.fuzeElapsed += dt;
+            if (w.fuzeElapsed >= w.def.fuzeTime) {
+                weapons.detonate(missile);
+                spent.push(missile);
+            }
+        }
+    }
+
+    // The semi-active seeker: re-homes every tick on the loudest (lowest
+    // stealth) opposed return the owner's radar illuminates, inside
+    // seekerRange. No return leaves the round flying straight; a destroyed
+    // owner drops the illumination gate (plain homing).
+    function seek(missile: Entity) {
+        const w = missile.weapon;
+        const best = weapons.bestReturn(missile, missile.owner, missile.side, w.def.seekerRange);
+        w.target = best;
+        if (best === null) {
+            missile.commandedSteer = 0;
+            return;
+        }
+        const error = weapons.wrap180(weapons.bearingTo(missile, best) - missile.heading);
+        missile.commandedSteer = Math.max(-1, Math.min(1, error / weapons.cutAngle));
+    }
+
+    // Consumes raised launch intents: a guided round refuses (keeping its
+    // charge) without an illuminated return to lock; a kinetic round fires
+    // straight off the nose. The spawned missile inherits the launcher's
+    // side, owns nothing and flies at full throttle from the rail.
+    function consumeLaunches() {
+        const roster = weapons.world.entities.slice();
+        for (let i = 0; i < roster.length; ++i) {
+            const launcher = roster[i];
+            for (let j = 0; j < launcher.abilities.length; ++j) {
+                const slot = launcher.abilities[j];
+                if (!(slot.def instanceof AbilityLaunch) || !slot.pending)
+                    continue;
+                slot.pending = false;
+                if (!slot.ready)
+                    continue;
+                const row = Database.weaponDataFor(slot.def.weapon);
+                if (row === null)
+                    continue;
+                let target = null;
+                if (row.guided) {
+                    target = weapons.bestReturn(launcher, launcher, launcher.side, row.seekerRange);
+                    if (target === null)
+                        continue;
+                }
+                const missile = weapons.world.spawn("MSL", {
+                    classification: row.classification,
+                    side: launcher.side,
+                    owner: launcher,
+                    posX: launcher.posX,
+                    posY: launcher.posY,
+                    heading: target !== null ? weapons.bearingTo(launcher, target) : launcher.heading,
+                    radarFov: 360,
+                    kinetic: row.speed,
+                    maneuver: row.turnRate,
+                    durable: 1,
+                    stealth: 8,
+                    maxHealth: 20,
+                    health: 20,
+                    commandedThrottle: 1
+                });
+                missile.weapon = weapons.weaponFactory.createObject(missile, {
+                    def: row,
+                    target: target
+                });
+                slot.charges = slot.charges > 0 ? slot.charges - 1 : slot.charges;
+                slot.cooldownRemaining = slot.def.cooldown;
+            }
+        }
+    }
+
+    // The blast: record the detonation for the view, then flat damage to
+    // every entity inside blastRadius — sparing the round itself and its
+    // owner, briardart's self-frag protection.
+    function detonate(missile: Entity) {
+        const w = missile.weapon;
+        weapons.detonations = [...weapons.detonations, weapons.detonationFactory.createObject(weapons, {
+            worldX: missile.posX,
+            worldY: missile.posY,
+            blastRadius: w.def.blastRadius,
+            life: weapons.detonationLife,
+            maxLife: weapons.detonationLife
+        })];
+        for (let i = 0; i < weapons.world.entities.length; ++i) {
+            const struck = weapons.world.entities[i];
+            if (struck === missile || struck === missile.owner)
+                continue;
+            if (weapons.dist(missile, struck) <= w.def.blastRadius)
+                struck.health = Math.max(0, struck.health - w.def.damage);
+        }
+    }
+
+    // Despawns detonated rounds and anything killed this tick; entities
+    // never given hull (maxHealth 0) and the invulnerable list are exempt.
+    function reap(spent: var) {
+        const roster = weapons.world.entities.slice();
+        for (let i = 0; i < roster.length; ++i) {
+            const entity = roster[i];
+            if (spent.includes(entity))
+                weapons.world.despawn(entity);
+            else if (entity.maxHealth > 0 && entity.health <= 0 && !weapons.invulnerable.includes(entity))
+                weapons.world.despawn(entity);
+        }
+    }
+
+    function ageDetonations(dt: real) {
+        let expired = false;
+        for (let i = 0; i < weapons.detonations.length; ++i) {
+            weapons.detonations[i].life -= dt;
+            if (weapons.detonations[i].life <= 0)
+                expired = true;
+        }
+        if (expired) {
+            const dead = weapons.detonations.filter(d => d.life <= 0);
+            weapons.detonations = weapons.detonations.filter(d => d.life > 0);
+            dead.forEach(d => d.destroy());
+        }
+    }
+
+    // The loudest opposed live return within range of at, gated by the
+    // illuminator's radar cone; ties break to the nearest.
+    function bestReturn(at: Entity, illuminator: Entity, side: int, range: real): Entity {
+        let best = null;
+        let bestDist = 0;
+        for (let i = 0; i < weapons.world.entities.length; ++i) {
+            const contact = weapons.world.entities[i];
+            if (contact === at || contact === illuminator || contact.health <= 0)
+                continue;
+            if (!weapons.opposed(side, contact.side))
+                continue;
+            const d = weapons.dist(at, contact);
+            if (d > range || !weapons.illuminated(illuminator, contact))
+                continue;
+            if (best === null || contact.stealth < best.stealth || (contact.stealth === best.stealth && d < bestDist)) {
+                best = contact;
+                bestDist = d;
+            }
+        }
+        return best;
+    }
+
+    // The nearest live entity the round's owner does not also own — the
+    // proximity-fuze trigger set for a kinetic round.
+    function nearestNonOwning(missile: Entity, range: real): Entity {
+        let best = null;
+        let bestDist = range;
+        for (let i = 0; i < weapons.world.entities.length; ++i) {
+            const contact = weapons.world.entities[i];
+            if (contact === missile || contact === missile.owner || contact.health <= 0)
+                continue;
+            if (missile.owner !== null && contact.owner === missile.owner)
+                continue;
+            const d = weapons.dist(missile, contact);
+            if (d <= bestDist) {
+                best = contact;
+                bestDist = d;
+            }
+        }
+        return best;
+    }
+
+    // Whether the illuminator's radar cone paints the contact; a missing
+    // illuminator is lenient, per briardart.
+    function illuminated(illuminator: Entity, contact: Entity): bool {
+        if (illuminator === null)
+            return true;
+        const off = weapons.wrap180(weapons.bearingTo(illuminator, contact) - illuminator.heading);
+        return Math.abs(off) <= illuminator.radarFov / 2;
+    }
+
+    // Whether two sides shoot at each other: ownship and friendly versus
+    // hostile; unknowns and neutrals engage no one.
+    function opposed(a: int, b: int): bool {
+        const friend = s => s === Side.Kind.Ownship || s === Side.Kind.Friendly;
+        return (friend(a) && b === Side.Kind.Hostile) || (a === Side.Kind.Hostile && friend(b));
+    }
+
+    function bearingTo(from: Entity, to: Entity): real {
+        return Math.atan2(to.posX - from.posX, -(to.posY - from.posY)) * 180 / Math.PI;
+    }
+
+    function wrap180(angle: real): real {
+        return ((angle % 360) + 540) % 360 - 180;
+    }
+
+    function dist(a: Entity, b: Entity): real {
+        return Math.hypot(b.posX - a.posX, b.posY - a.posY);
+    }
+}

--- a/app/briarthorn/qml/themes/Aurora.qml
+++ b/app/briarthorn/qml/themes/Aurora.qml
@@ -27,4 +27,5 @@ QtObject {
     property color cursorFree: "#FFFFC23D"
     property color cursorLatched: "#FF6CFBFF"
     property color detonation: "#FFFF6FA8"
+    property color flare: "#FFFFC23D"
 }

--- a/app/briarthorn/qml/ui/SymbolFlare.qml
+++ b/app/briarthorn/qml/ui/SymbolFlare.qml
@@ -1,0 +1,93 @@
+import QtQuick
+import "../themes"
+
+// A deployed countermeasure flare on the scope: briardart's burning radar
+// lure (scope_component._drawFlare) reduced to its quiet form — a steady hot
+// gold point source with a faint glow, inside a single expanding, fading
+// heat ring. Side-agnostic: burning magnesium reads the same whoever dropped
+// it. Centre it on the plot point like Symbol.
+Item {
+    id: symbol
+
+    // Symbol size in px before the flare's own scale; the heat ring swells
+    // to roughly this footprint.
+    property real symbolSize: 36
+
+    width: symbolSize * 0.9
+    height: width
+
+    // The heat ring: born at the core, swelling to the rim and fading out.
+    Rectangle {
+        id: ring
+        anchors.centerIn: parent
+        width: parent.width
+        height: width
+        radius: width / 2
+        color: "transparent"
+        border.color: Style.theme.warn
+        border.width: Math.max(1.5, symbol.width * 0.045)
+
+        SequentialAnimation {
+            running: symbol.visible
+            loops: Animation.Infinite
+
+            ParallelAnimation {
+                NumberAnimation {
+                    target: ring
+                    property: "scale"
+                    from: 0.3
+                    to: 1
+                    duration: 900
+                    easing.type: Easing.OutQuad
+                }
+                NumberAnimation {
+                    target: ring
+                    property: "opacity"
+                    from: 0.9
+                    to: 0
+                    duration: 900
+                    easing.type: Easing.OutQuad
+                }
+            }
+            PauseAnimation {
+                duration: 150
+            }
+        }
+    }
+
+    // A soft standing glow seating the core on the dark scope.
+    Rectangle {
+        anchors.centerIn: parent
+        width: symbol.width * 0.5
+        height: width
+        radius: width / 2
+        color: Style.theme.flare
+        opacity: 0.18
+    }
+
+    // The hot core, burning with a fast subtle flicker.
+    Rectangle {
+        id: core
+        anchors.centerIn: parent
+        width: symbol.width * 0.24
+        height: width
+        radius: width / 2
+        color: Style.theme.flare
+
+        SequentialAnimation on opacity {
+            running: symbol.visible
+            loops: Animation.Infinite
+
+            NumberAnimation {
+                from: 1
+                to: 0.75
+                duration: 200
+            }
+            NumberAnimation {
+                from: 0.75
+                to: 1
+                duration: 200
+            }
+        }
+    }
+}

--- a/app/briarthorn/qml/ui/ViewEngagements.qml
+++ b/app/briarthorn/qml/ui/ViewEngagements.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import QtQuick.Shapes
+import awen.shapes
+import "../model"
+import "../themes"
+
+// The engagement overlay: a dashed line from each fuzing missile to the
+// entity its fuze tripped on, and every blast as a ring expanding to true
+// scale while it fades. Ground-truth world positions plotted about the
+// observer and rotated as one picture, exactly like ViewTracks.
+Item {
+    id: view
+
+    // The observer at the scope centre.
+    property Entity observer
+
+    // The world's entities, scanned for fuzing missiles.
+    property list<Entity> entities
+
+    // Blasts in progress, from the weapon engine.
+    property list<Detonation> detonations
+
+    // Scope centre in item coordinates and the world-to-screen scale.
+    property real centerX: width / 2
+    property real centerY: height / 2
+    property real pxPerMeter: 0
+
+    // Screen rotation of the picture about the scope centre.
+    property real viewRotation: 0
+
+    transform: Rotation {
+        origin.x: view.centerX
+        origin.y: view.centerY
+        angle: view.viewRotation
+    }
+
+    // A world point's screen position about the observer (north-up; the
+    // container rotation turns the picture heading-up).
+    function sx(worldX: real): real {
+        return view.centerX + (worldX - view.observer.posX) * view.pxPerMeter;
+    }
+    function sy(worldY: real): real {
+        return view.centerY + (worldY - view.observer.posY) * view.pxPerMeter;
+    }
+
+    // The fuzing lines.
+    Repeater {
+        model: view.entities
+        delegate: ShapeLink {
+            required property Entity modelData
+
+            readonly property Weapon armed: modelData.weapon
+            readonly property bool fuzing: armed !== null && armed.state === Weapon.State.Fuzing && armed.fuzeTarget !== null
+
+            visible: fuzing
+            from: fuzing ? Qt.point(view.sx(modelData.posX), view.sy(modelData.posY)) : Qt.point(0, 0)
+            to: fuzing ? Qt.point(view.sx(armed.fuzeTarget.posX), view.sy(armed.fuzeTarget.posY)) : Qt.point(0, 0)
+            fromControl: from
+            toControl: to
+            strokeColor: Style.theme.detonation
+            strokeWidth: 1.5
+            strokeStyle: ShapePath.DashLine
+            dashPattern: [3, 2]
+        }
+    }
+
+    // The blast rings: expanding toward blastRadius as life runs down,
+    // fading with the remaining fraction.
+    Repeater {
+        model: view.detonations
+        delegate: Rectangle {
+            required property Detonation modelData
+
+            readonly property real growth: 1 - modelData.life / modelData.maxLife
+
+            x: view.sx(modelData.worldX) - width / 2
+            y: view.sy(modelData.worldY) - height / 2
+            width: modelData.blastRadius * view.pxPerMeter * 2 * growth
+            height: width
+            radius: width / 2
+            color: "transparent"
+            border.color: Style.theme.detonation
+            border.width: 2
+            opacity: modelData.life / modelData.maxLife
+        }
+    }
+}

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -24,6 +24,12 @@ Item {
     // The contact picture, plotted at each track's azimuth and range.
     property list<Track> tracks
 
+    // Engagement truth for the overlay: the world's entities (scanned for
+    // fuzing missiles) and the blasts in progress. Optional — leave empty
+    // (and showEngagements off) for a clean overview.
+    property list<Entity> entities
+    property list<Detonation> detonations
+
     // Geometry. The outer ring's radius is a fraction of the short side; the
     // centre drops by verticalShift (and slides by horizontalShift) so the
     // attack scope can push ownship down and crop the rear off the bottom edge.
@@ -50,6 +56,7 @@ Item {
     property bool showInnerRing: true
     property bool showTicks: true
     property bool showRadarCone: true
+    property bool showEngagements: true
     property bool showOwnship: true
     property bool showOwnshipPulse: true
     property bool showTrackLabels: true
@@ -141,6 +148,20 @@ Item {
         symbolSize: view.symbolSize
         showLabels: view.showTrackLabels
         clampRadius: view.rimClamp ? view.outerRadius : 0
+    }
+
+    // Fuzing lines and blast rings, over the tracks in the same rotated
+    // observer frame.
+    ViewEngagements {
+        anchors.fill: parent
+        visible: view.showEngagements
+        observer: view.observer
+        entities: view.entities
+        detonations: view.detonations
+        centerX: view.centerX
+        centerY: view.centerY
+        pxPerMeter: view.pxPerMeter
+        viewRotation: view.viewRotation
     }
 
     // Ownship, pinned at the scope centre; nose up on a heading-up scope.

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -37,7 +37,8 @@ Item {
 
     Repeater {
         model: view.tracks
-        delegate: Symbol {
+        delegate: Loader {
+            id: mark
             required property Track modelData
 
             readonly property real azimuthRad: modelData.azimuth * Math.PI / 180
@@ -48,13 +49,29 @@ Item {
 
             x: view.centerX + Math.sin(azimuthRad) * screenRange - width / 2
             y: view.centerY - Math.cos(azimuthRad) * screenRange - height / 2
-            symbolSize: view.symbolSize
-            noseAngle: modelData.heading
-            viewRotation: view.viewRotation
-            classification: modelData.classification
-            side: modelData.side
-            showLabel: view.showLabels
-            label: modelData.classification === Classification.Kind.Unknown ? "" : modelData.contactId
+
+            // A contact classified as a countermeasure plots as a burning
+            // flare, no faction symbol or label — briardart skips the symbol
+            // the same way. Everything else keeps the classification mark.
+            sourceComponent: mark.modelData.classification === Classification.Kind.Decoy ? mark.flareMark : mark.symbolMark
+
+            readonly property Component symbolMark: Component {
+                Symbol {
+                    symbolSize: view.symbolSize
+                    noseAngle: mark.modelData.heading
+                    viewRotation: view.viewRotation
+                    classification: mark.modelData.classification
+                    side: mark.modelData.side
+                    showLabel: view.showLabels
+                    label: mark.modelData.classification === Classification.Kind.Unknown ? "" : mark.modelData.contactId
+                }
+            }
+
+            readonly property Component flareMark: Component {
+                SymbolFlare {
+                    symbolSize: view.symbolSize
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Briarthorn learns to fight: entities carry invocable abilities, missiles fly and fuze, flares decoy seekers, and the scope renders the engagement. Ported from briardart's ability/entity definition architecture, adapted to briarthorn's direct-SI-stats style.

## Abilities
- `Ability` definition rows (cooldown/charges) in an `Abilities` singleton registry, with `AbilityLaunch` (guided/kinetic missile) and `AbilityFlare`; per-entity live state on `AbilitySlot`.
- `slot.activate()` is the one entry point player input and AI share: SPACE/E/F (and gamepad RB/West/South) post an `ability` command that StoreGame routes to ownship's slot; the bandit's `SystemEngage` (fires inside its radar cone and engage range) and `SystemThreat` (auto-flares against inbound homing rounds) call the same method.

## Weapons
- `DataWeapon` definition rows in the Database (speed, seeker, fuze, warhead); missiles and decoys spawn from them into a new `World` model that owns the roster and despawn authority.
- `SystemWeapon` runs the whole lifecycle: launch consumption, the semi-active seeker — a guided round re-homes on the loudest return only while its **owner's radar FOV illuminates it**, and flies straight otherwise — the proximity fuze (kinetic trips on the nearest non-owning entity, guided on its lock), timed fuzing, flat blast damage sparing the owner, and reaping of spent rounds and kills.
- `SystemCountermeasure` pops stealth-0 same-side decoys that outshine everything and steal seeker locks, then burns them out.
- The observer's own launches are datalinked: `SystemDetection` resolves them unconditionally, so your flares and missiles never plot as unknown contacts; it also drops tracks whose entity left the world.

## Rendering
- `ViewEngagements` overlays the scope in the shared rotated observer frame: a dashed fuzing line from missile to fuze target, and detonations as true-scale rings expanding and fading.
- Flares plot as a burning spark — gold flickering core inside an expanding heat ring (`SymbolFlare`), swapped in for the faction symbol on countermeasure tracks the way briardart does.

Verified live on the Windows build with scripted engagements (launch, guidance, decoying, fuze line, blast rings, exact 55/80 damage on the hull gauge, kill reaping and track pruning); all 98 ctest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)