### PR TITLE
Light the controller lamp for a gamepad connected before launch

### DIFF
--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -68,7 +68,10 @@ Window {
     Item {
         id: scene
 
-        property bool padConnected: false
+        // Read off the live device set rather than accumulated from the connect
+        // edge: a controller plugged in before launch is opened before this item
+        // ever attaches, so there is no edge left for it to catch.
+        readonly property bool padConnected: Gamepad.devices.length > 0
 
         anchors.fill: parent
         focus: !settings.open // the window's keys go here unless the page has them
@@ -96,8 +99,6 @@ Window {
                 event.accepted = actions.keyReleased(event.key);
         }
 
-        Gamepad.onConnected: deviceId => scene.padConnected = true
-        Gamepad.onDisconnected: deviceId => scene.padConnected = false
         // Controller events ignore focus entirely, so handing the page the
         // keyboard is not enough — the pad route is switched here instead.
         Gamepad.onAxisChanged: (deviceId, axis, value) => {

--- a/src/awen/gamepad/Gamepad.cpp
+++ b/src/awen/gamepad/Gamepad.cpp
@@ -54,3 +54,18 @@ auto Gamepad::setIdlePollInterval(int intervalMs) -> void
     idlePollInterval_ = interval;
     emit idlePollIntervalChanged();
 }
+
+auto Gamepad::devices() const -> QList<int>
+{
+    return devices_;
+}
+
+auto Gamepad::setDevices(const QList<int>& devices) -> void
+{
+    if (devices == devices_)
+    {
+        return;
+    }
+    devices_ = devices;
+    emit devicesChanged();
+}

--- a/src/awen/gamepad/Gamepad.h
+++ b/src/awen/gamepad/Gamepad.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QtQml/qqmlregistration.h>
+#include <QList>
 #include <QObject>
 
 #include <chrono>
@@ -38,6 +39,12 @@ namespace awen
         /// @brief Milliseconds between polls while no controller is connected or
         /// the app is inactive; clamped and engine-wide like pollInterval.
         Q_PROPERTY(int idlePollInterval READ idlePollInterval WRITE setIdlePollInterval NOTIFY idlePollIntervalChanged)
+
+        /// @brief The ids of the controllers connected right now, ascending. An
+        /// item that attaches after a controller was opened has already missed
+        /// that controller's connected edge, so bind state to this rather than
+        /// accumulate it from the edges.
+        Q_PROPERTY(QList<int> devices READ devices NOTIFY devicesChanged)
 
     public:
         /// @brief A gamepad button, matching SDL's SDL_GamepadButton values.
@@ -105,9 +112,18 @@ namespace awen
         [[nodiscard]] auto idlePollInterval() const -> int;
         auto setIdlePollInterval(int intervalMs) -> void;
 
+        [[nodiscard]] auto devices() const -> QList<int>;
+
+        /// @brief Mirror the backend's set of open controllers onto this instance;
+        /// called by attachGamepad to seed it and on every hotplug to keep it in
+        /// step. Not reachable from QML, where devices is read-only.
+        /// @param devices The ids of the controllers now connected, ascending.
+        auto setDevices(const QList<int>& devices) -> void;
+
     signals:
         /// @brief A controller was plugged in / unplugged. @p deviceId identifies
-        /// it in the axis and button signals.
+        /// it in the axis and button signals. These are edges only: what is
+        /// connected right now is the devices property.
         void connected(int deviceId);
         void disconnected(int deviceId);
 
@@ -124,9 +140,11 @@ namespace awen
 
         void pollIntervalChanged();
         void idlePollIntervalChanged();
+        void devicesChanged();
 
     private:
         std::chrono::milliseconds pollInterval_{DefaultPollInterval};         ///< See pollInterval.
         std::chrono::milliseconds idlePollInterval_{DefaultIdlePollInterval}; ///< See idlePollInterval.
+        QList<int> devices_;                                                  ///< See devices.
     };
 }

--- a/src/awen/gamepad/GamepadSource.cpp
+++ b/src/awen/gamepad/GamepadSource.cpp
@@ -3,9 +3,11 @@
 #include "GamepadBackend.h"
 #include "GamepadTranslate.h"
 
+#include <algorithm>
 #include <unordered_map>
 
 #include <QGuiApplication>
+#include <QList>
 #include <QQmlEngine>
 #include <QString>
 #include <QTimer>
@@ -83,8 +85,10 @@ namespace
             timer_->start(pollInterval_);
             // Drop to the idle heartbeat promptly when the app deactivates.
             connect(qApp, &QGuiApplication::applicationStateChanged, this, [this] { updatePollRate(); });
-            // Drain once now to open any controller already attached at startup.
-            poll();
+            // Deliberately no drain here: SDL_Init has already queued an ADDED
+            // event for every controller present at startup, and this runs from
+            // the first attach, before QML binds that item's handlers — draining
+            // now would announce them to nobody. The first tick does it instead.
         }
 
         ~GamepadSource() override
