### PR TITLE
Apply the week's code-review fixes

### DIFF
--- a/app/awen/Main.qml
+++ b/app/awen/Main.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import awen.entity
 import awen.shapes

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -78,6 +78,11 @@ Window {
         // ever attaches, so there is no edge left for it to catch.
         readonly property bool padConnected: Gamepad.devices.length > 0
 
+        // The one side both round corner instruments (condition gauge, minimap)
+        // draw at, floored where the readouts inside them would shrink
+        // illegible — a single property, so the pair stays a pair structurally.
+        readonly property real instrumentSide: Math.max(110, Math.min(root.width, root.height) * 0.22)
+
         anchors.fill: parent
         focus: !settings.open // the window's keys go here unless the page has them
 
@@ -383,14 +388,10 @@ Window {
         }
 
         // Ownship condition readout, top-left: a round dual-arc gauge (hull +
-        // fuel) sized to the minimap opposite, so the two round instruments read
-        // as a matched, compact pair. Dropped below the top band. The floor is
-        // what stops shrinking before the readouts inside do — the gauge sizes
-        // its own numbers off its short side, so a window small enough to take
-        // the instrument under it takes the numbers with it. The minimap carries
-        // the same floor to keep the pair a pair.
+        // fuel) on the shared instrument side, so it and the minimap opposite
+        // read as a matched, compact pair. Dropped below the top band.
         ViewStatus {
-            width: Math.max(110, Math.min(root.width, root.height) * 0.22)
+            width: scene.instrumentSide
             height: width
             ownship: game.ownship
 
@@ -403,19 +404,20 @@ Window {
         }
 
         // The ability rack, bottom-right: one square button per carried
-        // ability, each capped with the key or the pad button that fires it. It
-        // posts the same ability record the key and pad bindings post, so it
-        // adds no second invocation path. A thumb landing on one hands the HUD
-        // back to the touch controls.
-        //
-        // Docked in the corner rather than centred, and deliberately: the
-        // scope's centre column carries ownship, its acquisition pulse, the
-        // decoys it sheds astern and the sector this scenario's pursuer
-        // converges through, and a centred rack sits on all four at once. The
-        // buttons are captions and clocks — a key or a pad button is what
-        // actually fires an ability — so the rack is what gives way.
+        // ability, capped with the key or pad button that fires it and posting
+        // the same ability record those bindings post — no second invocation
+        // path. A thumb landing on one hands the HUD back to the touch
+        // controls. Docked in the corner rather than centred: the scope's
+        // centre column carries ownship, its pulse, the decoys astern and the
+        // pursuer's sector, and the rack is captions and clocks, so it is what
+        // gives way.
         ViewAbilities {
             id: abilities
+
+            // How far ownship's acquisition pulse draws past the scope centre
+            // (ViewSituation's pulse ring); the rack reaches in from its margin
+            // no further than the pulse's edge.
+            readonly property real pulseReach: 48
 
             visible: !root.device.touch && !settings.open
             // Smaller than a touch target: nothing here is ever pressed by a
@@ -423,10 +425,9 @@ Window {
             // instead. Sized so the rack clears ownship's own bearing line as
             // well as its column on any window taller than about 720.
             buttonSize: Math.max(44, Math.min(root.width, root.height) * 0.07)
-            // The rack may reach in from the margin as far as ownship's pulse
-            // and no further, so a craft carrying six abilities shrinks its
-            // buttons rather than growing across the scope centre.
-            maximumWidth: root.width / 2 - 48 - 20
+            // A craft carrying six abilities shrinks its buttons rather than
+            // growing across the scope centre.
+            maximumWidth: root.width / 2 - abilities.pulseReach - abilities.anchors.margins
             keymap: root.keymap
             loadout: game.ownship.abilities
             device: root.device
@@ -450,6 +451,10 @@ Window {
         ViewHints {
             visible: abilities.visible
             device: root.device
+            // Centred, but never under the rack: capped so the line's right
+            // edge stays clear of abilities' left and elides on a window too
+            // narrow to hold both.
+            width: Math.max(0, Math.min(implicitWidth, 2 * (abilities.x - 16) - root.width))
 
             anchors {
                 horizontalCenter: parent.horizontalCenter
@@ -520,7 +525,7 @@ Window {
         ViewSituation {
             id: minimap
 
-            width: Math.max(110, Math.min(root.width, root.height) * 0.22)
+            width: scene.instrumentSide
             height: width
 
             projection: projection
@@ -576,6 +581,7 @@ Window {
         anchors.fill: parent
         keymap: root.keymap
         loadout: game.ownship.abilities
+        device: root.device
         onClosed: root.closeSettings()
     }
 

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -139,15 +139,17 @@ Window {
             minimum: 0
         }
 
-        // The scope's range control. A stepped axis, not a held one: each edge
-        // moves the picture one step and the release back to rest moves
-        // nothing, so a control held down never runs the range away.
+        // The scope's range control, the one object every ranging source —
+        // d-pad edge, wheel notch, touch tap — converges on. A stepped axis,
+        // not a held one: each step out of rest moves the picture once and the
+        // release back moves nothing, so a control held down never runs the
+        // range away.
         Axis {
             id: axisRange
-            onValueChanged: {
-                if (axisRange.value > 0.5)
+            onStepped: direction => {
+                if (direction > 0)
                     projection.rangeIn();
-                else if (axisRange.value < -0.5)
+                else
                     projection.rangeOut();
             }
         }
@@ -257,10 +259,11 @@ Window {
             queue: bus
         }
 
-        // The mouse's range control: wheel up ranges in, wheel down out. It
-        // steps per notch of 120 units — a trackpad sends smaller ones, so they
-        // bank up into a step, and a reversal drops what was banked rather than
-        // spending it against the new direction.
+        // The mouse's range control, stepping the shared axis: wheel up ranges
+        // in, wheel down out. It steps per notch of 120 units — a trackpad
+        // sends smaller ones, so they bank up into a step, and a reversal
+        // drops what was banked rather than spending it against the new
+        // direction.
         WheelHandler {
             id: wheel
 
@@ -276,11 +279,11 @@ Window {
                 wheel.banked += event.angleDelta.y;
                 while (wheel.banked >= 120) {
                     wheel.banked -= 120;
-                    projection.rangeIn();
+                    axisRange.step(1);
                 }
                 while (wheel.banked <= -120) {
                     wheel.banked += 120;
-                    projection.rangeOut();
+                    axisRange.step(-1);
                 }
             }
         }
@@ -495,10 +498,11 @@ Window {
             visible: TouchScreen.available && root.device.touch && !settings.open
             loadout: game.ownship.abilities
             onInvoked: ability => touched.post({ ability: ability })
-            // The range pair at the rack's pivot drives the projection direct:
-            // the scope is a display, so ranging it never goes near the bus.
-            onRangedIn: projection.rangeIn()
-            onRangedOut: projection.rangeOut()
+            // The range pair at the rack's pivot steps the shared range axis,
+            // same as the wheel and the d-pad: the scope is a display, so
+            // ranging it never goes near the bus.
+            onRangedIn: axisRange.step(1)
+            onRangedOut: axisRange.step(-1)
 
             anchors {
                 right: parent.right

--- a/app/briarthorn/qml/input/AbilityInput.qml
+++ b/app/briarthorn/qml/input/AbilityInput.qml
@@ -26,11 +26,8 @@ QtObject {
     readonly property string ability: root.def ? root.def.name : ""
 
     readonly property Axis control: Axis {
-        id: trigger
-
         minimum: 0
-        onValueChanged: if (trigger.value > 0.5)
-            root.invoke.post()
+        onStepped: root.invoke.post()
     }
 
     readonly property ActionKey keys: ActionKey {

--- a/app/briarthorn/qml/input/Keymap.qml
+++ b/app/briarthorn/qml/input/Keymap.qml
@@ -138,9 +138,9 @@ QtObject {
     // Binds one control to one ability, exclusively: whatever other ability held
     // it loses it, so one press can never post two intents. Returns whether the
     // control was taken, and remembers which ability paid for it. Key code 0 is
-    // refused with the negatives — no keyboard produces it, so a binding on it
-    // would be dead but still live to a synthesised event. Button 0 is South,
-    // a face button the loadout ships bindings on, so the pad floor is 0.
+    // refused with the negatives — no keyboard produces it, only synthesised
+    // events — but button 0 is South, a face button the loadout ships bindings
+    // on, so the pad floor alone is 0.
     function bind(name: string, pad: bool, code: int): bool {
         const floor = pad ? 0 : 1;
         if (name === "" || code < floor || root.reserved(pad, code))

--- a/app/briarthorn/qml/model/AbilitySlot.qml
+++ b/app/briarthorn/qml/model/AbilitySlot.qml
@@ -21,6 +21,11 @@ QtObject {
 
     readonly property bool ready: cooldownRemaining <= 0 && charges !== 0
 
+    // The cooldown still to run as a fraction of this ability's own — 1 the
+    // moment it pops, 0 once ready — so a long reload and a short one both
+    // wind a readiness dial over its full sweep.
+    readonly property real cooling: def && def.cooldown > 0 ? cooldownRemaining / def.cooldown : 0
+
     function activate() {
         if (root.ready)
             root.pending = true;

--- a/app/briarthorn/qml/ui/AbilityButton.qml
+++ b/app/briarthorn/qml/ui/AbilityButton.qml
@@ -147,9 +147,8 @@ Item {
     // Buttons are ignored outright: a touchscreen point this handler is already
     // tracking is also delivered as a synthetic left-button press, which
     // de-activates the handler and re-activates it under the one finger — and
-    // the invocation rides that rising edge, so a single tap would fire twice.
-    // A cooling ability swallows the second one, which is exactly what makes
-    // this cheap to miss; a flare off no cooldown spends two decoys.
+    // the invocation rides that rising edge, so a single tap would fire twice
+    // and a flare off no cooldown would spend two decoys.
     PointHandler {
         id: handler
 

--- a/app/briarthorn/qml/ui/Symbol.qml
+++ b/app/briarthorn/qml/ui/Symbol.qml
@@ -29,7 +29,7 @@ Item {
 
     readonly property Data def: Database.dataFor(root.classification)
 
-    width: symbolSize * def.symbolScale
+    width: root.symbolSize * root.def.symbolScale
     height: width
 
     ShapePolygon {

--- a/app/briarthorn/qml/ui/TouchAbilities.qml
+++ b/app/briarthorn/qml/ui/TouchAbilities.qml
@@ -7,11 +7,9 @@ import "../model"
 // carries, laid along a quarter circle swept from the bottom edge round to the
 // right edge, so a thumb pivoting in that corner reaches every one of them
 // without the hand leaving the display. The scope's range pair sits at that
-// pivot, the one spot the thumb never travels to reach. The stick's
-// counterpart in the opposite corner, and like it, only a touch device shows
-// it. Nothing here names an ability — the rack is the loadout, so a craft
-// carrying a new one grows a button for it and a rack of one still lands under
-// the thumb.
+// pivot, the one spot the thumb never travels to reach. Nothing here names an
+// ability — the rack is the loadout, so a craft carrying a new one grows a
+// button for it and a rack of one still lands under the thumb.
 Item {
     id: root
 

--- a/app/briarthorn/qml/ui/TouchAbilities.qml
+++ b/app/briarthorn/qml/ui/TouchAbilities.qml
@@ -82,9 +82,7 @@ Item {
             label: control.modelData.def ? control.modelData.def.label : ""
             charges: control.modelData.charges
             ready: control.modelData.ready
-            // The cooldown as a fraction of this ability's own, so a long
-            // reload and a short one both wind the bar over its full sweep.
-            cooling: control.modelData.def && control.modelData.def.cooldown > 0 ? control.modelData.cooldownRemaining / control.modelData.def.cooldown : 0
+            cooling: control.modelData.cooling
 
             // A slot carrying no definition binds nothing and fires nothing —
             // a loadout typo must not reach the bus.

--- a/app/briarthorn/qml/ui/TouchArrow.qml
+++ b/app/briarthorn/qml/ui/TouchArrow.qml
@@ -4,7 +4,7 @@ import "../themes"
 
 // One round touch step control: a disc carrying a triangle, for a control that
 // steps a setting rather than invokes something. It answers on press as
-// TouchButton does, so touch matches the rising edge a key or a pad button
+// AbilityButton does, so touch matches the rising edge a key or a pad button
 // fires on; unlike an ability it has nothing to run out of and no clock to
 // wind, so the rim is a plain frame.
 Item {

--- a/app/briarthorn/qml/ui/ViewAbilities.qml
+++ b/app/briarthorn/qml/ui/ViewAbilities.qml
@@ -69,9 +69,7 @@ Row {
             label: button.modelData.def ? button.modelData.def.label : ""
             charges: button.modelData.charges
             ready: button.modelData.ready
-            // The cooldown as a fraction of this ability's own, so a long
-            // reload and a short one both wind the bar over its full sweep.
-            cooling: button.modelData.def && button.modelData.def.cooldown > 0 ? button.modelData.cooldownRemaining / button.modelData.def.cooldown : 0
+            cooling: button.modelData.cooling
 
             // The cap follows the device in the player's hands: the pad's own
             // button while a controller is driving, the key otherwise.

--- a/app/briarthorn/qml/ui/ViewHints.qml
+++ b/app/briarthorn/qml/ui/ViewHints.qml
@@ -15,5 +15,6 @@ Text {
 
     text: root.device.pad ? qsTr("LEFT STICK fly · D-PAD range · START controls") : qsTr("W thrust · A/D turn · WHEEL range · ESC controls")
     color: Style.theme.textMuted
+    elide: Text.ElideRight // the caller caps width where the line would collide
     font { pixelSize: 12; family: Style.monospace }
 }

--- a/app/briarthorn/qml/ui/ViewSettings.qml
+++ b/app/briarthorn/qml/ui/ViewSettings.qml
@@ -49,61 +49,6 @@ Item {
         root.keymap.displaced = "";
     }
 
-    // The ability at a row, or empty past the end or on a slot with no
-    // definition.
-    function abilityAt(index: int): string {
-        if (index < 0 || index >= root.loadout.length)
-            return "";
-        const def = root.loadout[index].def;
-        return def ? def.name : "";
-    }
-
-    function move(delta: int) {
-        if (root.loadout.length > 0)
-            root.cursor = (root.cursor + delta + root.loadout.length) % root.loadout.length;
-    }
-
-    function capture(name: string, pad: bool) {
-        if (name === "")
-            return;
-        root.capturing = name;
-        root.capturingPad = pad;
-        root.resetArmed = false;
-        root.keymap.displaced = "";
-    }
-
-    // The capture gate, in front of everything else: while a row is waiting, the
-    // control the player presses becomes its binding and never does its usual
-    // job. A control the keymap refuses is swallowed and the row keeps waiting,
-    // so a mis-press onto a flight key binds nothing. Returns whether the event
-    // was taken.
-    function captured(pad: bool, code: int): bool {
-        if (root.capturing === "")
-            return false;
-        if (pad ? code === Gamepad.Button.East : code === Qt.Key_Escape) {
-            root.capturing = "";
-            return true;
-        }
-        if (pad !== root.capturingPad)
-            return true;
-        if (root.keymap.bind(root.capturing, pad, code))
-            root.capturing = "";
-        return true;
-    }
-
-    // Two presses, because it throws away every rebind and there is no undo.
-    function resetAll() {
-        if (root.resetArmed)
-            root.keymap.reset();
-        root.resetArmed = !root.resetArmed;
-    }
-
-    function clearRow() {
-        const name = root.abilityAt(root.cursor);
-        root.keymap.unbind(name, false);
-        root.keymap.unbind(name, true);
-    }
-
     Keys.onPressed: event => {
         event.accepted = true;
         if (event.isAutoRepeat || root.captured(false, event.key))
@@ -132,36 +77,6 @@ Item {
         }
     }
     Keys.onReleased: event => event.accepted = true
-
-    // The pad's whole vocabulary here. Controller events ignore focus entirely,
-    // so Main hands them over explicitly while the page is up.
-    function padPressed(code: int) {
-        if (root.captured(true, code))
-            return;
-        switch (code) {
-        case Gamepad.Button.DpadUp:
-            root.move(-1);
-            break;
-        case Gamepad.Button.DpadDown:
-            root.move(1);
-            break;
-        case Gamepad.Button.South:
-            root.capture(root.abilityAt(root.cursor), true);
-            break;
-        case Gamepad.Button.West:
-            root.clearRow();
-            break;
-        case Gamepad.Button.North:
-            root.resetAll();
-            break;
-        case Gamepad.Button.East:
-        case Gamepad.Button.Start:
-            root.closed();
-            break;
-        default:
-            break;
-        }
-    }
 
     // Opaque, and swallowing every pointer event: the on-screen stick sits
     // underneath, and a bare Item does not stop its handler grabbing a touch.
@@ -363,6 +278,91 @@ Item {
         MouseArea {
             anchors.fill: parent
             onClicked: choice.tapped()
+        }
+    }
+
+    // The ability at a row, or empty past the end or on a slot with no
+    // definition.
+    function abilityAt(index: int): string {
+        if (index < 0 || index >= root.loadout.length)
+            return "";
+        const def = root.loadout[index].def;
+        return def ? def.name : "";
+    }
+
+    function move(delta: int) {
+        if (root.loadout.length > 0)
+            root.cursor = (root.cursor + delta + root.loadout.length) % root.loadout.length;
+    }
+
+    function capture(name: string, pad: bool) {
+        if (name === "")
+            return;
+        root.capturing = name;
+        root.capturingPad = pad;
+        root.resetArmed = false;
+        root.keymap.displaced = "";
+    }
+
+    // The capture gate, in front of everything else: while a row is waiting, the
+    // control the player presses becomes its binding and never does its usual
+    // job. A control the keymap refuses is swallowed and the row keeps waiting,
+    // so a mis-press onto a flight key binds nothing. Returns whether the event
+    // was taken.
+    function captured(pad: bool, code: int): bool {
+        if (root.capturing === "")
+            return false;
+        if (pad ? code === Gamepad.Button.East : code === Qt.Key_Escape) {
+            root.capturing = "";
+            return true;
+        }
+        if (pad !== root.capturingPad)
+            return true;
+        if (root.keymap.bind(root.capturing, pad, code))
+            root.capturing = "";
+        return true;
+    }
+
+    // Two presses, because it throws away every rebind and there is no undo.
+    function resetAll() {
+        if (root.resetArmed)
+            root.keymap.reset();
+        root.resetArmed = !root.resetArmed;
+    }
+
+    function clearRow() {
+        const name = root.abilityAt(root.cursor);
+        root.keymap.unbind(name, false);
+        root.keymap.unbind(name, true);
+    }
+
+    // The pad's whole vocabulary here. Controller events ignore focus entirely,
+    // so Main hands them over explicitly while the page is up.
+    function padPressed(code: int) {
+        if (root.captured(true, code))
+            return;
+        switch (code) {
+        case Gamepad.Button.DpadUp:
+            root.move(-1);
+            break;
+        case Gamepad.Button.DpadDown:
+            root.move(1);
+            break;
+        case Gamepad.Button.South:
+            root.capture(root.abilityAt(root.cursor), true);
+            break;
+        case Gamepad.Button.West:
+            root.clearRow();
+            break;
+        case Gamepad.Button.North:
+            root.resetAll();
+            break;
+        case Gamepad.Button.East:
+        case Gamepad.Button.Start:
+            root.closed();
+            break;
+        default:
+            break;
         }
     }
 }

--- a/app/briarthorn/qml/ui/ViewSettings.qml
+++ b/app/briarthorn/qml/ui/ViewSettings.qml
@@ -24,6 +24,10 @@ Item {
     required property Keymap keymap
     required property list<AbilitySlot> loadout
 
+    // Which device the player is driving with; the page's keys report in, as
+    // the pad route already does, so a keyboard rebind swaps the HUD's caps.
+    required property ActiveDevice device
+
     // Whether the page is up. Main drives this; focus and the pause follow it.
     property bool open: false
 
@@ -51,6 +55,9 @@ Item {
 
     Keys.onPressed: event => {
         event.accepted = true;
+        // Any key here is keyboard flying, reported ahead of the dispatch the
+        // way Main reports the pad ahead of padPressed.
+        root.device.kind = ActiveDevice.Keyboard;
         if (event.isAutoRepeat || root.captured(false, event.key))
             return;
         switch (event.key) {

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -52,8 +52,8 @@ Item {
             id: mark
             required property Track modelData
 
-            readonly property real azimuthRad: modelData.azimuth * Math.PI / 180
-            readonly property real trueRange: modelData.range * root.pxPerMeter
+            readonly property real azimuthRad: mark.modelData.azimuth * Math.PI / 180
+            readonly property real trueRange: mark.modelData.range * root.pxPerMeter
 
             // Beyond the scale, and so clamped: the symbol steps out to its
             // seat past the clamp radius rather than plotting where it truly
@@ -79,8 +79,8 @@ Item {
                 }
             }
 
-            x: root.centerX + Math.sin(azimuthRad) * screenRange - width / 2
-            y: root.centerY - Math.cos(azimuthRad) * screenRange - height / 2
+            x: root.centerX + Math.sin(mark.azimuthRad) * mark.screenRange - width / 2
+            y: root.centerY - Math.cos(mark.azimuthRad) * mark.screenRange - height / 2
 
             // A contact classified as a countermeasure plots as a burning
             // flare, no faction symbol or label — briardart skips the symbol

--- a/cmake/target/qmllint.cmake
+++ b/cmake/target/qmllint.cmake
@@ -9,6 +9,9 @@
 #     property; this file must be included after the subdirectories that
 #     register them, because linting resolves the in-project imports out of
 #     their generated .qmltypes.
+#   * Lintable QML lives under app/ or src/: the file list is a glob over those
+#     roots, so a module registered from anywhere else builds before lint but
+#     is never linted.
 #
 # Usage:
 #   cmake --build --preset <preset> --target qmllint
@@ -16,9 +19,11 @@
 #
 # Like qmlpreview, qmllint is not exported as an imported target, so it has to
 # be found on disk: a prebuilt kit keeps it in bin/, vcpkg relocates the Qt
-# tools to tools/Qt6/bin, and a cross build (wasm, android) has the host tools
-# under QT_HOST_PATH rather than in the target kit. Include after
-# find_package(Qt6), which is what defines QT6_INSTALL_PREFIX.
+# tools to tools/Qt6/bin, and a prebuilt-kit cross build (wasm, android) has
+# the host tools under QT_HOST_PATH rather than in the target kit. A vcpkg
+# cross build sets no QT_HOST_PATH, so its lint targets skip — linting runs on
+# the desktop presets. Include after find_package(Qt6), which is what defines
+# QT6_INSTALL_PREFIX.
 find_program(QMLLINT_EXECUTABLE
     NAMES qmllint
     HINTS

--- a/src/awen/gamepad/Gamepad.h
+++ b/src/awen/gamepad/Gamepad.h
@@ -114,12 +114,6 @@ namespace awen
 
         [[nodiscard]] auto devices() const -> QList<int>;
 
-        /// @brief Mirror the backend's set of open controllers onto this instance;
-        /// called by attachGamepad to seed it and on every hotplug to keep it in
-        /// step. Not reachable from QML, where devices is read-only.
-        /// @param devices The ids of the controllers now connected, ascending.
-        auto setDevices(const QList<int>& devices) -> void;
-
     signals:
         /// @brief A controller was plugged in / unplugged. @p deviceId identifies
         /// it in the axis and button signals. These are edges only: what is
@@ -143,6 +137,14 @@ namespace awen
         void devicesChanged();
 
     private:
+        /// @brief Mirror the backend's set of open controllers onto this instance;
+        /// called by attachGamepad to seed it and on every hotplug to keep it in
+        /// step. Private with attachGamepad as the one friend, so the mirror has
+        /// exactly one writer and the compiler holds that boundary.
+        /// @param devices The ids of the controllers now connected, ascending.
+        auto setDevices(const QList<int>& devices) -> void;
+        friend auto attachGamepad(Gamepad* gamepad, QObject* attachee) -> void;
+
         std::chrono::milliseconds pollInterval_{DefaultPollInterval};         ///< See pollInterval.
         std::chrono::milliseconds idlePollInterval_{DefaultIdlePollInterval}; ///< See idlePollInterval.
         QList<int> devices_;                                                  ///< See devices.

--- a/src/awen/gamepad/GamepadSource.cpp
+++ b/src/awen/gamepad/GamepadSource.cpp
@@ -3,15 +3,15 @@
 #include "GamepadBackend.h"
 #include "GamepadTranslate.h"
 
-#include <algorithm>
-#include <unordered_map>
-
 #include <QGuiApplication>
 #include <QList>
 #include <QQmlEngine>
 #include <QString>
 #include <QTimer>
+
+#include <algorithm>
 #include <chrono>
+#include <unordered_map>
 
 #include <SDL3/SDL.h>
 

--- a/src/awen/input/Axis.qml
+++ b/src/awen/input/Axis.qml
@@ -14,12 +14,20 @@ QtObject {
     property real minimum: -1
     property real maximum: 1
 
+    // The rest band for stepped(): a fold leaving ±band emits one step, and
+    // nothing fires again until it has returned to rest.
+    property real band: 0.5
+
     // The current folded value; refold() owns the writes. Assignments of an
     // unchanged fold do not notify, so valueChanged fires once per real move.
     property real value: 0
 
     // One contribution per source, keyed by the source object itself.
     property var contributions: new Map()
+
+    // One discrete step out of rest, ±1 by the side the fold left on. Sources
+    // with no held state (a wheel notch, a touch tap) inject theirs via step().
+    signal stepped(int direction)
 
     onEnabledChanged: root.refold()
 
@@ -35,6 +43,13 @@ QtObject {
         root.contribute(root, contribution);
     }
 
+    // Emits one step without moving the fold — how discrete sources join the
+    // held ones on the same axis.
+    function step(direction: int) {
+        if (root.enabled)
+            root.stepped(direction);
+    }
+
     // Folds the contributions into the value, unless disabled.
     function refold() {
         if (!root.enabled)
@@ -42,6 +57,9 @@ QtObject {
         let sum = 0;
         for (const part of root.contributions.values())
             sum += part;
+        const rested = Math.abs(root.value) <= root.band;
         root.value = Math.max(root.minimum, Math.min(root.maximum, sum));
+        if (rested && Math.abs(root.value) > root.band)
+            root.stepped(root.value > 0 ? 1 : -1);
     }
 }

--- a/src/awen/input/test/Axis.test.cpp
+++ b/src/awen/input/test/Axis.test.cpp
@@ -180,11 +180,16 @@ TEST(Axis, StepsOncePerEngagement)
     call(*axis, "pushA", 1.0);
     EXPECT_EQ(axis->property("steps").toInt(), 1);
 
+    // Rest is the whole band, not just zero: dipping inside it re-arms.
+    call(*axis, "pushA", 0.4);
+    call(*axis, "pushA", 1.0);
+    EXPECT_EQ(axis->property("steps").toInt(), 2);
+
     call(*axis, "pushA", 0.0);
-    EXPECT_EQ(axis->property("steps").toInt(), 1);
+    EXPECT_EQ(axis->property("steps").toInt(), 2);
 
     call(*axis, "pushA", -1.0);
-    EXPECT_EQ(axis->property("steps").toInt(), 2);
+    EXPECT_EQ(axis->property("steps").toInt(), 3);
     EXPECT_EQ(axis->property("lastStep").toInt(), -1);
 }
 
@@ -198,6 +203,14 @@ TEST(Axis, StepInjectsWithoutMovingTheFold)
     EXPECT_EQ(axis->property("steps").toInt(), 1);
     EXPECT_EQ(axis->property("lastStep").toInt(), 1);
     EXPECT_DOUBLE_EQ(axis->property("value").toDouble(), 0.0);
+
+    // Injection ignores where the fold sits: a held direction must not block
+    // steps arriving from another source.
+    call(*axis, "pushA", 1.0);
+    EXPECT_EQ(axis->property("steps").toInt(), 2);
+    step(*axis, -1);
+    EXPECT_EQ(axis->property("steps").toInt(), 3);
+    EXPECT_EQ(axis->property("lastStep").toInt(), -1);
 }
 
 TEST(Axis, DisabledSwallowsStepsUntilReEnabled)

--- a/src/awen/input/test/Axis.test.cpp
+++ b/src/awen/input/test/Axis.test.cpp
@@ -32,6 +32,13 @@ namespace
         EXPECT_TRUE(QMetaObject::invokeMethod(&axis, function, Q_ARG(double, contribution)));
     }
 
+    /// @brief Injects a discrete step; step() takes an int, so the double
+    /// helper's argument would never match.
+    auto step(QObject& axis, int direction) -> void
+    {
+        EXPECT_TRUE(QMetaObject::invokeMethod(&axis, "step", Q_ARG(int, direction)));
+    }
+
     // Two distinct source objects prove contributions fold per source; the
     // change counter proves valueChanged fires once per actual move.
     constexpr auto Harness = R"(
@@ -42,7 +49,13 @@ Axis {
     id: root
 
     property int changes
+    property int steps
+    property int lastStep
     onValueChanged: root.changes += 1
+    onStepped: direction => {
+        root.steps += 1;
+        root.lastStep = direction;
+    }
 
     property QtObject sourceA: QtObject {}
     property QtObject sourceB: QtObject {}
@@ -150,6 +163,58 @@ TEST(Axis, ReEnableRefoldsToLiveInputs)
 
     axis->setProperty("enabled", true);
     EXPECT_DOUBLE_EQ(axis->property("value").toDouble(), 0.0);
+}
+
+TEST(Axis, StepsOncePerEngagement)
+{
+    auto engine = QQmlEngine{};
+    const auto axis = load(engine, Harness);
+    ASSERT_NE(axis, nullptr);
+
+    call(*axis, "pushA", 1.0);
+    EXPECT_EQ(axis->property("steps").toInt(), 1);
+    EXPECT_EQ(axis->property("lastStep").toInt(), 1);
+
+    // Wobble on the engaged side stays one step; only rest re-arms it.
+    call(*axis, "pushA", 0.6);
+    call(*axis, "pushA", 1.0);
+    EXPECT_EQ(axis->property("steps").toInt(), 1);
+
+    call(*axis, "pushA", 0.0);
+    EXPECT_EQ(axis->property("steps").toInt(), 1);
+
+    call(*axis, "pushA", -1.0);
+    EXPECT_EQ(axis->property("steps").toInt(), 2);
+    EXPECT_EQ(axis->property("lastStep").toInt(), -1);
+}
+
+TEST(Axis, StepInjectsWithoutMovingTheFold)
+{
+    auto engine = QQmlEngine{};
+    const auto axis = load(engine, Harness);
+    ASSERT_NE(axis, nullptr);
+
+    step(*axis, 1);
+    EXPECT_EQ(axis->property("steps").toInt(), 1);
+    EXPECT_EQ(axis->property("lastStep").toInt(), 1);
+    EXPECT_DOUBLE_EQ(axis->property("value").toDouble(), 0.0);
+}
+
+TEST(Axis, DisabledSwallowsStepsUntilReEnabled)
+{
+    auto engine = QQmlEngine{};
+    const auto axis = load(engine, Harness);
+    ASSERT_NE(axis, nullptr);
+
+    axis->setProperty("enabled", false);
+    step(*axis, 1);
+    call(*axis, "pushA", 1.0);
+    EXPECT_EQ(axis->property("steps").toInt(), 0);
+
+    // Re-enabling folds the recorded engagement in: that move is real, so it
+    // steps once.
+    axis->setProperty("enabled", true);
+    EXPECT_EQ(axis->property("steps").toInt(), 1);
 }
 
 TEST(Axis, ClampsIntoCustomRange)


### PR DESCRIPTION
Fixes the 21 confirmed findings from the review of the past week's work (2026-07-27..08-03), verified per commit and re-verified after rebasing onto the merged #79.

## Framework (awen)
- `Axis` gains a discrete edge hook: `stepped(int direction)` fires once when the fold leaves a configurable rest `band`, and `step(direction)` injects for stateless sources. Briarthorn's three range paths (d-pad, wheel notches, touch arrows) now converge on `axisRange`, and `AbilityInput` drops its hand-rolled 0.5 threshold. Value-edge semantics were chosen deliberately over press-driven steps to preserve chord behaviour; the contract is pinned by new unit tests, including rest-band re-arm and injection-while-engaged.
- `Gamepad::setDevices` is private with `attachGamepad` as its one friend, so the devices mirror's single-writer rule is compiler-held; `GamepadSource.cpp` adopts the header's Qt-then-std include order.

## Briarthorn
- `AbilitySlot` owns the `cooling` fraction both racks previously copy-pasted.
- HUD layout constraints are named: `scene.instrumentSide` pairs the gauge and minimap structurally, the rack ceiling reads `pulseReach` and its own margins, and `ViewHints` is width-capped against the rack with elide.
- `ViewSettings` takes the `ActiveDevice` seam and reports keyboard use, mirroring the pad route.
- Lint-sweep residues settled: `ViewSettings` functions moved below children, `ViewTracks`/`Symbol` qualification unified, the sample app gets the missing `ComponentBehavior` pragma, and over-length comments trimmed to the house 1-3 sentences.

## Build
- `qmllint.cmake` documents the app/-or-src/ file-set contract and the vcpkg cross-build skip.

Verified: full build, 101/101 ctest, `qmllint-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)