### PR TITLE
Add per-app qmlpreview targets and VS Code tasks for QML live reload

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,33 @@
             "group": "build",
             "detail": "Build the awen sample app with the selected CMake preset",
             "problemMatcher": []
+        },
+        {
+            // Builds the app and runs it under Qt's qmlpreview, which pushes
+            // every QML edit into the running app — no rebuild, no debugger.
+            // The CMake target holds the path to the tool, which differs
+            // between a prebuilt Qt kit and vcpkg's Qt; run it from
+            // Terminal > Run Task. Keep a *-debug preset selected: without
+            // QT_QML_DEBUG the app has no debug connection for qmlpreview to
+            // push into, and it just runs.
+            "type": "cmake",
+            "label": "qmlpreview: briarthorn",
+            "command": "build",
+            "targets": [
+                "briarthorn-qmlpreview"
+            ],
+            "detail": "Run briarthorn under qmlpreview, live-reloading QML edits",
+            "problemMatcher": []
+        },
+        {
+            "type": "cmake",
+            "label": "qmlpreview: awen",
+            "command": "build",
+            "targets": [
+                "awen-qmlpreview"
+            ],
+            "detail": "Run the awen sample app under qmlpreview, live-reloading QML edits",
+            "problemMatcher": []
         }
     ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,16 @@ assembles the APK).
   QML edit trips MSVC C4702 in Qt headers under /WX, that warning is already
   disabled on the briarthorn target.
 - Desktop **debug** builds instead load `Main.qml` from the source tree, so
-  `qmlpreview <build dir>/briarthorn.exe` live-reloads QML edits with no
-  rebuild. The `qmldir` beside each of briarthorn's singleton folders is what
-  makes them resolve on that path, and a file using a type from another folder
-  must directory-import it (`import "../themes"`) rather than lean on the
-  compiled module — mirror singleton changes into `QML_SINGLETONS` too.
+  qmlpreview live-reloads QML edits with no rebuild: build the
+  `briarthorn-qmlpreview` target (`cmake --build --preset windows-msvc-debug
+  --target briarthorn-qmlpreview`, or the `qmlpreview: briarthorn` task), which
+  runs the app under the tool. `cmake/target/qmlpreview.cmake` locates
+  qmlpreview — it is not an imported target, and vcpkg puts it in
+  `tools/Qt6/bin` rather than the kit's `bin`. The `qmldir` beside each of
+  briarthorn's singleton folders is what makes them resolve on that path, and a
+  file using a type from another folder must directory-import it (`import
+  "../themes"`) rather than lean on the compiled module — mirror singleton
+  changes into `QML_SINGLETONS` too.
 - The same connection carries QML/JavaScript debugging: `.vscode/launch.json`
   drives the Qt Qml extension (QML-only, plus a compound that pairs it with the
   C++ debugger), building through the `cmake: build briarthorn` task. Both need

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,10 @@ include(cmake/qt-build-tree-conf.cmake)
 # src/ and app/.
 include(cmake/awen-target.cmake)
 
+# The <app>-qmlpreview targets awen_add_executable registers; after
+# find_package(Qt6), whose QT6_INSTALL_PREFIX locates the tool.
+include(cmake/target/qmlpreview.cmake)
+
 add_subdirectory(src)
 add_subdirectory(app)
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,19 @@ configuration in the Run and Debug view:
 The MSVC variant of the combined session uses the C/C++ extension's `cppvsdbg`;
 the others use CodeLLDB.
 
-**qmlpreview** — `qmlpreview <build dir>/briarthorn` live-reloads QML edits into
-the running app, with no debugger attached.
+**qmlpreview** — live-reloads QML edits into the running app, with no debugger
+attached. Each app gets an `<app>-qmlpreview` target that builds it and runs it
+under the tool, so nothing has to know where Qt keeps qmlpreview (`bin/` in a
+prebuilt kit, `tools/Qt6/bin` with vcpkg's Qt):
+
+```sh
+cmake --build --preset windows-msvc-debug --target briarthorn-qmlpreview
+```
+
+In VS Code the same targets are the `qmlpreview: briarthorn` and
+`qmlpreview: awen` entries under **Terminal > Run Task**. Edit any file under
+[app/briarthorn/qml](app/briarthorn/qml) while it runs and the app reloads it;
+errors from a reload print in that terminal.
 
 Outside either tool, start the app yourself and connect any Qt debug client:
 

--- a/cmake/awen-target.cmake
+++ b/cmake/awen-target.cmake
@@ -106,6 +106,12 @@ function(awen_add_executable target)
         MACOSX_BUNDLE TRUE
     )
 
+    # <target>-qmlpreview, the live-reload run. Desktop only: the cross builds
+    # run on a device with no source tree to reload from.
+    if(NOT EMSCRIPTEN AND NOT ANDROID)
+        awen_add_qmlpreview_target(${target})
+    endif()
+
     if(EMSCRIPTEN)
         # Embed ":/qt/etc/qt.conf" so QLibraryInfo skips getRelocatablePrefix(),
         # whose debug-only assert aborts this static wasm build at startup.