@@ -121,6 +125,22 @@ namespace
         {
             idlePollInterval_ = interval;
             updatePollRate();
+        }
+
+        /// @brief The ids of the gamepads open right now, ascending — what a
+        /// Gamepad attaching later seeds its devices property from.
+        [[nodiscard]] auto devices() const -> QList<int>
+        {
+            auto ids = QList<int>{};
+            ids.reserve(static_cast<qsizetype>(gamepads_.size()));
+            for (const auto& entry : gamepads_)
+            {
+                ids.append(static_cast<int>(entry.first));
+            }
+            // The map iterates in no set order; sort so the property reads the
+            // same list every time and only really changes on a hotplug.
+            std::sort(ids.begin(), ids.end());
+            return ids;
         }
 
     signals:
@@ -253,14 +273,30 @@ auto awen::attachGamepad(Gamepad* gamepad, QObject* attachee) -> void
         return;
     }
 
-    QObject::connect(source, &GamepadSource::connected, gamepad, &Gamepad::connected);
-    QObject::connect(source, &GamepadSource::disconnected, gamepad, &Gamepad::disconnected);
+    // The device set updates before the edge, so a connected handler already sees
+    // the new controller in devices.
+    QObject::connect(source, &GamepadSource::connected, gamepad,
+                     [gamepad, source](int deviceId)
+                     {
+                         gamepad->setDevices(source->devices());
+                         emit gamepad->connected(deviceId);
+                     });
+    QObject::connect(source, &GamepadSource::disconnected, gamepad,
+                     [gamepad, source](int deviceId)
+                     {
+                         gamepad->setDevices(source->devices());
+                         emit gamepad->disconnected(deviceId);
+                     });
     QObject::connect(source, &GamepadSource::buttonPressed, gamepad,
                      [gamepad](int deviceId, int button) { emit gamepad->buttonPressed(deviceId, static_cast<Gamepad::Button>(button)); });
     QObject::connect(source, &GamepadSource::buttonReleased, gamepad,
                      [gamepad](int deviceId, int button) { emit gamepad->buttonReleased(deviceId, static_cast<Gamepad::Button>(button)); });
     QObject::connect(source, &GamepadSource::axisChanged, gamepad, [gamepad](int deviceId, int axis, double value)
                      { emit gamepad->axisChanged(deviceId, static_cast<Gamepad::Axis>(axis), value); });
+
+    // A controller opened before this instance existed has no edge left to fire,
+    // so hand over the set the source already holds.
+    gamepad->setDevices(source->devices());
 
     // Cadence writes pass through to the shared source (engine-wide, last write
     // wins). Wired before QML can assign, so no initial push is needed.


### PR DESCRIPTION
The "controller connected" lamp never lit for a pad that was already plugged in when the app started, even though axis events streamed from that same device.

## Root cause

`GamepadSource`'s constructor ended with a `poll()` to open any controller present at startup. That constructor runs from `sourceFor()` inside `attachGamepad()`, which is called from the `Gamepad` constructor — so the drain opened the pad and emitted `connected` before `attachGamepad` had wired a single connection, let alone before QML bound the item's `Gamepad.onConnected` handler. The edge went to nobody, and there was no way to ask what was connected.

## Changes

- `GamepadSource.cpp`: no drain in the constructor. SDL has already queued an `ADDED` event per present controller, so leaving it for the first timer tick (8 ms, once the event loop runs) means the edge lands after handlers exist.
- `Gamepad`: new read-only `devices` property (`QList<int>`, ascending ids) with `devicesChanged`, plus a `setDevices` backend hook. `attachGamepad` seeds each instance from the source and refreshes it before re-emitting an edge, so an `onConnected` handler already sees the new id — and an item attached long after a pad was opened (a Loader, a page created later) still knows about it. The android stub is untouched; `devices` simply stays empty there.
- briarthorn: the lamp binds to `Gamepad.devices.length > 0` instead of accumulating state from the two edge handlers.

## Verification

Windows debug build, Xbox pad connected before launch, temporary logging in `Main.qml`:

```
qml: VERIFY completed devices: [] padConnected: false
qml: VERIFY padConnected -> true devices: [1]
qml: VERIFY connected edge: 1
```

Empty at `Component.onCompleted` (the source has not ticked yet), then the first tick opens the pad, `devices` becomes `[1]`, and the `connected` edge — which previously never fired — reaches the QML handler. Lamp confirmed lit by screenshot of the final binary. `ctest` 98/98, `qmllint-check` and `clang-format-check` clean.

No new unit test: the change is the SDL/QML edge, not `awen-gamepad-core`, so there is nothing new for the core's gtest binary to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)