### PR TITLE
Add duel end states, a pause menu and the way back to the launch screen

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -63,6 +63,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/systems/SystemEngage.qml
         qml/systems/SystemEvade.qml
         qml/systems/SystemFuel.qml
+        qml/systems/SystemMission.qml
         qml/systems/SystemMovement.qml
         qml/systems/SystemPursuit.qml
         qml/systems/SystemThreat.qml
@@ -71,15 +72,19 @@ awen_add_executable(${PROJECT_NAME}
         qml/ui/AbilityButton.qml
         qml/ui/ControlCap.qml
         qml/ui/Joystick.qml
+        qml/ui/MenuButton.qml
+        qml/ui/MenuPage.qml
         qml/ui/RangeRing.qml
         qml/ui/Symbol.qml
         qml/ui/SymbolFlare.qml
         qml/ui/TouchAbilities.qml
         qml/ui/TouchArrow.qml
         qml/ui/ViewAbilities.qml
+        qml/ui/ViewEnd.qml
         qml/ui/ViewEngagements.qml
         qml/ui/ViewHints.qml
         qml/ui/ViewMenu.qml
+        qml/ui/ViewPause.qml
         qml/ui/ViewSettings.qml
         qml/ui/ViewSituation.qml
         qml/ui/ViewSituationAttack.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -48,6 +48,14 @@ Window {
     // input route feeds the menu cursor instead of the game.
     property bool inMenu: true
 
+    // The pause menu, duel only: the sim freezes behind it and the input
+    // routes feed its cursor, exactly as the launch screen's.
+    property bool paused: false
+
+    // Whether the duel has been decided: the sim freezes on the deciding
+    // frame and the end screen takes the input until the player moves on.
+    readonly property bool ended: !root.inMenu && scenario.mission.status !== SystemMission.Status.Ongoing
+
     width: 1280
     height: 720
     visible: true
@@ -90,10 +98,10 @@ Window {
         readonly property real instrumentSide: Math.max(110, Math.min(root.width, root.height) * 0.22)
 
         anchors.fill: parent
-        // The window's keys go here unless the controls page or the launch
-        // screen has them — each declares its own focus, and the bindings
-        // trade it as those states flip.
-        focus: !settings.open && !root.inMenu
+        // The window's keys go here unless the controls page or one of the
+        // overlay menus has them — each declares its own focus, and the
+        // bindings trade it as those states flip.
+        focus: !settings.open && !root.inMenu && !root.paused && !root.ended
 
         // Gamepad input via awen.gamepad; these fire regardless of focus. On wasm
         // the browser refreshes gamepad state once per frame, so poll at 16ms there.
@@ -106,22 +114,22 @@ Window {
         Keys.onPressed: event => {
             if (event.isAutoRepeat)
                 return;
-            // Keys the focused launch screen declined bubble up here; they
-            // have no game meaning while the menu is up.
-            if (root.inMenu)
+            // Keys a focused overlay menu declined bubble up here; they have
+            // no game meaning while one is up.
+            if (root.inMenu || root.paused || root.ended)
                 return;
             // Any key at all hands the HUD back to the keyboard, bound or not:
             // a player reaching for keys wants the key caps, not the pad's.
             root.device.kind = ActiveDevice.Keyboard;
             if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
-                root.openSettings();
+                root.openPause();
                 event.accepted = true;
                 return;
             }
             event.accepted = actions.keyPressed(event.key);
         }
         Keys.onReleased: event => {
-            if (!event.isAutoRepeat && !root.inMenu)
+            if (!event.isAutoRepeat && !root.inMenu && !root.paused && !root.ended)
                 event.accepted = actions.keyReleased(event.key);
         }
 
@@ -133,6 +141,10 @@ Window {
                 return;
             if (root.inMenu)
                 menu.axisMoved(axis, value);
+            else if (root.ended)
+                endPage.axisMoved(axis, value);
+            else if (root.paused)
+                pausePage.axisMoved(axis, value);
             else
                 actions.axisMoved(axis, value);
         }
@@ -142,13 +154,17 @@ Window {
                 settings.padPressed(button);
             else if (root.inMenu)
                 menu.padPressed(button);
+            else if (root.ended)
+                endPage.padPressed(button);
+            else if (root.paused)
+                pausePage.padPressed(button);
             else if (button === Gamepad.Button.Start)
-                root.openSettings();
+                root.openPause();
             else
                 actions.buttonPressed(button);
         }
         Gamepad.onButtonReleased: (deviceId, button) => {
-            if (!settings.open && !root.inMenu)
+            if (!settings.open && !root.inMenu && !root.paused && !root.ended)
                 actions.buttonReleased(button);
         }
 
@@ -293,7 +309,7 @@ Window {
 
             property real banked: 0
 
-            enabled: !settings.open && !root.inMenu
+            enabled: !settings.open && !root.inMenu && !root.paused && !root.ended
             onWheel: event => {
                 // The mouse belongs to the desktop set, so a scroll counts as
                 // keyboard play for the HUD's captions.
@@ -319,10 +335,11 @@ Window {
         // radar sweep — detection last, so tracks see the tick's outcome.
         // The two scenarios share one slot in the run, gated on the mode.
         Systems {
-            // The page stops the duel rather than letting it run on behind the
-            // player. dropInput() posts the zeroed axes before this flips, and
+            // The controls page, the pause menu and a decided duel all stop
+            // the sim rather than letting it run on behind the player.
+            // dropInput() posts the zeroed axes before these flip, and
             // nothing clears the queue, so they publish on resume.
-            running: !settings.open
+            running: !settings.open && !root.paused && !root.ended
 
             CommandQueue {
                 id: bus
@@ -403,7 +420,7 @@ Window {
             entities: root.entities
             detonations: weapons.detonations
             symbolSize: height * 0.04
-            trailsRunning: !settings.open && !root.inMenu
+            trailsRunning: !settings.open && !root.inMenu && !root.paused && !root.ended
 
             anchors {
                 left: parent.left
@@ -634,6 +651,36 @@ Window {
             anchors.fill: parent
         }
 
+        // The pause menu, over the frozen scope and HUD; the controls page
+        // stacks on top of it and hands the keys back on close.
+        ViewPause {
+            id: pausePage
+
+            visible: root.paused
+            focus: root.paused && !settings.open
+            device: root.device
+            onResumed: root.resumeDuel()
+            onControls: root.openSettings()
+            onToMenu: root.startMenu()
+            onExitGame: Qt.quit()
+
+            anchors.fill: parent
+        }
+
+        // The duel's result, over the deciding frame.
+        ViewEnd {
+            id: endPage
+
+            visible: root.ended
+            focus: root.ended
+            device: root.device
+            mission: scenario.mission
+            onFlyAgain: root.startDuel()
+            onToMenu: root.startMenu()
+            onExitGame: Qt.quit()
+
+            anchors.fill: parent
+        }
     }
 
     // The controls page, a sibling of the scene rather than a child: it paints
@@ -661,11 +708,27 @@ Window {
     }
 
     // The launch screen: the demo scenario populates the world itself, on the
-    // tightest range step so the close fight fills the picture.
+    // tightest range step so the close fight fills the picture. Arriving from
+    // a paused or decided duel, the demo's own restart sweeps the fight's
+    // leavings and reseats ownship for the show.
     function startMenu() {
         root.dropInput();
+        root.paused = false;
+        demo.restart();
         projection.step = 0;
         root.inMenu = true;
+    }
+
+    // Escape or Start mid-duel: freeze the sim behind the pause menu. Held
+    // input is dropped while the bus still runs, exactly as the page does.
+    function openPause() {
+        root.dropInput();
+        root.paused = true;
+    }
+
+    function resumeDuel() {
+        root.paused = false;
+        root.dropInput();
     }
 
     // New game: rebuild both craft factory-fresh, sweep the whole world —

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -54,7 +54,7 @@ Window {
 
     // Whether the duel has been decided: the sim freezes on the deciding
     // frame and the end screen takes the input until the player moves on.
-    readonly property bool ended: !root.inMenu && scenario.mission.status !== SystemMission.Status.Ongoing
+    readonly property bool ended: !root.inMenu && mission.status !== SystemMission.Status.Ongoing
 
     width: 1280
     height: 720
@@ -329,11 +329,13 @@ Window {
         }
 
         // Run order is the lifetimes and the data flow: publish the batch,
-        // consume player intent into the game store, run the scenario's own
-        // systems (AI steering and trigger discipline), age ability clocks,
-        // integrate poses, then resolve weapons, countermeasures and the
-        // radar sweep — detection last, so tracks see the tick's outcome.
-        // The two scenarios share one slot in the run, gated on the mode.
+        // consume player intent into the game store, let the scenarios set
+        // conditions, judge the duel, then run the one set of shared systems
+        // — behaviour by entity aspect, ability clocks, fuel, poses, weapons,
+        // countermeasures and the radar sweep, detection last so tracks see
+        // the tick's outcome. Every system runs in every mode and processes
+        // exactly the entities carrying its aspect; the scenarios only shape
+        // the world and never load systems of their own.
         Systems {
             // The controls page, the pause menu and a decided duel all stop
             // the sim rather than letting it run on behind the player.
@@ -361,11 +363,38 @@ Window {
                 id: scenario
                 enabled: !root.inMenu
                 ownship: game.ownship
-                world: root.world
+            }
+
+            // The duel's judge, always on: in menu mode both hulls it reads
+            // sit topped or out of the fight, so the latch never trips.
+            SystemMission {
+                id: mission
+                player: game.ownship
+                target: scenario.bandit
+            }
+
+            SystemPursuit {
+                entities: root.entities
+            }
+
+            SystemEvade {
+                entities: root.entities
+            }
+
+            SystemEngage {
+                entities: root.entities
+            }
+
+            SystemThreat {
+                entities: root.entities
             }
 
             SystemAbility {
                 world: root.world
+            }
+
+            SystemFuel {
+                entities: root.entities
             }
 
             SystemMovement {
@@ -674,7 +703,7 @@ Window {
             visible: root.ended
             focus: root.ended
             device: root.device
-            mission: scenario.mission
+            mission: mission
             onFlyAgain: root.startDuel()
             onToMenu: root.startMenu()
             onExitGame: Qt.quit()
@@ -738,6 +767,7 @@ Window {
         demo.reset();
         game.reset();
         scenario.reset();
+        mission.reset();
         const roster = root.world.entities.slice();
         for (let i = 0; i < roster.length; ++i)
             root.world.despawn(roster[i]);

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -40,6 +40,36 @@ QtObject {
     property real commandedThrottle: 0
     property real commandedSteer: 0
 
+    // Behaviour aspects: every system runs against the whole world and
+    // processes the entities carrying its aspect, so a scenario arms
+    // behaviour by setting fields at spawn — never by loading systems of its
+    // own. A null target or a cleared flag simply opts the entity out.
+
+    // SystemPursuit chases this at full throttle.
+    property Entity pursuitTarget: null
+
+    // SystemEvade orbits this, holding off at the standoff distance (m).
+    property Entity evadeTarget: null
+    property real evadeStandoff: 12000
+
+    // SystemEngage shoots at this inside the envelope. holdoff (s) paces the
+    // launches; the timer is its run-down state, seedable to stagger a
+    // wave's opening shots; engageHold stands the shooter down while true —
+    // a director's salvo cap.
+    property Entity engageTarget: null
+    property real engageHoldoff: 6
+    property real engageTimer: 0
+    property bool engageHold: false
+
+    // SystemThreat pops this entity's flares at inbound homing rounds; the
+    // timer spaces the pops so each decoy gets its chance to seduce.
+    property bool threatReflex: false
+    property real threatTimer: 0
+
+    // SystemFuel drains the tank; the launch screen's demo craft clears this
+    // so an endless showing never runs dry.
+    property bool burnsFuel: true
+
     // The six stats, as the dimensionless 0..10 ratings GameRules prices (see
     // Stats). Never a game quantity — assigning one here re-derives every
     // capability below with it.

--- a/app/briarthorn/qml/scenarios/Scenario.qml
+++ b/app/briarthorn/qml/scenarios/Scenario.qml
@@ -1,9 +1,13 @@
 import awen.entity
 import "../model"
 
-// Base type for a level: the entities and systems that live and die with
-// it, packaged as one swappable slot in the game's run order. The player's
-// craft and the command handlers stay outside, in the game store.
+// Base type for a level: the initial conditions and the entities that exist
+// in it, packaged as one swappable slot in the game's run order. Behaviour
+// belongs on the entities as aspect fields the shared systems process — a
+// scenario never loads systems of its own; the group base is only for a
+// scenario that must direct events as they unfold (the launch screen's wave
+// director). The player's craft and the command handlers stay outside, in
+// the game store.
 SystemGroup {
     id: root
 

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -39,6 +39,9 @@ Scenario {
     // The live bandit. reset() owns the swap.
     property Entity bandit: DuelBandit {}
 
+    // The latched duel outcome the end screen reads; reset() rearms it.
+    readonly property SystemMission mission: missionSystem
+
     readonly property Component banditFactory: Component {
         DuelBandit {}
     }
@@ -52,6 +55,7 @@ Scenario {
         const spent = root.bandit;
         root.bandit = root.banditFactory.createObject(root) as Entity;
         spent.destroy();
+        missionSystem.reset();
     }
 
     SystemPursuit {
@@ -73,5 +77,13 @@ Scenario {
     // carries no fuel system, so it needs no top-up either.
     SystemFuel {
         entity: root.ownship
+    }
+
+    // The outcome judge, latching victory or defeat off the pair's hulls; it
+    // reads last tick's blast results, one frame the end screen never shows.
+    SystemMission {
+        id: missionSystem
+        player: root.ownship
+        target: root.bandit
     }
 }

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -1,20 +1,21 @@
+// The bandit's declaration reaches the file root's ownship; bound component
+// behaviour is what makes that resolve statically.
+pragma ComponentBehavior: Bound
+
 import QtQml
 import "../database"
 import "../model"
-import "../systems"
 
 // The 1v1 duel: one hostile fighter boring in from the north, spawned just
-// past sensor range so it opens as an Unknown contact. The bandit shoots
-// back — guided rounds inside its engage envelope — and pops flares when a
-// missile homes in on it.
+// past sensor range so it opens as an Unknown contact. Pure initial
+// conditions — the bandit's declaration carries its behaviour aspects
+// (pursue the player, shoot inside the envelope, flare at inbound rounds)
+// and the shared systems do the rest; this scenario loads nothing of its own.
 Scenario {
     id: root
 
     // The player's craft, for the bandit to pursue; the game store owns it.
     required property Entity ownship
-
-    // The world the bandit's defensive scan reads.
-    required property World world
 
     // The downrated airframe, so the duel is winnable, with its rack's flare
     // pod halved on top — a full pod outlasts the player's patience.
@@ -24,6 +25,9 @@ Scenario {
         side: Side.Kind.Hostile
         posY: -65000
         heading: 180
+        pursuitTarget: root.ownship
+        engageTarget: root.ownship
+        threatReflex: true
 
         abilities: [
             AbilitySlot {
@@ -39,9 +43,6 @@ Scenario {
     // The live bandit. reset() owns the swap.
     property Entity bandit: DuelBandit {}
 
-    // The latched duel outcome the end screen reads; reset() rearms it.
-    readonly property SystemMission mission: missionSystem
-
     readonly property Component banditFactory: Component {
         DuelBandit {}
     }
@@ -55,35 +56,5 @@ Scenario {
         const spent = root.bandit;
         root.bandit = root.banditFactory.createObject(root) as Entity;
         spent.destroy();
-        missionSystem.reset();
-    }
-
-    SystemPursuit {
-        entity: root.bandit
-        target: root.ownship
-    }
-
-    SystemEngage {
-        entity: root.bandit
-        target: root.ownship
-    }
-
-    SystemThreat {
-        entity: root.bandit
-        world: root.world
-    }
-
-    // The player's tank drains only while a duel is on: the menu demo simply
-    // carries no fuel system, so it needs no top-up either.
-    SystemFuel {
-        entity: root.ownship
-    }
-
-    // The outcome judge, latching victory or defeat off the pair's hulls; it
-    // reads last tick's blast results, one frame the end screen never shows.
-    SystemMission {
-        id: missionSystem
-        player: root.ownship
-        target: root.bandit
     }
 }

--- a/app/briarthorn/qml/scenarios/ScenarioMenu.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioMenu.qml
@@ -1,17 +1,13 @@
-pragma ComponentBehavior: Bound
-
-import QtQml
 import awen.entity
 import "../database"
 import "../model"
-import "../systems"
 
 // The main-menu demo: a hands-off, endlessly-looping dogfight in the real
-// world, read through the live scope. Ownship orbits the nearest hostile
-// under SystemEvade, returns fire off its guided rack and pops flares by
-// reflex, while armed waves spawn ahead, bore in and shoot back; a wiped
-// wave respawns after a beat, so the menu shows continuous combat with no
-// input. The whole show restarts on a clock — briardart rebuilt its demo
+// world, read through the live scope. Everything flies on entity aspects the
+// shared systems process — ownship orbits and returns fire through the
+// targets the director points, waves spawn already declaring pursuit, trigger
+// discipline and flare reflex — so the scenario owns one director and no
+// systems. The whole show restarts on a clock: briardart rebuilt its demo
 // session on every menu entry, and an unbounded run would carry ownship
 // arbitrarily far from the origin. Ports briardart's MenuDemoController.
 Scenario {
@@ -37,81 +33,30 @@ Scenario {
     property real showTimer: 0
 
     // The most rounds one side may hold in the air: the demo reads as a
-    // sparring match, not a missile barrage, so each side's engage system
-    // stands down until its salvo thins. direct() recounts each tick.
+    // sparring match, not a missile barrage, so each side's shooters stand
+    // down behind their engageHold flags until their salvo thins.
     readonly property int missileCap: 2
     property int ownshipRounds: 0
     property int hostileRounds: 0
 
+    // Seconds a bandit's opening shot waits per wave slot, so a fresh wave —
+    // spawned inside the envelope with every timer at zero — never fires as
+    // one volley straight through the lagging round count.
+    readonly property real stagger: 5
+
+    // How the demo craft fights: launches paced a beat apart.
+    readonly property real demoHoldoff: 6
+
     // Seconds the sky has been clear, toward the next wave.
     property real clearTimer: 0
 
-    // Each live bandit's brain, keyed by its entity; spawnWave() appends them
-    // to the run and prune() drops them with their craft.
-    property var brains: new Map()
-
-    // One wave member's behaviour: chase the player, shoot inside the
-    // envelope, pop flares at inbound rounds — the duel bandit's rig.
-    // stagger delays the opening shot: the wave spawns inside the envelope
-    // with every timer at zero, and the round count the cap reads lags a
-    // tick, so unstaggered members all fire together straight through it.
-    component BanditBrain: SystemGroup {
-        id: brain
-
-        required property Entity entity
-        required property real stagger
-
-        SystemPursuit {
-            entity: brain.entity
-            target: root.ownship
-        }
-
-        SystemEngage {
-            entity: brain.entity
-            target: root.ownship
-            timer: brain.stagger
-            // Slower than the duel bandit — three shooters share one salvo
-            // allowance — and stood down entirely while the side's rounds
-            // in the air sit at the cap.
-            holdoff: 12
-            enabled: root.hostileRounds < root.missileCap
-        }
-
-        SystemThreat {
-            entity: brain.entity
-            world: root.world
-        }
-    }
-
-    readonly property Component brainFactory: Component {
-        BanditBrain {}
-    }
-
-    // Wave direction, ahead of everything else in the run: sustain ownship,
-    // point its systems at the nearest fighter, keep the wave populated and
-    // prune brains whose craft was reaped.
+    // Wave direction, the scenario's one running part: sustain ownship,
+    // point its aspects at the nearest fighter, hold each side's shooters at
+    // the salvo cap and keep the wave populated.
     System {
         function update(dt: real) {
             root.direct(dt);
         }
-    }
-
-    SystemEvade {
-        id: evade
-        entity: root.ownship
-    }
-
-    SystemEngage {
-        id: engage
-        entity: root.ownship
-        target: null
-        holdoff: 6
-        enabled: root.ownshipRounds < root.missileCap
-    }
-
-    SystemThreat {
-        entity: root.ownship
-        world: root.world
     }
 
     function direct(dt: real) {
@@ -121,12 +66,19 @@ Scenario {
             return;
         }
         root.sustain();
-        root.prune();
         root.countRounds();
         const foes = root.foes();
+        root.ownship.engageHold = root.ownshipRounds >= root.missileCap;
+        const hostileHold = root.hostileRounds >= root.missileCap;
+        for (let i = 0; i < foes.length; ++i)
+            foes[i].engageHold = hostileHold;
         if (foes.length === 0) {
-            evade.target = null;
-            engage.target = null;
+            root.ownship.evadeTarget = null;
+            root.ownship.engageTarget = null;
+            // With no aspect steering it, ownship flies straight and level
+            // toward the next engagement.
+            root.ownship.commandedSteer = 0;
+            root.ownship.commandedThrottle = 1;
             root.clearTimer += dt;
             if (root.clearTimer >= root.respawnDelay) {
                 root.clearTimer = 0;
@@ -136,14 +88,13 @@ Scenario {
         }
         root.clearTimer = 0;
         const threat = root.nearest(foes);
-        evade.target = threat;
-        engage.target = threat;
+        root.ownship.evadeTarget = threat;
+        root.ownship.engageTarget = threat;
     }
 
     // The demo must never end: the hull stays topped (SystemWeapon must keep
     // running — blasts and reaping are the show — so hits do land) and the
-    // racks reload. Fuel needs nothing: the duel scenario owns SystemFuel, so
-    // in menu mode no system drains the tank at all.
+    // racks reload. Fuel needs nothing: burnsFuel is cleared on the craft.
     function sustain() {
         root.ownship.health = root.ownship.maxHealth;
         const slots = root.ownship.abilities;
@@ -153,7 +104,7 @@ Scenario {
         }
     }
 
-    // Tallies each side's rounds in the air for the engage gates above.
+    // Tallies each side's rounds in the air for the engageHold gates above.
     function countRounds() {
         let own = 0;
         let hostile = 0;
@@ -191,56 +142,45 @@ Scenario {
     }
 
     // Spawns a fresh wave fanned out ahead of ownship's nose — downrated
-    // airframes off the database, each flown by its own appended brain.
+    // airframes off the database, each declaring its whole behaviour at
+    // birth: chase the player, shoot on a slow cadence from a staggered
+    // start, flare at inbound rounds.
     function spawnWave() {
         const heading = root.ownship.heading;
         for (let i = 0; i < root.waveSize; ++i) {
             const lateral = (i - (root.waveSize - 1) / 2) * root.spawnSpread;
-            const bandit = root.world.spawn("FOE", Classification.Kind.AircraftFighterLight, {
+            root.world.spawn("FOE", Classification.Kind.AircraftFighterLight, {
                 side: Side.Kind.Hostile,
                 posX: root.ownship.posX + Geo.offsetX(heading, root.spawnAhead) + Geo.offsetX(heading + 90, lateral),
                 posY: root.ownship.posY + Geo.offsetY(heading, root.spawnAhead) + Geo.offsetY(heading + 90, lateral),
                 heading: (heading + 180) % 360,
-                speed: 320
+                speed: 320,
+                pursuitTarget: root.ownship,
+                engageTarget: root.ownship,
+                // Slower than the duel bandit: three shooters share one
+                // salvo allowance.
+                engageHoldoff: 12,
+                engageTimer: i * root.stagger,
+                threatReflex: true
             });
-            const brain = root.brainFactory.createObject(root, {
-                entity: bandit,
-                stagger: i * 5
-            });
-            root.brains.set(bandit, brain);
-            root.systems.push(brain);
         }
     }
 
-    // Brains whose bandit has been reaped leave the run with their craft.
-    function prune() {
-        for (const [bandit, brain] of root.brains) {
-            if (!root.world.entities.includes(bandit)) {
-                root.systems = root.systems.filter(s => s !== brain);
-                root.brains.delete(bandit);
-                brain.destroy();
-            }
-        }
-    }
-
-    // Ends the show: unhooks ownship's demo targets and drops every brain —
-    // the world purge on leaving the menu despawns the bandits themselves.
+    // Ends the show: strips the demo aspects off the player's craft — the
+    // wave bandits despawn with the world purge on leaving the menu.
     function reset() {
-        evade.target = null;
-        engage.target = null;
+        root.ownship.evadeTarget = null;
+        root.ownship.engageTarget = null;
+        root.ownship.engageHold = false;
         root.clearTimer = 0;
         root.showTimer = 0;
-        for (const brain of root.brains.values()) {
-            root.systems = root.systems.filter(s => s !== brain);
-            brain.destroy();
-        }
-        root.brains.clear();
     }
 
     // Reopens the show from the top: sweep everything but ownship out of the
-    // world, seat ownship back at the origin and let the wave clock spawn the
-    // next engagement — in menu mode every other entity is demo-spawned, so
-    // the sweep owns exactly what the demo made.
+    // world, seat ownship back at the origin armed for the demo — reflexive
+    // flares, a paced trigger, no fuel burn — and let the wave clock spawn
+    // the next engagement. In menu mode every other entity is demo-spawned,
+    // so the sweep owns exactly what the demo made.
     function restart() {
         const roster = root.world.entities.slice();
         for (let i = 0; i < roster.length; ++i) {
@@ -251,6 +191,10 @@ Scenario {
         root.ownship.posY = 0;
         root.ownship.heading = 0;
         root.ownship.speed = 0;
+        root.ownship.burnsFuel = false;
+        root.ownship.threatReflex = true;
+        root.ownship.engageHoldoff = root.demoHoldoff;
+        root.ownship.engageTimer = 0;
         root.reset();
     }
 }

--- a/app/briarthorn/qml/systems/SystemEngage.qml
+++ b/app/briarthorn/qml/systems/SystemEngage.qml
@@ -2,16 +2,16 @@ import awen.entity
 import "../database"
 import "../model"
 
-// AI trigger discipline: invokes the entity's named launch ability when its
-// target is alive, inside the radar cone and within engageRange — with a
-// holdoff between invocations on top of the ability's own cooldown, so the
-// magazine is not dumped in one pass.
+// AI trigger discipline: every entity carrying an engageTarget invokes its
+// named launch ability when that target is alive, inside the radar cone and
+// within engageRange — paced by the entity's own holdoff on top of the
+// ability's cooldown, so no magazine is dumped in one pass. An entity held
+// by its engageHold flag stands down entirely, its pacing frozen with it.
 System {
     id: root
 
-    // The shooter and what it shoots at.
-    required property Entity entity
-    required property Entity target
+    // The world's roster; entities without the aspect are passed over.
+    property list<Entity> entities
 
     // The launch ability invoked, by registry name, and the round it spawns;
     // the cast is null for a name that is not a launch at all.
@@ -23,28 +23,30 @@ System {
     // physically fly, so the envelope tracks the weapon's own tuning.
     property real engageRange: root.round ? root.round.reach : 0
 
-    // Minimum seconds between invocations.
-    property real holdoff: 6
-
-    property real timer: 0
-
     function update(dt: real) {
-        root.timer = Math.max(0, root.timer - dt);
-        if (root.timer > 0 || root.target === null || root.target.health <= 0)
-            return;
-        const dx = root.target.posX - root.entity.posX;
-        const dy = root.target.posY - root.entity.posY;
-        if (Math.hypot(dx, dy) > root.engageRange)
-            return;
-        const bearing = Math.atan2(dx, -dy) * 180 / Math.PI;
-        const off = (((bearing - root.entity.heading) % 360) + 540) % 360 - 180;
-        if (Math.abs(off) > root.entity.radarFov / 2)
-            return;
-        for (let i = 0; i < root.entity.abilities.length; ++i) {
-            const slot = root.entity.abilities[i];
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (entity.engageTarget === null || entity.engageHold)
+                continue;
+            entity.engageTimer = Math.max(0, entity.engageTimer - dt);
+            if (entity.engageTimer > 0 || entity.engageTarget.health <= 0)
+                continue;
+            if (Geo.distance(entity, entity.engageTarget) > root.engageRange)
+                continue;
+            const off = Geo.wrap180(Geo.bearing(entity, entity.engageTarget) - entity.heading);
+            if (Math.abs(off) > entity.radarFov / 2)
+                continue;
+            root.fire(entity);
+        }
+    }
+
+    // Raises the named launch on its ready slot, winding the pacing back up.
+    function fire(entity: Entity) {
+        for (let i = 0; i < entity.abilities.length; ++i) {
+            const slot = entity.abilities[i];
             if (slot.def.name === root.ability && slot.ready) {
                 slot.activate();
-                root.timer = root.holdoff;
+                entity.engageTimer = entity.engageHoldoff;
                 return;
             }
         }

--- a/app/briarthorn/qml/systems/SystemEvade.qml
+++ b/app/briarthorn/qml/systems/SystemEvade.qml
@@ -1,33 +1,30 @@
 import awen.entity
 import "../model"
 
-// Standoff evasion: flies its entity about the target at full throttle —
-// beyond the standoff it noses in, at it it rides the perimeter, well inside
-// it turns tail — the 0..180 degree swing off the target's bearing blending
-// across half the standoff. Ports briardart's ManeuverEvade. With no target
-// it holds course.
+// Standoff evasion: every entity carrying an evadeTarget flies about it at
+// full throttle — beyond its standoff it noses in, at it it rides the
+// perimeter, well inside it turns tail — the 0..180 degree swing off the
+// target's bearing blending across half the standoff. Ports briardart's
+// ManeuverEvade.
 System {
     id: root
 
-    // The entity being flown and the threat it holds off; null flies straight.
-    required property Entity entity
-    property Entity target: null
-
-    // The orbit distance held off the target, metres.
-    property real standoff: 12000
+    // The world's roster; entities without the aspect are passed over.
+    property list<Entity> entities
 
     // Bearing error, in degrees, at which steer reaches full deflection.
     readonly property real cutAngle: 30
 
     function update(dt: real) {
-        root.entity.commandedThrottle = 1;
-        if (root.target === null) {
-            root.entity.commandedSteer = 0;
-            return;
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (entity.evadeTarget === null)
+                continue;
+            const excess = Math.max(-1, Math.min(1, (Geo.distance(entity, entity.evadeTarget) - entity.evadeStandoff) / (entity.evadeStandoff / 2)));
+            const desired = Geo.bearing(entity, entity.evadeTarget) + 90 * (1 - excess);
+            const error = Geo.wrap180(desired - entity.heading);
+            entity.commandedSteer = Math.max(-1, Math.min(1, error / root.cutAngle));
+            entity.commandedThrottle = 1;
         }
-        const excess = Math.max(-1, Math.min(1, (Geo.distance(root.entity, root.target) - root.standoff) / (root.standoff / 2)));
-        const desired = Geo.bearing(root.entity, root.target) + 90 * (1 - excess);
-        const error = Geo.wrap180(desired - root.entity.heading);
-        root.entity.commandedSteer = Math.max(-1, Math.min(1, error / root.cutAngle));
     }
 }

--- a/app/briarthorn/qml/systems/SystemFuel.qml
+++ b/app/briarthorn/qml/systems/SystemFuel.qml
@@ -2,18 +2,24 @@ import awen.entity
 import "../database"
 import "../model"
 
-// Fuel burn: the tank drains each tick at the rate the craft's kinetic rating
-// affords — a steady cruise draw, multiplied up under throttle — clamped at
-// empty. The sole writer of fuel; the condition readout reads it.
+// Fuel burn: every entity carrying the burnsFuel aspect drains its tank each
+// tick at the rate its kinetic rating affords — a steady cruise draw,
+// multiplied up under throttle — clamped at empty. The launch screen's demo
+// craft clears the flag rather than any scenario unloading this system.
 System {
     id: root
 
-    // The craft whose tank this drains.
-    required property Entity entity
+    // The world's roster; entities without the aspect are passed over.
+    property list<Entity> entities
 
     function update(dt: real) {
-        const throttle = Math.max(0, Math.min(1, root.entity.commandedThrottle));
-        const draw = root.entity.fuelBurn * (1 + GameRules.fuelThrottleBurn * throttle);
-        root.entity.fuel = Math.max(0, root.entity.fuel - draw * dt);
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (!entity.burnsFuel || entity.maxFuel <= 0)
+                continue;
+            const throttle = Math.max(0, Math.min(1, entity.commandedThrottle));
+            const draw = entity.fuelBurn * (1 + GameRules.fuelThrottleBurn * throttle);
+            entity.fuel = Math.max(0, entity.fuel - draw * dt);
+        }
     }
 }

--- a/app/briarthorn/qml/systems/SystemMission.qml
+++ b/app/briarthorn/qml/systems/SystemMission.qml
@@ -4,7 +4,7 @@ import "../model"
 // The win/lose engine: latches the duel's outcome from live model state —
 // defeat when the player's hull is gone, victory when the target's is. Once
 // terminal it holds, so a mutual kill the same tick cannot flip a result,
-// and the scenario reads the latch to freeze the game behind the end screen.
+// and the shell reads the latch to freeze the game behind the end screen.
 // Fuel starvation is deliberately not a loss yet: the current fuel economy
 // drains a full-throttle tank before the merge, so that condition waits on
 // the fuel tuning pass. Ports briardart's SystemMission.

--- a/app/briarthorn/qml/systems/SystemMission.qml
+++ b/app/briarthorn/qml/systems/SystemMission.qml
@@ -1,0 +1,40 @@
+import awen.entity
+import "../model"
+
+// The win/lose engine: latches the duel's outcome from live model state —
+// defeat when the player's hull is gone, victory when the target's is. Once
+// terminal it holds, so a mutual kill the same tick cannot flip a result,
+// and the scenario reads the latch to freeze the game behind the end screen.
+// Fuel starvation is deliberately not a loss yet: the current fuel economy
+// drains a full-throttle tank before the merge, so that condition waits on
+// the fuel tuning pass. Ports briardart's SystemMission.
+System {
+    id: root
+
+    enum Status {
+        Ongoing,
+        Victory,
+        Defeat
+    }
+
+    // The player's craft and the craft whose destruction wins the duel.
+    required property Entity player
+    required property Entity target
+
+    // The latched outcome.
+    property int status: SystemMission.Status.Ongoing
+
+    function update(dt: real) {
+        if (root.status !== SystemMission.Status.Ongoing)
+            return;
+        if (root.player.health <= 0)
+            root.status = SystemMission.Status.Defeat;
+        else if (root.target.health <= 0)
+            root.status = SystemMission.Status.Victory;
+    }
+
+    // Rearms the engine for a fresh duel.
+    function reset() {
+        root.status = SystemMission.Status.Ongoing;
+    }
+}

--- a/app/briarthorn/qml/systems/SystemPursuit.qml
+++ b/app/briarthorn/qml/systems/SystemPursuit.qml
@@ -1,25 +1,26 @@
 import awen.entity
 import "../model"
 
-// Pure-pursuit behaviour: flies its entity toward the target at full
-// throttle, steer saturating once the target sits more than cutAngle off the
-// nose.
+// Pure-pursuit behaviour: every entity carrying a pursuitTarget flies toward
+// it at full throttle, steer saturating once the target sits more than
+// cutAngle off the nose.
 System {
     id: root
 
-    // The entity being flown and the entity it chases.
-    required property Entity entity
-    required property Entity target
+    // The world's roster; entities without the aspect are passed over.
+    property list<Entity> entities
 
     // Bearing error, in degrees, at which steer reaches full deflection.
     readonly property real cutAngle: 30
 
     function update(dt: real) {
-        const dx = root.target.posX - root.entity.posX;
-        const dy = root.target.posY - root.entity.posY;
-        const bearing = Math.atan2(dx, -dy) * 180 / Math.PI;
-        const error = (((bearing - root.entity.heading) % 360) + 540) % 360 - 180;
-        root.entity.commandedSteer = Math.max(-1, Math.min(1, error / root.cutAngle));
-        root.entity.commandedThrottle = 1;
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (entity.pursuitTarget === null)
+                continue;
+            const error = Geo.wrap180(Geo.bearing(entity, entity.pursuitTarget) - entity.heading);
+            entity.commandedSteer = Math.max(-1, Math.min(1, error / root.cutAngle));
+            entity.commandedThrottle = 1;
+        }
     }
 }

--- a/app/briarthorn/qml/systems/SystemThreat.qml
+++ b/app/briarthorn/qml/systems/SystemThreat.qml
@@ -2,45 +2,57 @@ import awen.entity
 import "../database"
 import "../model"
 
-// Defensive reflex: pops the entity's flare once a hostile missile homing
-// on it closes inside threatRange, with a holdoff so consecutive pops give
-// each decoy a chance to steal the lock before the next one burns.
+// Defensive reflex: every entity carrying the threatReflex flag pops its
+// flare once a hostile missile homing on it closes inside threatRange, with
+// a per-entity holdoff so consecutive pops give each decoy a chance to
+// steal the lock before the next one burns.
 System {
     id: root
 
-    // The defended entity and the world scanned for inbound rounds.
-    required property Entity entity
-    required property World world
+    // The world's roster — both the defended entities and the sky scanned
+    // for the rounds homing on them.
+    property list<Entity> entities
 
     // Metres at which an inbound homing round triggers a pop.
     property real threatRange: 9000
 
-    // Minimum seconds between pops.
+    // Minimum seconds between one entity's pops.
     property real holdoff: 1.5
 
-    property real timer: 0
-
     function update(dt: real) {
-        root.timer = Math.max(0, root.timer - dt);
-        if (root.timer > 0)
-            return;
-        for (let i = 0; i < root.world.entities.length; ++i) {
-            const missile = root.world.entities[i];
-            if (missile.weapon === null || missile.weapon.target !== root.entity)
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (!entity.threatReflex)
                 continue;
-            const dx = missile.posX - root.entity.posX;
-            const dy = missile.posY - root.entity.posY;
-            if (Math.hypot(dx, dy) > root.threatRange)
+            entity.threatTimer = Math.max(0, entity.threatTimer - dt);
+            if (entity.threatTimer > 0)
                 continue;
-            for (let j = 0; j < root.entity.abilities.length; ++j) {
-                const slot = root.entity.abilities[j];
-                if (slot.def instanceof AbilityCountermeasure && slot.ready) {
-                    slot.activate();
-                    root.timer = root.holdoff;
-                    return;
-                }
+            if (root.inboundOn(entity))
+                root.pop(entity);
+        }
+    }
+
+    // Whether any homing round targeting the entity has closed inside range.
+    function inboundOn(entity: Entity): bool {
+        for (let i = 0; i < root.entities.length; ++i) {
+            const missile = root.entities[i];
+            if (missile.weapon === null || missile.weapon.target !== entity)
+                continue;
+            if (Geo.distance(missile, entity) <= root.threatRange)
+                return true;
+        }
+        return false;
+    }
+
+    // Burns one flare off the first ready countermeasure slot.
+    function pop(entity: Entity) {
+        for (let i = 0; i < entity.abilities.length; ++i) {
+            const slot = entity.abilities[i];
+            if (slot.def instanceof AbilityCountermeasure && slot.ready) {
+                slot.activate();
+                entity.threatTimer = root.holdoff;
+                return;
             }
-            return;
         }
     }
 }

--- a/app/briarthorn/qml/ui/MenuButton.qml
+++ b/app/briarthorn/qml/ui/MenuButton.qml
@@ -1,0 +1,111 @@
+import QtQuick
+import "../themes"
+
+// One themed menu action: lit by hover or the caller's cursor highlight,
+// accent-bordered when primary, sliding in on an index stagger each time the
+// owning overlay is revealed. Shared by the launch screen, the pause menu and
+// the end screen, so every menu reads as one chrome.
+Item {
+    id: root
+
+    // The stagger order — the row's position in its menu.
+    required property int index
+
+    property string label
+    property bool primary: false
+
+    // The cursor highlight, owned by the caller's Selector.
+    property bool selected: false
+
+    // Enlarges type and padding together; 1.0 is the compact card size.
+    property real scaleFactor: 1
+
+    // The owning overlay's visibility: each reveal replays the entrance.
+    property bool revealed: true
+
+    signal invoked
+
+    readonly property bool active: mouse.containsMouse || root.selected
+
+    // Breathing room above and below the caption, per side.
+    readonly property real captionPadding: 13
+
+    height: caption.implicitHeight + 2 * root.captionPadding * root.scaleFactor
+    opacity: 0
+
+    transform: Translate {
+        id: slide
+        x: -24
+    }
+
+    SequentialAnimation {
+        running: root.revealed
+
+        PropertyAction {
+            target: root
+            property: "opacity"
+            value: 0
+        }
+        PropertyAction {
+            target: slide
+            property: "x"
+            value: -24
+        }
+        PauseAnimation {
+            duration: 150 + root.index * 90
+        }
+        ParallelAnimation {
+            NumberAnimation {
+                target: root
+                property: "opacity"
+                to: 1
+                duration: 350
+                easing.type: Easing.OutCubic
+            }
+            NumberAnimation {
+                target: slide
+                property: "x"
+                to: 0
+                duration: 350
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: Style.theme.panelRadius
+        color: root.active ? Qt.alpha(Style.theme.accent, 0.2) : Style.theme.instrumentBackground
+        border.width: root.primary ? 2 : 1.5
+        border.color: root.active ? Style.theme.accentBright : (root.primary ? Style.theme.accent : Style.theme.frameInner)
+
+        Behavior on color {
+            ColorAnimation {
+                duration: 120
+            }
+        }
+        Behavior on border.color {
+            ColorAnimation {
+                duration: 120
+            }
+        }
+    }
+
+    Text {
+        id: caption
+
+        text: root.label
+        color: root.primary ? Style.theme.textBright : Style.theme.textPrimary
+        anchors.centerIn: parent
+        font { pixelSize: 14 * root.scaleFactor; bold: true; letterSpacing: 2 * root.scaleFactor; family: Style.monospace }
+    }
+
+    MouseArea {
+        id: mouse
+
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: root.invoked()
+    }
+}

--- a/app/briarthorn/qml/ui/MenuPage.qml
+++ b/app/briarthorn/qml/ui/MenuPage.qml
@@ -1,0 +1,183 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import awen.gamepad
+import awen.input
+import "../input"
+import "../themes"
+
+// A scrim-and-card overlay menu: a dimmed backdrop over the frozen scene, a
+// centred themed card with a title, an optional subtitle and one MenuButton
+// per entry, driven by mouse, keys (on the page's focus) and the pad routed
+// through Main — the pause and end screens are thin configurations of this.
+// The launch screen keeps its own bespoke layout.
+Item {
+    id: root
+
+    // Which device the player is driving with; the page's keys report in.
+    required property ActiveDevice device
+
+    property string title
+    property color titleColor: Style.theme.textBright
+    property string subtitle: ""
+
+    // The ordered actions: {label, primary, act} records, as ViewMenu builds.
+    property var entries: []
+
+    // Whether Escape / pad East backs out of the page; the end screen has
+    // nowhere to back out to, so it declines them.
+    property bool dismissible: false
+
+    signal dismissed
+
+    // The pad/keyboard cursor over the entries; mouse hover stays independent.
+    readonly property Selector cursor: Selector {
+        count: root.entries.length
+        onActivated: index => root.entries[index].act()
+    }
+
+    // A page being (re)shown starts unnavigated.
+    onVisibleChanged: if (visible)
+        root.cursor.reset()
+
+    // The left stick steps the cursor once per push, re-armed at centre.
+    Axis {
+        id: navAxis
+        onStepped: direction => root.cursor.move(direction)
+    }
+
+    Keys.onPressed: event => {
+        if (event.isAutoRepeat) {
+            event.accepted = false;
+            return;
+        }
+        root.device.kind = ActiveDevice.Keyboard;
+        switch (event.key) {
+        case Qt.Key_Up:
+        case Qt.Key_W:
+            root.cursor.move(-1);
+            break;
+        case Qt.Key_Down:
+        case Qt.Key_S:
+            root.cursor.move(1);
+            break;
+        case Qt.Key_Return:
+        case Qt.Key_Enter:
+        case Qt.Key_Space:
+            root.cursor.activate();
+            break;
+        case Qt.Key_Escape:
+        case Qt.Key_Back:
+            if (root.dismissible)
+                root.dismissed();
+            else
+                event.accepted = false;
+            break;
+        default:
+            event.accepted = false;
+            break;
+        }
+    }
+
+    // The pad's vocabulary; Main hands buttons over while the page is up.
+    // Start doubles as the way back where there is one — it opened the pause
+    // menu, so it closes it too.
+    function padPressed(button: int) {
+        switch (button) {
+        case Gamepad.Button.DpadUp:
+            root.cursor.move(-1);
+            break;
+        case Gamepad.Button.DpadDown:
+            root.cursor.move(1);
+            break;
+        case Gamepad.Button.South:
+            root.cursor.activate();
+            break;
+        case Gamepad.Button.East:
+        case Gamepad.Button.Start:
+            if (root.dismissible)
+                root.dismissed();
+            else if (button === Gamepad.Button.Start)
+                root.cursor.activate();
+            break;
+        default:
+            break;
+        }
+    }
+
+    function axisMoved(axis: int, value: real) {
+        if (axis === Gamepad.Axis.LeftY)
+            navAxis.invoke(value);
+    }
+
+    // The scrim: dims the frozen scene and swallows every pointer event.
+    Rectangle {
+        anchors.fill: parent
+        color: "#CC05080D"
+
+        MouseArea {
+            anchors.fill: parent
+        }
+    }
+
+    Rectangle {
+        id: card
+
+        width: Math.min(380, root.width - 32)
+        height: column.implicitHeight + 52
+        color: Style.theme.panelBackground
+        border.color: Style.theme.frameInner
+        border.width: 1
+        radius: Style.theme.panelRadius
+        anchors.centerIn: parent
+
+        Column {
+            id: column
+
+            spacing: 6
+
+            anchors {
+                left: parent.left
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+                leftMargin: 28
+                rightMargin: 28
+            }
+
+            Text {
+                text: root.title
+                color: root.titleColor
+                anchors.horizontalCenter: parent.horizontalCenter
+                font { pixelSize: 28; bold: true; letterSpacing: 4; family: Style.monospace }
+            }
+
+            Text {
+                visible: root.subtitle !== ""
+                text: root.subtitle
+                color: Style.theme.textLabel
+                anchors.horizontalCenter: parent.horizontalCenter
+                font { pixelSize: 12; letterSpacing: 3; family: Style.monospace }
+            }
+
+            Item {
+                width: 1
+                height: 14
+            }
+
+            Repeater {
+                model: root.entries
+
+                MenuButton {
+                    required property var modelData
+
+                    width: column.width
+                    label: modelData.label
+                    primary: modelData.primary
+                    selected: root.cursor.engaged && root.cursor.index === index
+                    revealed: root.visible
+                    onInvoked: modelData.act()
+                }
+            }
+        }
+    }
+}

--- a/app/briarthorn/qml/ui/ViewEnd.qml
+++ b/app/briarthorn/qml/ui/ViewEnd.qml
@@ -1,0 +1,48 @@
+import QtQuick
+import "../model"
+import "../systems"
+import "../themes"
+
+// The duel's result screen, over the frozen last frame: VICTORY or DEFEAT
+// with what decided it, then the retry, the way back to the launch screen
+// and the way out. A loss leads with the retry. Ports briardart's EndOverlay.
+MenuPage {
+    id: root
+
+    // The latched outcome this screen reads.
+    required property SystemMission mission
+
+    readonly property bool won: root.mission.status === SystemMission.Status.Victory
+
+    signal flyAgain
+    signal toMenu
+    signal exitGame
+
+    title: root.won ? qsTr("VICTORY") : qsTr("DEFEAT")
+    titleColor: root.won ? Style.theme.accentBright : Style.theme.warn
+    subtitle: root.won ? qsTr("%1 DESTROYED").arg(root.mission.target.callsign) : qsTr("AIRCRAFT DESTROYED")
+
+    // The web build has no window of its own to close, so it carries no exit.
+    entries: {
+        const list = [
+            {
+                label: qsTr("FLY AGAIN"),
+                primary: true,
+                act: () => root.flyAgain()
+            },
+            {
+                label: qsTr("MAIN MENU"),
+                primary: false,
+                act: () => root.toMenu()
+            }
+        ];
+        if (Qt.platform.os !== "wasm") {
+            list.push({
+                label: qsTr("EXIT GAME"),
+                primary: false,
+                act: () => root.exitGame()
+            });
+        }
+        return list;
+    }
+}

--- a/app/briarthorn/qml/ui/ViewHints.qml
+++ b/app/briarthorn/qml/ui/ViewHints.qml
@@ -13,7 +13,7 @@ Text {
     // craft on entirely different controls.
     required property ActiveDevice device
 
-    text: root.device.pad ? qsTr("LEFT STICK fly · D-PAD range · START controls") : qsTr("W thrust · A/D turn · WHEEL range · ESC controls")
+    text: root.device.pad ? qsTr("LEFT STICK fly · D-PAD range · START pause") : qsTr("W thrust · A/D turn · WHEEL range · ESC pause")
     color: Style.theme.textMuted
     elide: Text.ElideRight // the caller caps width where the line would collide
     font { pixelSize: 12; family: Style.monospace }

--- a/app/briarthorn/qml/ui/ViewMenu.qml
+++ b/app/briarthorn/qml/ui/ViewMenu.qml
@@ -226,8 +226,15 @@ Item {
             model: root.entries
 
             MenuButton {
+                required property var modelData
+
                 width: root.buttonWidth
                 scaleFactor: root.uiScale
+                label: modelData.label
+                primary: modelData.primary
+                selected: root.cursor.engaged && root.cursor.index === index
+                revealed: root.visible
+                onInvoked: modelData.act()
             }
         }
     }
@@ -281,103 +288,16 @@ Item {
                 model: root.entries
 
                 MenuButton {
+                    required property var modelData
+
                     width: cardColumn.width
+                    label: modelData.label
+                    primary: modelData.primary
+                    selected: root.cursor.engaged && root.cursor.index === index
+                    revealed: root.visible
+                    onInvoked: modelData.act()
                 }
             }
-        }
-    }
-
-    // One themed action: lit by hover or the engaged cursor, accent-bordered
-    // when primary, sliding in on a stagger as the menu shows.
-    component MenuButton: Item {
-        id: button
-
-        required property var modelData
-        required property int index
-        property real scaleFactor: 1
-
-        readonly property bool active: mouse.containsMouse || (root.cursor.engaged && root.cursor.index === button.index)
-
-        // Breathing room above and below the caption, per side.
-        readonly property real captionPadding: 13
-
-        height: caption.implicitHeight + 2 * button.captionPadding * button.scaleFactor
-        opacity: 0
-
-        transform: Translate {
-            id: slide
-            x: -24
-        }
-
-        SequentialAnimation {
-            running: root.visible
-
-            PropertyAction {
-                target: button
-                property: "opacity"
-                value: 0
-            }
-            PropertyAction {
-                target: slide
-                property: "x"
-                value: -24
-            }
-            PauseAnimation {
-                duration: 150 + button.index * 90
-            }
-            ParallelAnimation {
-                NumberAnimation {
-                    target: button
-                    property: "opacity"
-                    to: 1
-                    duration: 350
-                    easing.type: Easing.OutCubic
-                }
-                NumberAnimation {
-                    target: slide
-                    property: "x"
-                    to: 0
-                    duration: 350
-                    easing.type: Easing.OutCubic
-                }
-            }
-        }
-
-        Rectangle {
-            anchors.fill: parent
-            radius: Style.theme.panelRadius
-            color: button.active ? Qt.alpha(Style.theme.accent, 0.2) : Style.theme.instrumentBackground
-            border.width: button.modelData.primary ? 2 : 1.5
-            border.color: button.active ? Style.theme.accentBright : (button.modelData.primary ? Style.theme.accent : Style.theme.frameInner)
-
-            Behavior on color {
-                ColorAnimation {
-                    duration: 120
-                }
-            }
-            Behavior on border.color {
-                ColorAnimation {
-                    duration: 120
-                }
-            }
-        }
-
-        Text {
-            id: caption
-
-            text: button.modelData.label
-            color: button.modelData.primary ? Style.theme.textBright : Style.theme.textPrimary
-            anchors.centerIn: parent
-            font { pixelSize: 14 * button.scaleFactor; bold: true; letterSpacing: 2 * button.scaleFactor; family: Style.monospace }
-        }
-
-        MouseArea {
-            id: mouse
-
-            anchors.fill: parent
-            hoverEnabled: true
-            cursorShape: Qt.PointingHandCursor
-            onClicked: button.modelData.act()
         }
     }
 }

--- a/app/briarthorn/qml/ui/ViewPause.qml
+++ b/app/briarthorn/qml/ui/ViewPause.qml
@@ -1,0 +1,46 @@
+import QtQuick
+
+// The pause menu (Escape / pad Start mid-duel), over the frozen scope and
+// HUD. Resume leads; the way back to the launch screen and out of the game
+// sit below it. Ports briardart's PauseOverlay.
+MenuPage {
+    id: root
+
+    signal resumed
+    signal controls
+    signal toMenu
+    signal exitGame
+
+    title: qsTr("PAUSED")
+    dismissible: true
+    onDismissed: root.resumed()
+
+    // The web build has no window of its own to close, so it carries no exit.
+    entries: {
+        const list = [
+            {
+                label: qsTr("RESUME"),
+                primary: true,
+                act: () => root.resumed()
+            },
+            {
+                label: qsTr("CONTROLS"),
+                primary: false,
+                act: () => root.controls()
+            },
+            {
+                label: qsTr("MAIN MENU"),
+                primary: false,
+                act: () => root.toMenu()
+            }
+        ];
+        if (Qt.platform.os !== "wasm") {
+            list.push({
+                label: qsTr("EXIT GAME"),
+                primary: false,
+                act: () => root.exitGame()
+            });
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
## What

Closes the game loop: the duel now ends, pauses, and returns to the launch screen.

- **SystemMission** — the win/lose engine, run with the duel scenario: latches Victory when the bandit's hull is gone, Defeat when the player's is, and holds so a mutual kill cannot flip the result. `reset()` rearms it with the rest of the duel.
- **ViewPause** — Escape / pad Start mid-duel freezes the sim behind RESUME / CONTROLS / MAIN MENU / EXIT GAME; Escape, B or Start resumes; the controls page stacks on top and hands the keys back on close.
- **ViewEnd** — VICTORY (accent) or DEFEAT (warn) with what decided it, over the frozen deciding frame. FLY AGAIN re-enters through the same factory-fresh `startDuel()`; MAIN MENU returns via `startMenu()`, which now sweeps the duel's leavings through the demo's own restart.
- **Shared menu chrome** — `MenuButton` extracted from ViewMenu into its own file, plus a `MenuPage` scrim-and-card base carrying the Selector cursor, the key/pad vocabulary and the entrance stagger, so the pause and end screens are thin configurations and all three menus read as one system.
- **Main** — `paused` / `ended` join the focus dance and gate the sim, trails, wheel and pad routing. The stale "ESC controls" hint became "ESC pause".

## Why

The duel previously had no ending — kill the bandit or lose your hull and nothing happened — and no path back to the launch screen after PR #81 introduced it.

## Notes for review

- **No fuel-defeat yet, deliberately:** the current fuel economy empties a full-throttle tank in ~22 s while the duel merge takes ~70 s, so a fuel loss-condition would make the duel unwinnable. It waits on a fuel-tuning pass (commented in SystemMission).
- The duel itself can still stall (a rack-dry bandit chasing a faster player indefinitely) — same shape as the menu demo's old stall. Worth addressing alongside the fuel pass, since fuel pressure ends exactly that chase.
- Verified live end-to-end with scripted input: menu → duel → pause → resume → pause → MAIN MENU → duel → VICTORY → FLY AGAIN. Build, all 111 tests and qmllint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
