### PR TITLE
Entity personalities: database-defined stance machines, one system to fly them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,12 @@ assembles the APK).
 ## Briarthorn's game database
 
 Every static kind definition is one file under `app/briarthorn/qml/database/`,
-in `entities/`, `weapons/` or `abilities/`, registered in the single list on the
-`Database` (or `Abilities`) singleton — the lookup table derives from that list,
-so adding a kind is a new file, a new `Classification` and one line, never a
-switch to keep in step. `qml/model/` holds the live state those rows seed and is
-allowed to import `../database`; the database imports nothing back.
+in `entities/`, `weapons/`, `abilities/` or `personalities/`, registered in the
+single list on the `Database`, `Abilities` or `Personalities` singleton — the
+lookup table derives from that list, so adding a kind is a new file, a new
+`Classification` and one line, never a switch to keep in step. `qml/model/`
+holds the live state those rows seed and is allowed to import `../database`;
+the database imports nothing back.
 
 - **Stats are ratings, never quantities.** A `DataEntity` rates a kind 0..10 on
   the six stats and `GameRules` prices every rating into m/s, deg/s, m/s^2,
@@ -113,6 +114,14 @@ allowed to import `../database`; the database imports nothing back.
   overrides only what makes that one different; assigning nothing to `abilities`
   gives it the loadout its kind carries. `World.spawn(prefix, classification,
   props)` is the one spawn path.