--- a/cmake/target/qmlpreview.cmake
+++ b/cmake/target/qmlpreview.cmake
@@ -1,0 +1,50 @@
+# Per-app "run under qmlpreview" targets. qmlpreview starts the app with Qt's
+# QML debug connection open and pushes edited QML files into it, so a running
+# app picks up QML edits with no rebuild.
+#
+# Unlike the Qt build tools (qmlcachegen, moc, ...) qmlpreview is not exported
+# as an imported target, so it has to be found on disk: a prebuilt kit keeps it
+# in bin/, while vcpkg relocates the Qt tools to tools/Qt6/bin. Include after
+# find_package(Qt6), which is what defines QT6_INSTALL_PREFIX.
+find_program(QMLPREVIEW_EXECUTABLE
+    NAMES qmlpreview
+    HINTS
+        "${QT6_INSTALL_PREFIX}/${QT6_INSTALL_BINS}"
+        "${QT6_INSTALL_PREFIX}/tools/Qt6/bin"
+    DOC "Qt's QML preview tool, which live-reloads QML into a running app"
+)
+
+if(NOT QMLPREVIEW_EXECUTABLE)
+    message(STATUS "qmlpreview executable not found - the <app>-qmlpreview targets will be skipped.")
+endif()
+
+# Adds <target>-qmlpreview: build the app, then run it under qmlpreview. Live
+# reload wants a Debug build, which is where the apps define QT_QML_DEBUG (no
+# debug connection without it) and load Main.qml from the source tree (the
+# engine only reloads QML that came from a file URL).
+function(awen_add_qmlpreview_target target)
+    if(NOT QMLPREVIEW_EXECUTABLE)
+        return()
+    endif()
+
+    # Without QT_QML_DEBUG the app has no debug connection, so it starts,
+    # silently ignores the -qmljsdebugger argument qmlpreview passes it, and no
+    # edit ever arrives. The run is harmless, so warn and go ahead.
+    set(warning "")
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(warning COMMAND ${CMAKE_COMMAND} -E echo
+            "warning: not a Debug build - QT_QML_DEBUG is Debug-only, so QML edits will not reload")
+    endif()
+
+    # USES_TERMINAL so the app's output streams to the terminal as it runs
+    # instead of arriving buffered at exit, and Ctrl+C reaches the app.
+    add_custom_target(${target}-qmlpreview
+        ${warning}
+        COMMAND ${QMLPREVIEW_EXECUTABLE} $<TARGET_FILE:${target}>
+        USES_TERMINAL
+        COMMENT "Running ${target} under qmlpreview - edit its QML to reload it"
+        VERBATIM
+    )
+
+    add_dependencies(${target}-qmlpreview ${target})
+endfunction()


### PR DESCRIPTION
Adds a first-class way to launch an app under Qt's `qmlpreview`, which pushes QML
edits into the running app with no rebuild and no debugger attached. The debug
source-tree load that makes this work has been in place since the QML debugging
PR; this wires a target and a task to it so it is one click rather than a
remembered command line with a machine-specific path in it.

## What's here

- **`cmake/target/qmlpreview.cmake`** — finds the tool and defines
  `awen_add_qmlpreview_target()`. qmlpreview is the one Qt tool that is *not*
  exported as an imported target (there is no `Qt6::qmlpreview` beside
  `Qt6::qmlcachegen`), so it has to be found on disk. The two hints cover both Qt
  sources this repo supports: a prebuilt kit keeps it in `bin/`, vcpkg relocates
  the Qt tools to `tools/Qt6/bin`.
- **`awen_add_executable`** now registers `<target>-qmlpreview` on desktop, so
  both apps get one: `briarthorn-qmlpreview` and `awen-qmlpreview`.
- **`.vscode/tasks.json`** — `qmlpreview: briarthorn` and `qmlpreview: awen`,
  under Terminal > Run Task.

From the CLI it is the same target:

```sh
cmake --build --preset windows-msvc-debug --target briarthorn-qmlpreview
```

Tasks rather than launch configurations, deliberately: a launch configuration
needs a debug adapter, qmlpreview owns the app process itself, and it competes
with the Qt Qml extension for the single debug connection — so it is not
something you would ever run alongside the existing `briarthorn (QML/JS)`
configuration.

Off a Debug build the app has no `QT_QML_DEBUG`, so it silently ignores the
`-qmljsdebugger` argument qmlpreview starts it with and no edit ever arrives —
verified, there is no Qt-side message at all. The target prints a warning in that
case and runs anyway.

## Verification

Run headless (`QT_QPA_PLATFORM=minimal`) so nothing stole window focus.

- **Live reload proven, not assumed.** With briarthorn running under qmlpreview,
  appending a deliberate syntax error to `Main.qml` made the *running* app report
  `Main.qml:397:1: Syntax error` — the edited bytes reached the engine. `Main.qml`
  was restored byte-for-byte afterwards.
- **The target itself:** `cmake --build --target briarthorn-qmlpreview` rebuilt
  the app, launched it under the tool, and `QML debugging is enabled` appeared on
  the connection.
- **Release:** configures, runs, and prints the warning above.
- `ctest --preset windows-msvc-debug`: 98/98 passed.

## On the vcpkg side

No manifest change was needed. qmlpreview ships on both Qt paths: the prebuilt
kit's `bin/`, and vcpkg's qtdeclarative port, which lists it in `TOOL_NAMES` and
stages it to `tools/Qt6/bin` — confirmed against the port's own installed-file
manifest and against the staged `qtdeclarative_x64-windows-release` package, this
repo's native desktop release triplet.

Worth recording, since it is easy to trip over: a build that finds a prebuilt kit
has *no* Qt in `vcpkg_installed` at all — `qt-source.cmake` sets
`VCPKG_MANIFEST_NO_DEFAULT_FEATURES`, and qtdeclarative lives inside that feature.
So qmlpreview is legitimately absent from `vcpkg_installed` on the prebuilt path,
and the `find_program` hints are what bridge the two layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