+- **A personality is stances plus switches, priced on envelopes.** A
+  `Personality` row's stances name maneuvers from the model's `Maneuvers`
+  registry, and its `Switch` rows express every distance as a fraction of a
+  priced envelope (own weapon reach, the target's, detection range) — never
+  metres. `SystemPersonality` attaches the live `PersonalityState` and owns
+  `maneuvers`, `engageHold` and `engageHoldoff` on its entities; scenarios
+  point `engageTarget` and the personality decides how to fight it, so a
+  director-run entity (the menu demo's spawns) stays personality-free.
 - **Ability input is generated, never written.** Adding an ability is four
   edits: the def under `database/abilities/` (carrying its own `defaultKey` and
   `defaultButton`), a line in the `Abilities` registry, a line in

--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -5,7 +5,9 @@ set(QML_SINGLETONS
     qml/database/Abilities.qml
     qml/database/Database.qml
     qml/database/GameRules.qml
+    qml/database/Personalities.qml
     qml/model/Geo.qml
+    qml/model/Maneuvers.qml
     qml/themes/Style.qml
 )
 
@@ -32,7 +34,15 @@ awen_add_executable(${PROJECT_NAME}
         qml/database/Data.qml
         qml/database/DataEntity.qml
         qml/database/DataWeapon.qml
+        qml/database/Envelope.qml
+        qml/database/Personality.qml
+        qml/database/Stance.qml
         qml/database/Stats.qml
+        qml/database/Switch.qml
+        qml/database/SwitchAmmoOut.qml
+        qml/database/SwitchHealth.qml
+        qml/database/SwitchRange.qml
+        qml/database/SwitchThreat.qml
         qml/database/abilities/AbilityFlare.qml
         qml/database/abilities/AbilityLaunchGuided.qml
         qml/database/abilities/AbilityLaunchKinetic.qml
@@ -40,6 +50,10 @@ awen_add_executable(${PROJECT_NAME}
         qml/database/entities/DataAircraftFighterLight.qml
         qml/database/entities/DataDecoy.qml
         qml/database/entities/DataUnknown.qml
+        qml/database/personalities/PersonalityAggressive.qml
+        qml/database/personalities/PersonalityDefensive.qml
+        qml/database/personalities/PersonalityFearful.qml
+        qml/database/personalities/PersonalityTactical.qml
         qml/database/weapons/DataMissileGuided.qml
         qml/database/weapons/DataMissileKinetic.qml
         qml/input/AbilityInput.qml
@@ -54,6 +68,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/model/ManeuverFormation.qml
         qml/model/ManeuverNotch.qml
         qml/model/ManeuverPursue.qml
+        qml/model/PersonalityState.qml
         qml/model/RangeProjection.qml
         qml/model/Side.qml
         qml/model/StoreGame.qml
@@ -71,6 +86,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/systems/SystemManeuver.qml
         qml/systems/SystemMission.qml
         qml/systems/SystemMovement.qml
+        qml/systems/SystemPersonality.qml
         qml/systems/SystemThreat.qml
         qml/systems/SystemWeapon.qml
         qml/themes/Aurora.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -331,11 +331,13 @@ Window {
         // Run order is the lifetimes and the data flow: publish the batch,
         // consume player intent into the game store, let the scenarios set
         // conditions, judge the duel, then run the one set of shared systems
-        // — behaviour by entity aspect, ability clocks, fuel, poses, weapons,
-        // countermeasures and the radar sweep, detection last so tracks see
-        // the tick's outcome. Every system runs in every mode and processes
-        // exactly the entities carrying its aspect; the scenarios only shape
-        // the world and never load systems of their own.
+        // — threat marks first so minds and reflexes read fresh inbounds,
+        // personalities pick their stances, behaviour by entity aspect,
+        // ability clocks, fuel, poses, weapons, countermeasures and the
+        // radar sweep, detection last so tracks see the tick's outcome.
+        // Every system runs in every mode and processes exactly the entities
+        // carrying its aspect; the scenarios only shape the world and never
+        // load systems of their own.
         Systems {
             // The controls page, the pause menu and a decided duel all stop
             // the sim rather than letting it run on behind the player.
@@ -373,15 +375,19 @@ Window {
                 target: scenario.bandit
             }
 
+            SystemThreat {
+                entities: root.entities
+            }
+
+            SystemPersonality {
+                entities: root.entities
+            }
+
             SystemManeuver {
                 entities: root.entities
             }
 
             SystemEngage {
-                entities: root.entities
-            }
-
-            SystemThreat {
                 entities: root.entities
             }
 

--- a/app/briarthorn/qml/database/DataEntity.qml
+++ b/app/briarthorn/qml/database/DataEntity.qml
@@ -18,4 +18,9 @@ Data {
     // The abilities instances carry, by registry name — the whole loadout an
     // airframe brings, turned into live AbilitySlots when one is created.
     property list<string> abilities
+
+    // The stock temperament instances carry, by registry name; empty is
+    // pilot- or director-flown. Kind rows stay empty for now — the menu
+    // demo's director must keep sole ownership of engageHold on its spawns.
+    property string personality: ""
 }

--- a/app/briarthorn/qml/database/Envelope.qml
+++ b/app/briarthorn/qml/database/Envelope.qml
@@ -1,0 +1,12 @@
+import QtQml
+
+// The spans a personality prices its distances against, so a definition
+// never spells a metre: the carrier's own weapon reach, the target's, or the
+// carrier's detection range.
+QtObject {
+    enum Kind {
+        OwnWeapon,
+        TargetWeapon,
+        Detection
+    }
+}

--- a/app/briarthorn/qml/database/Personalities.qml
+++ b/app/briarthorn/qml/database/Personalities.qml
@@ -1,0 +1,35 @@
+pragma Singleton
+
+import QtQml
+import "personalities"
+
+// The personality registry: one definition per file under personalities/,
+// registered in the one list below and indexed by the name spawn sites and
+// kind rows route on. Adding a personality is a new file plus a single line.
+QtObject {
+    id: root
+
+    // The registration index. Order is not load-bearing.
+    readonly property list<Personality> registry: [
+        PersonalityAggressive {},
+        PersonalityDefensive {},
+        PersonalityFearful {},
+        PersonalityTactical {}
+    ]
+
+    // Name to row, derived from the registry on first lookup.
+    readonly property var table: root.indexed(root.registry)
+
+    // The definition routed on a name, or null for an unregistered one.
+    function defFor(name: string): Personality {
+        const row = root.table[name];
+        return row !== undefined ? row : null;
+    }
+
+    function indexed(rows: list<Personality>): var {
+        const table = {};
+        for (let i = 0; i < rows.length; ++i)
+            table[rows[i].name] = rows[i];
+        return table;
+    }
+}

--- a/app/briarthorn/qml/database/Personality.qml
+++ b/app/briarthorn/qml/database/Personality.qml
@@ -1,0 +1,30 @@
+import QtQml
+
+// One temperament: a named machine of stances, entry stance first.
+// Personality-wide switches are checked before the current stance's, and a
+// hit naming the current stance simply holds there.
+QtObject {
+    id: root
+
+    // The name spawn sites and kind rows route on.
+    property string name: ""
+
+    property list<Stance> stances
+    property list<Switch> switches
+
+    // Name to stance, derived from the list on first lookup.
+    readonly property var table: root.indexed(root.stances)
+
+    // The stance routed on a name, or null for one the personality lacks.
+    function stanceFor(name: string): Stance {
+        const row = root.table[name];
+        return row !== undefined ? row : null;
+    }
+
+    function indexed(rows: list<Stance>): var {
+        const table = {};
+        for (let i = 0; i < rows.length; ++i)
+            table[rows[i].name] = rows[i];
+        return table;
+    }
+}

--- a/app/briarthorn/qml/database/Stance.qml
+++ b/app/briarthorn/qml/database/Stance.qml
@@ -1,0 +1,37 @@
+import QtQml
+
+// One posture inside a Personality: what it flies (by Maneuvers-registry
+// name, so the database imports nothing back), how it holds the trigger, and
+// where it may go next. Shared and immutable like every database row.
+QtObject {
+    id: root
+
+    enum Reference {
+        Target,
+        Threat
+    }
+
+    property string name: ""
+
+    // The maneuver flown, by registry name; "" flies nothing and leaves the
+    // last commands standing.
+    property string maneuver: ""
+
+    // What the maneuver flies against: the engage target, or the inbound
+    // round — which falls back to the target while the sky is clear.
+    property int reference: Stance.Reference.Target
+
+    // Fraction of the envelope below priced onto the maneuver's standoff;
+    // 0 keeps the maneuver's own default.
+    property real standoff: 0
+    property int standoffOf: Envelope.Kind.OwnWeapon
+
+    // Trigger posture while current: holdFire mirrors onto engageHold, and a
+    // non-negative holdoff repaces the launches (-1 keeps the spawn pace).
+    property bool holdFire: false
+    property real holdoff: -1
+
+    // Outgoing transitions in priority order, checked after the
+    // personality's own.
+    property list<Switch> switches
+}

--- a/app/briarthorn/qml/database/Switch.qml
+++ b/app/briarthorn/qml/database/Switch.qml
@@ -1,0 +1,21 @@
+import QtQml
+
+// Base transition row inside a Personality: a pure condition and the stance
+// it leads to. One shared instance per use — the dwell clock lives on the
+// entity's PersonalityState, only the required seconds live here.
+QtObject {
+    id: root
+
+    // The destination stance, by name on the same personality.
+    property string to: ""
+
+    // Seconds the condition must hold continuously before the switch fires;
+    // 0 fires the tick it first holds.
+    property real dwell: 0
+
+    // Whether the condition holds against the situation SystemPersonality
+    // prices each tick; derived switches override this.
+    function holds(s: var): bool {
+        return false;
+    }
+}

--- a/app/briarthorn/qml/database/SwitchAmmoOut.qml
+++ b/app/briarthorn/qml/database/SwitchAmmoOut.qml
@@ -1,0 +1,8 @@
+// Fires once the launch rack is spent; an unlimited (-1) slot never trips it.
+Switch {
+    id: root
+
+    function holds(s: var): bool {
+        return s.rounds === 0;
+    }
+}

--- a/app/briarthorn/qml/database/SwitchHealth.qml
+++ b/app/briarthorn/qml/database/SwitchHealth.qml
@@ -1,0 +1,10 @@
+// Fires at or under a hull fraction.
+Switch {
+    id: root
+
+    property real below: 0.3
+
+    function holds(s: var): bool {
+        return s.healthFrac <= root.below;
+    }
+}

--- a/app/briarthorn/qml/database/SwitchRange.qml
+++ b/app/briarthorn/qml/database/SwitchRange.qml
@@ -1,0 +1,21 @@
+// Fires on the engage target sitting inside (or outside) a fraction of a
+// priced envelope; never with no target, or against an envelope that prices
+// to nothing.
+Switch {
+    id: root
+
+    property bool inside: true
+
+    // The band edge, as a fraction of the envelope named below.
+    property real at: 1
+    property int of: Envelope.Kind.OwnWeapon
+
+    function holds(s: var): bool {
+        if (s.target === null)
+            return false;
+        const span = root.of === Envelope.Kind.OwnWeapon ? s.reach : root.of === Envelope.Kind.TargetWeapon ? s.targetReach : s.entity.detectionRange;
+        if (span <= 0)
+            return false;
+        return root.inside ? s.range <= root.at * span : s.range > root.at * span;
+    }
+}

--- a/app/briarthorn/qml/database/SwitchThreat.qml
+++ b/app/briarthorn/qml/database/SwitchThreat.qml
@@ -1,0 +1,16 @@
+// Fires while a homing round is marked inbound inside a fraction of the
+// defended craft's detection envelope (present), or once none is (present
+// false) — the calm side of the same test, for the switch back.
+Switch {
+    id: root
+
+    property bool present: true
+
+    // Fraction of the carrier's detection range the round must close inside.
+    property real within: 1
+
+    function holds(s: var): bool {
+        const inbound = s.threat !== null && s.threatRange <= root.within * s.entity.detectionRange;
+        return root.present ? inbound : !inbound;
+    }
+}

--- a/app/briarthorn/qml/database/personalities/PersonalityAggressive.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityAggressive.qml
@@ -1,0 +1,47 @@
+import ".."
+
+// Closes and kills: presses through anything but a terminal inbound, and
+// backs off only once staying engaged stops paying — an empty rack. guard
+// keeps the trigger; the radar cone is what disciplines a beaming shot.
+Personality {
+    name: "aggressive"
+
+    switches: [
+        SwitchAmmoOut {
+            to: "disengage"
+        }
+    ]
+
+    stances: [
+        Stance {
+            name: "press"
+            maneuver: "pursue"
+            switches: [
+                SwitchThreat {
+                    present: true
+                    within: 0.2
+                    dwell: 0.3
+                    to: "guard"
+                }
+            ]
+        },
+        Stance {
+            name: "guard"
+            maneuver: "notch"
+            reference: Stance.Reference.Threat
+            switches: [
+                SwitchThreat {
+                    present: false
+                    within: 0.2
+                    dwell: 0.5
+                    to: "press"
+                }
+            ]
+        },
+        Stance {
+            name: "disengage"
+            maneuver: "flee"
+            holdFire: true
+        }
+    ]
+}

--- a/app/briarthorn/qml/database/personalities/PersonalityDefensive.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityDefensive.qml
@@ -1,0 +1,77 @@
+import ".."
+
+// Denial, not sniping: it holds station just outside the TARGET's envelope,
+// fires only at an intruder who presses into it, and half a hull ends its
+// war — where fearful trusts distance and has no health response at all.
+// Against an unarmed target the range switches never fire and monitor's
+// standoff falls back to the carrier's own reach.
+Personality {
+    name: "defensive"
+
+    switches: [
+        SwitchThreat {
+            present: true
+            within: 1
+            to: "break"
+        },
+        SwitchHealth {
+            below: 0.5
+            to: "abscond"
+        },
+        SwitchAmmoOut {
+            to: "abscond"
+        }
+    ]
+
+    stances: [
+        Stance {
+            name: "monitor"
+            maneuver: "evade"
+            holdFire: true
+            standoff: 1.15
+            standoffOf: Envelope.Kind.TargetWeapon
+            switches: [
+                SwitchRange {
+                    inside: true
+                    at: 0.9
+                    of: Envelope.Kind.TargetWeapon
+                    dwell: 1
+                    to: "repel"
+                }
+            ]
+        },
+        Stance {
+            name: "repel"
+            maneuver: "pursue"
+            holdoff: 4
+            switches: [
+                SwitchRange {
+                    inside: false
+                    at: 1
+                    of: Envelope.Kind.TargetWeapon
+                    dwell: 2
+                    to: "monitor"
+                }
+            ]
+        },
+        Stance {
+            name: "break"
+            maneuver: "notch"
+            reference: Stance.Reference.Threat
+            holdFire: true
+            switches: [
+                SwitchThreat {
+                    present: false
+                    within: 1
+                    dwell: 3
+                    to: "monitor"
+                }
+            ]
+        },
+        Stance {
+            name: "abscond"
+            maneuver: "flee"
+            holdFire: true
+        }
+    ]
+}

--- a/app/briarthorn/qml/database/personalities/PersonalityFearful.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityFearful.qml
@@ -1,0 +1,74 @@
+import ".."
+
+// Keeps its distance: orbits well inside its own envelope with the trigger
+// cold, buys one paced shot with two safe seconds, and drops everything the
+// moment danger shows. The orbit at 0.8 sits clear of the snipe gate at 0.9
+// so the entry holds solidly rather than flickering on the rim.
+Personality {
+    name: "fearful"
+
+    switches: [
+        SwitchThreat {
+            present: true
+            within: 0.6
+            to: "bail"
+        },
+        SwitchAmmoOut {
+            to: "depart"
+        }
+    ]
+
+    stances: [
+        Stance {
+            name: "shadow"
+            maneuver: "evade"
+            holdFire: true
+            standoff: 0.8
+            switches: [
+                SwitchRange {
+                    inside: true
+                    at: 0.9
+                    dwell: 2
+                    to: "snipe"
+                }
+            ]
+        },
+        Stance {
+            name: "snipe"
+            maneuver: "pursue"
+            holdoff: 8
+            switches: [
+                SwitchRange {
+                    inside: true
+                    at: 0.5
+                    to: "shadow"
+                },
+                SwitchRange {
+                    inside: false
+                    at: 1
+                    dwell: 1
+                    to: "shadow"
+                }
+            ]
+        },
+        Stance {
+            name: "bail"
+            maneuver: "notch"
+            reference: Stance.Reference.Threat
+            holdFire: true
+            switches: [
+                SwitchThreat {
+                    present: false
+                    within: 0.6
+                    dwell: 1.5
+                    to: "shadow"
+                }
+            ]
+        },
+        Stance {
+            name: "depart"
+            maneuver: "flee"
+            holdFire: true
+        }
+    ]
+}

--- a/app/briarthorn/qml/database/personalities/PersonalityTactical.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityTactical.qml
@@ -1,0 +1,91 @@
+import ".."
+
+// Attrition: cycles a firing band on its own envelope — advance cold, strike
+// paced, withdraw when pressed — with overlapped band edges as hysteresis,
+// notches only genuine inbounds, and retires hurt or dry.
+Personality {
+    name: "tactical"
+
+    switches: [
+        SwitchThreat {
+            present: true
+            within: 0.4
+            to: "evade"
+        },
+        // Hurt is one solid hit: flat warhead damage quantizes the hull, so
+        // a deeper threshold would never be seen alive.
+        SwitchHealth {
+            below: 0.45
+            to: "retire"
+        },
+        SwitchAmmoOut {
+            to: "retire"
+        }
+    ]
+
+    stances: [
+        Stance {
+            name: "advance"
+            maneuver: "pursue"
+            holdFire: true
+            switches: [
+                SwitchRange {
+                    inside: true
+                    at: 0.9
+                    to: "strike"
+                }
+            ]
+        },
+        Stance {
+            name: "strike"
+            maneuver: "pursue"
+            holdoff: 10
+            switches: [
+                SwitchRange {
+                    inside: true
+                    at: 0.6
+                    to: "withdraw"
+                },
+                SwitchRange {
+                    inside: false
+                    at: 1
+                    dwell: 1
+                    to: "advance"
+                }
+            ]
+        },
+        Stance {
+            name: "withdraw"
+            maneuver: "evade"
+            holdFire: true
+            standoff: 0.9
+            switches: [
+                SwitchRange {
+                    inside: false
+                    at: 0.85
+                    dwell: 1.5
+                    to: "strike"
+                }
+            ]
+        },
+        Stance {
+            name: "evade"
+            maneuver: "notch"
+            reference: Stance.Reference.Threat
+            holdFire: true
+            switches: [
+                SwitchThreat {
+                    present: false
+                    within: 0.4
+                    dwell: 1
+                    to: "advance"
+                }
+            ]
+        },
+        Stance {
+            name: "retire"
+            maneuver: "flee"
+            holdFire: true
+        }
+    ]
+}

--- a/app/briarthorn/qml/database/qmldir
+++ b/app/briarthorn/qml/database/qmldir
@@ -3,3 +3,4 @@
 singleton Abilities Abilities.qml
 singleton Database Database.qml
 singleton GameRules GameRules.qml
+singleton Personalities Personalities.qml

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -50,6 +50,16 @@ QtObject {
     // an empty (or fully stood-down) list leaves the commands to the pilot.
     property list<Maneuver> maneuvers
 
+    // The temperament SystemPersonality flies this entity with, defaulting
+    // from its kind; empty opts out. A personality owns maneuvers,
+    // engageHold and engageHoldoff — a director must not share an entity
+    // with one.
+    property string personality: root.def ? root.def.personality : ""
+
+    // The live stance machine, built by SystemPersonality on the first
+    // tick; reassigning personality mid-life is not supported.
+    property PersonalityState mind: null
+
     // SystemEngage shoots at this inside the envelope. holdoff (s) paces the
     // launches; the timer is its run-down state, seedable to stagger a
     // wave's opening shots; engageHold stands the shooter down while true —
@@ -63,6 +73,10 @@ QtObject {
     // timer spaces the pops so each decoy gets its chance to seduce.
     property bool threatReflex: false
     property real threatTimer: 0
+
+    // The nearest homing round SystemThreat marked inbound this tick; both
+    // the flare reflex and SystemPersonality read this one fact.
+    property Entity threatInbound: null
 
     // SystemFuel drains the tank; the launch screen's demo craft clears this
     // so an endless showing never runs dry.
@@ -85,6 +99,23 @@ QtObject {
     readonly property real acceleration: GameRules.accelerationFor(root.maneuver)
     readonly property real detectionRange: GameRules.detectionRangeFor(root.sensor)
     readonly property real fuelBurn: GameRules.fuelBurnFor(root.kinetic)
+
+    // The longest reach across the rack's launch slots — capability, not
+    // stock, so the envelope survives an empty magazine.
+    readonly property real weaponReach: root.reachFrom(root.abilities)
+
+    function reachFrom(slots: list<AbilitySlot>): real {
+        let reach = 0;
+        for (let i = 0; i < slots.length; ++i) {
+            const launch = slots[i].def as AbilityLaunch;
+            if (launch === null)
+                continue;
+            const round = Database.weaponDataFor(launch.weapon);
+            if (round !== null)
+                reach = Math.max(reach, round.reach);
+        }
+        return reach;
+    }
 
     // Condition: current and maximum hull integrity and fuel. Pure state —
     // SystemWeapon's blasts write health, SystemFuel writes fuel, the view

--- a/app/briarthorn/qml/model/Maneuvers.qml
+++ b/app/briarthorn/qml/model/Maneuvers.qml
@@ -1,0 +1,50 @@
+pragma Singleton
+
+import QtQml
+
+// The maneuver factory registry: database stances name flights by string so
+// the database keeps importing nothing back, and this table turns a name
+// into a live instance. A new maneuver is its model file plus one Component
+// and one table line here.
+QtObject {
+    id: root
+
+    readonly property Component pursue: Component {
+        ManeuverPursue {}
+    }
+
+    readonly property Component evade: Component {
+        ManeuverEvade {}
+    }
+
+    readonly property Component notch: Component {
+        ManeuverNotch {}
+    }
+
+    readonly property Component flee: Component {
+        ManeuverFlee {}
+    }
+
+    readonly property Component formation: Component {
+        ManeuverFormation {}
+    }
+
+    readonly property var table: ({
+            "pursue": root.pursue,
+            "evade": root.evade,
+            "notch": root.notch,
+            "flee": root.flee,
+            "formation": root.formation
+        })
+
+    // A fresh maneuver of the named kind under the given owner, or null with
+    // a warning for a name nothing registered.
+    function make(name: string, owner: QtObject): Maneuver {
+        const factory = root.table[name];
+        if (factory === undefined) {
+            console.warn("Maneuvers: no registered maneuver named \"" + name + "\"");
+            return null;
+        }
+        return factory.createObject(owner) as Maneuver;
+    }
+}

--- a/app/briarthorn/qml/model/PersonalityState.qml
+++ b/app/briarthorn/qml/model/PersonalityState.qml
@@ -1,0 +1,36 @@
+import QtQml
+import "../database"
+
+// One personality as carried by an entity: the shared definition row plus
+// every mutable per-entity thing — current stance, the dwell clock and the
+// live maneuvers the stances fly. SystemPersonality is the only writer, so
+// all of it advances on sim time and freezes with the tick.
+QtObject {
+    id: root
+
+    // The personality definition this mind runs; null seats an unregistered
+    // name, warned once at attach and skipped ever after.
+    property Personality def: null
+
+    // The current stance, a shared immutable row reference.
+    property Stance stance: null
+
+    // The switch accumulating dwell and its clock; a different switch coming
+    // up first resets the clock.
+    property Switch pending: null
+    property real dwell: 0
+
+    // The entity's engageHoldoff captured at attach, restored by stances
+    // that do not repace it.
+    property real baseHoldoff: 6
+
+    // One live maneuver per stance in definition order, null where a stance
+    // flies nothing — a JS array, because a QML list cannot hold the gaps.
+    property var maneuvers: []
+
+    // The live maneuver a stance flies, or null.
+    function maneuverFor(stance: Stance): Maneuver {
+        const i = root.def.stances.indexOf(stance);
+        return i >= 0 ? root.maneuvers[i] : null;
+    }
+}

--- a/app/briarthorn/qml/model/qmldir
+++ b/app/briarthorn/qml/model/qmldir
@@ -1,3 +1,4 @@
-# This folder's singleton for the directory import — see commands/qmldir for
+# This folder's singletons for the directory import — see commands/qmldir for
 # the full story. Mirror changes into QML_SINGLETONS in ../../CMakeLists.txt.
 singleton Geo Geo.qml
+singleton Maneuvers Maneuvers.qml

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -18,21 +18,18 @@ Scenario {
     required property Entity ownship
 
     // The downrated airframe, so the duel is winnable, with its rack's flare
-    // pod halved on top — a full pod outlasts the player's patience.
+    // pod halved on top — a full pod outlasts the player's patience. The
+    // scenario points the target; the personality decides how to fight it,
+    // so a dry bandit breaks off rather than pursuing forever.
     component DuelBandit: Entity {
         callsign: "BANDIT 1"
         classification: Classification.Kind.AircraftFighterLight
         side: Side.Kind.Hostile
         posY: -65000
         heading: 180
+        personality: "aggressive"
         engageTarget: root.ownship
         threatReflex: true
-
-        maneuvers: [
-            ManeuverPursue {
-                target: root.ownship
-            }
-        ]
 
         abilities: [
             AbilitySlot {

--- a/app/briarthorn/qml/scenarios/ScenarioMenu.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioMenu.qml
@@ -155,7 +155,9 @@ Scenario {
     // Spawns a fresh wave fanned out ahead of ownship's nose — downrated
     // airframes off the database, each declaring its whole behaviour at
     // birth: chase the player, shoot on a slow cadence from a staggered
-    // start, flare at inbound rounds.
+    // start, flare at inbound rounds. Deliberately personality-free: the
+    // director owns engageHold for its salvo cap, and a personality would
+    // fight it for the trigger every tick.
     function spawnWave() {
         const heading = root.ownship.heading;
         for (let i = 0; i < root.waveSize; ++i) {

--- a/app/briarthorn/qml/systems/SystemPersonality.qml
+++ b/app/briarthorn/qml/systems/SystemPersonality.qml
@@ -1,0 +1,179 @@
+import QtQml
+import awen.entity
+import "../database"
+import "../model"
+
+// How a personality-carrying entity fights the target its scenario points:
+// each tick it prices one situation, advances the stance machine with dt and
+// arms the maneuver and trigger machinery the stance chose — it never steers
+// or shoots itself, and a frozen sim freezes every mind mid-dwell.
+System {
+    id: root
+
+    // The world's roster; entities without a personality are passed over.
+    property list<Entity> entities
+
+    readonly property Component mindFactory: Component {
+        PersonalityState {}
+    }
+
+    function update(dt: real) {
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (entity.personality === "")
+                continue;
+            if (entity.mind === null)
+                root.attach(entity);
+            if (entity.mind.def === null)
+                continue;
+            const s = root.situationOf(entity);
+            root.advance(entity, s, dt);
+            root.arm(entity, s);
+        }
+    }
+
+    // Builds the mind on the entity's first tick — construction inside sim
+    // time, so a factory-reset craft gets a factory-fresh mind. An
+    // unregistered name warns once and leaves a def-less mind behind.
+    function attach(entity: Entity) {
+        const def = Personalities.defFor(entity.personality);
+        entity.mind = root.mindFactory.createObject(entity, {
+            def: def,
+            baseHoldoff: entity.engageHoldoff
+        }) as PersonalityState;
+        if (def === null) {
+            console.warn("SystemPersonality: no registered personality named \"" + entity.personality + "\"");
+            return;
+        }
+        const flown = [];
+        const owned = [];
+        for (let i = 0; i < def.stances.length; ++i) {
+            const m = def.stances[i].maneuver !== "" ? Maneuvers.make(def.stances[i].maneuver, entity.mind) : null;
+            flown.push(m);
+            if (m !== null)
+                owned.push(m);
+        }
+        entity.mind.maneuvers = flown;
+        entity.maneuvers = owned;
+        entity.mind.stance = def.stances[0];
+        root.vet(def);
+    }
+
+    // Warns about any switch destination the definition lacks, so a typo'd
+    // stance name surfaces at spawn instead of as a silent hold mid-fight.
+    function vet(def: Personality) {
+        for (let i = 0; i < def.switches.length; ++i)
+            root.vetSwitch(def, def.switches[i]);
+        for (let i = 0; i < def.stances.length; ++i) {
+            for (let j = 0; j < def.stances[i].switches.length; ++j)
+                root.vetSwitch(def, def.stances[i].switches[j]);
+        }
+    }
+
+    function vetSwitch(def: Personality, sw: Switch) {
+        if (def.stanceFor(sw.to) === null)
+            console.warn("SystemPersonality: personality \"" + def.name + "\" switches to an unknown stance \"" + sw.to + "\"");
+    }
+
+    // One priced fact sheet per entity per tick: every span an envelope,
+    // never a raw metre. threat reads the mark SystemThreat pinned.
+    function situationOf(entity: Entity): var {
+        const target = entity.engageTarget;
+        return {
+            entity: entity,
+            target: target,
+            range: target !== null ? Geo.distance(entity, target) : Infinity,
+            reach: entity.weaponReach,
+            targetReach: target !== null ? target.weaponReach : 0,
+            threat: entity.threatInbound,
+            threatRange: entity.threatInbound !== null ? Geo.distance(entity, entity.threatInbound) : Infinity,
+            // A hull never given health is unkillable, so it is never hurt.
+            healthFrac: entity.maxHealth > 0 ? entity.health / entity.maxHealth : 1,
+            rounds: root.roundsOf(entity)
+        };
+    }
+
+    // Rounds left across the launch rack; any unlimited slot reads Infinity.
+    function roundsOf(entity: Entity): real {
+        let rounds = 0;
+        for (let i = 0; i < entity.abilities.length; ++i) {
+            const slot = entity.abilities[i];
+            if (!(slot.def instanceof AbilityLaunch))
+                continue;
+            if (slot.charges === -1)
+                return Infinity;
+            rounds += slot.charges;
+        }
+        return rounds;
+    }
+
+    // First-hold-wins over the personality's switches then the stance's,
+    // skipping any that name the stance already held — satisfied, never
+    // blocking — so a survival switch further down still fires out of a
+    // pinned stance. Dwell accumulates only while the same switch stays
+    // first.
+    function advance(entity: Entity, s: var, dt: real) {
+        const mind = entity.mind;
+        const first = root.firstSwitch(mind, s);
+        if (first === null) {
+            mind.pending = null;
+            mind.dwell = 0;
+            return;
+        }
+        if (mind.pending !== first) {
+            mind.pending = first;
+            mind.dwell = 0;
+        }
+        mind.dwell += dt;
+        if (mind.dwell >= first.dwell) {
+            // A destination the definition lacks was warned at attach; the
+            // stance holds rather than poisoning the tick with a null.
+            const next = mind.def.stanceFor(first.to);
+            if (next !== null)
+                mind.stance = next;
+            mind.pending = null;
+            mind.dwell = 0;
+        }
+    }
+
+    // The highest-priority holding switch that would actually move the
+    // stance, or null when none would.
+    function firstSwitch(mind: PersonalityState, s: var): Switch {
+        for (let i = 0; i < mind.def.switches.length; ++i) {
+            const sw = mind.def.switches[i];
+            if (sw.to !== mind.stance.name && sw.holds(s))
+                return sw;
+        }
+        for (let i = 0; i < mind.stance.switches.length; ++i) {
+            const sw = mind.stance.switches[i];
+            if (sw.to !== mind.stance.name && sw.holds(s))
+                return sw;
+        }
+        return null;
+    }
+
+    // Points exactly the current stance's maneuver — the targets drive the
+    // maneuvers' own engaged bindings — prices its standoff, and sets the
+    // trigger posture SystemEngage obeys.
+    function arm(entity: Entity, s: var) {
+        const mind = entity.mind;
+        const stance = mind.stance;
+        const current = mind.maneuverFor(stance);
+        const reference = stance.reference === Stance.Reference.Threat && s.threat !== null ? s.threat : s.target;
+        for (let i = 0; i < mind.maneuvers.length; ++i) {
+            const m = mind.maneuvers[i];
+            if (m !== null)
+                m.target = m === current ? reference : null;
+        }
+        if (current !== null && stance.standoff > 0 && "standoff" in current) {
+            let span = stance.standoffOf === Envelope.Kind.OwnWeapon ? s.reach : stance.standoffOf === Envelope.Kind.TargetWeapon ? s.targetReach : entity.detectionRange;
+            // An unarmed target still needs a ring to ride.
+            if (span <= 0)
+                span = s.reach;
+            if (span > 0)
+                current.standoff = stance.standoff * span;
+        }
+        entity.engageHold = stance.holdFire;
+        entity.engageHoldoff = stance.holdoff >= 0 ? stance.holdoff : mind.baseHoldoff;
+    }
+}

--- a/app/briarthorn/qml/systems/SystemThreat.qml
+++ b/app/briarthorn/qml/systems/SystemThreat.qml
@@ -2,10 +2,13 @@ import awen.entity
 import "../database"
 import "../model"
 
-// Defensive reflex: every entity carrying the threatReflex flag pops its
-// flare once a hostile missile homing on it closes inside threatRange, with
-// a per-entity holdoff so consecutive pops give each decoy a chance to
-// steal the lock before the next one burns.
+// Threat sensing and the defensive reflex: a mark pass pins the nearest
+// homing round inside each target's detection envelope onto its
+// threatInbound — the one inbound fact both the flare reflex below and
+// SystemPersonality read — then every entity carrying the threatReflex flag
+// pops its flare once its marked round closes inside threatRange, with a
+// per-entity holdoff so consecutive pops give each decoy a chance to steal
+// the lock before the next one burns.
 System {
     id: root
 
@@ -20,6 +23,7 @@ System {
     property real holdoff: 1.5
 
     function update(dt: real) {
+        root.mark();
         for (let i = 0; i < root.entities.length; ++i) {
             const entity = root.entities[i];
             if (!entity.threatReflex)
@@ -27,21 +31,27 @@ System {
             entity.threatTimer = Math.max(0, entity.threatTimer - dt);
             if (entity.threatTimer > 0)
                 continue;
-            if (root.inboundOn(entity))
+            if (entity.threatInbound !== null && Geo.distance(entity, entity.threatInbound) <= root.threatRange)
                 root.pop(entity);
         }
     }
 
-    // Whether any homing round targeting the entity has closed inside range.
-    function inboundOn(entity: Entity): bool {
+    // Pins each entity's nearest homing round within its detection range,
+    // clearing yesterday's marks first so a defeated round drops off.
+    function mark() {
+        for (let i = 0; i < root.entities.length; ++i)
+            root.entities[i].threatInbound = null;
         for (let i = 0; i < root.entities.length; ++i) {
             const missile = root.entities[i];
-            if (missile.weapon === null || missile.weapon.target !== entity)
+            if (missile.weapon === null || missile.weapon.target === null)
                 continue;
-            if (Geo.distance(missile, entity) <= root.threatRange)
-                return true;
+            const target = missile.weapon.target;
+            const range = Geo.distance(missile, target);
+            if (range > target.detectionRange)
+                continue;
+            if (target.threatInbound === null || range < Geo.distance(target, target.threatInbound))
+                target.threatInbound = missile;
         }
-        return false;
     }
 
     // Burns one flare off the first ready countermeasure slot.


### PR DESCRIPTION
## Summary

- **Personalities live in `database/personalities/`** — one file per temperament, registered in the new `Personalities` singleton (the `Abilities` pattern). A `Personality` is a named machine of `Stance` rows: each stance names the maneuver it flies (by `Maneuvers`-registry string, so the database still imports nothing back), its trigger posture (`holdFire` onto `engageHold`, an optional launch `holdoff`), and its outgoing `Switch` transitions. Switch kinds are one file each — `SwitchAmmoOut`, `SwitchThreat`, `SwitchRange`, `SwitchHealth` — with `dwell` seconds of hysteresis, and every distance is a **fraction of a priced envelope** (own weapon reach, the target''s, detection range — `Envelope.Kind`), never metres.
- **The live side is the `AbilitySlot` split**: `model/PersonalityState` holds the current stance, the dwell clock and the live maneuvers; `systems/SystemPersonality` attaches it on the entity''s first tick, prices one situation per tick, advances the machine with dt (first-hold-wins, personality-wide switches before the stance''s; a switch naming the held stance is satisfied, not blocking, so survival switches still fire out of a pinned stance), then arms the maneuver targets and trigger aspects. Everything advances on sim time — a paused game freezes every mind mid-dwell.
- **Four temperaments shipped**: *Aggressive* presses through anything and breaks off only dry; *Fearful* orbits cold at distance, buys one paced shot with two safe seconds, bails the moment danger shows; *Tactical* cycles a firing band with overlapped edges as hysteresis and retires hurt or dry; *Defensive* holds station off the **target''s** envelope, repels intruders, and half a hull ends its war.
- **SystemThreat gained a mark pass**: the nearest inbound homing round within each craft''s detection envelope pins to `Entity.threatInbound` — one fact the flare reflex and every mind read, replacing per-consumer O(n²) scans.
- Scenarios keep target selection: the duel bandit now just declares `personality: aggressive`; the menu demo''s waves stay deliberately personality-free because its director owns `engageHold` (documented at the spawn site and in CLAUDE.md''s new database clause).

## Design

Chosen by a three-architecture judge panel: a typed declarative FSM beat QML States/StateGroup (whose `when` bindings re-evaluate on property writes — transitions mid-tick, decisions while frozen, no dt for dwell) and a behavior tree (whose composites go uncalled — every tree for these four personalities is one guarded priority list deep). Extension cost: a fifth personality or a new switch kind is one file plus a registry/CMake line; `SystemPersonality` is never edited.

## Verification

- A 50-assertion headless harness (qml.exe driving `SystemThreat` + `SystemPersonality` off the source tree) covers attach, every declared transition, dwell hysteresis and freeze-under-pause, envelope pricing (including the unarmed-target fallback), threat marks and reflex thresholds, warn-once on unregistered names, and the no-personality regression.
- An adversarial four-lens review ran against the diff; its three real findings are fixed and asserted: a typo''d switch destination now warns at attach and holds the stance instead of poisoning the tick loop, survival switches escape threat-pinned stances, and an unkillable (maxHealth 0) hull prices as whole rather than dead. Tactical''s health threshold moved to 0.45 — flat warhead damage quantizes the hull, so the original 0.3 was unreachable alive.
- Debug build, qmllint gate, and all 111 ctest cases pass; a live duel run shows the aggressive bandit resolved on the nose pressing in from spawn, with clean logs; the menu demo is regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)