### PR TITLE
Anchored maneuvers and a patrol orbit

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -67,6 +67,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/model/ManeuverFlee.qml
         qml/model/ManeuverFormation.qml
         qml/model/ManeuverNotch.qml
+        qml/model/ManeuverOrbit.qml
         qml/model/ManeuverPursue.qml
         qml/model/PersonalityState.qml
         qml/model/RangeProjection.qml

--- a/app/briarthorn/qml/model/Maneuver.qml
+++ b/app/briarthorn/qml/model/Maneuver.qml
@@ -8,14 +8,33 @@ import QtQml
 QtObject {
     id: root
 
-    // The craft this maneuver flies relative to; null stands it down.
+    // The craft this maneuver flies relative to; null stands it down unless
+    // a point is anchored below.
     property Entity target: null
 
+    // A fixed world point flown when no target is set — a waypoint, patrol
+    // station or avoid area. Scenario- and director-armed only: a
+    // personality disengages its stances by nulling target, so its
+    // maneuvers must stay anchor-free.
+    property real anchorX: 0
+    property real anchorY: 0
+    property bool anchored: false
+
     // Whether this maneuver wants the stick this tick.
-    property bool engaged: root.target !== null
+    property bool engaged: root.target !== null || root.anchored
 
     // Bearing error, in degrees, at which steer reaches full deflection.
     readonly property real cutAngle: 30
+
+    // Where the maneuver flies relative to: the target when one is set, the
+    // anchored point otherwise.
+    function focusX(): real {
+        return root.target !== null ? root.target.posX : root.anchorX;
+    }
+
+    function focusY(): real {
+        return root.target !== null ? root.target.posY : root.anchorY;
+    }
 
     // Flies the entity for one tick: onto the desired heading at full throttle.
     function fly(entity: Entity, dt: real) {

--- a/app/briarthorn/qml/model/ManeuverEvade.qml
+++ b/app/briarthorn/qml/model/ManeuverEvade.qml
@@ -1,17 +1,17 @@
 import QtQml
 
-// Standoff evasion: fly about the target — beyond the standoff nose in, at it
-// ride the perimeter, well inside turn tail — the 0..180 degree swing off the
-// target's bearing blending across half the standoff. Ports briardart's
-// ManeuverEvade.
+// Standoff evasion: fly about the focus — a target, or an anchored point —
+// beyond the standoff nose in, at it ride the perimeter, well inside turn
+// tail — the 0..180 degree swing off its bearing blending across half the
+// standoff. Ports briardart's ManeuverEvade.
 Maneuver {
     id: root
 
-    // Metres held off the target.
+    // Metres held off the focus.
     property real standoff: 12000
 
     function desiredHeading(entity: Entity): real {
-        const excess = Math.max(-1, Math.min(1, (Geo.distance(entity, root.target) - root.standoff) / (root.standoff / 2)));
-        return Geo.bearing(entity, root.target) + 90 * (1 - excess);
+        const excess = Math.max(-1, Math.min(1, (Geo.distanceFrom(entity.posX, entity.posY, root.focusX(), root.focusY()) - root.standoff) / (root.standoff / 2)));
+        return Geo.bearingFrom(entity.posX, entity.posY, root.focusX(), root.focusY()) + 90 * (1 - excess);
     }
 }

--- a/app/briarthorn/qml/model/ManeuverFlee.qml
+++ b/app/briarthorn/qml/model/ManeuverFlee.qml
@@ -1,10 +1,11 @@
 import QtQml
 
-// Flight: fly directly away from the target, tail square to its bearing.
+// Flight: fly directly away from the focus — a target, or an anchored area
+// to avoid — tail square to its bearing.
 Maneuver {
     id: root
 
     function desiredHeading(entity: Entity): real {
-        return Geo.reciprocal(Geo.bearing(entity, root.target));
+        return Geo.reciprocal(Geo.bearingFrom(entity.posX, entity.posY, root.focusX(), root.focusY()));
     }
 }

--- a/app/briarthorn/qml/model/ManeuverFormation.qml
+++ b/app/briarthorn/qml/model/ManeuverFormation.qml
@@ -6,6 +6,11 @@ import QtQml
 Maneuver {
     id: root
 
+    // Entity-only: the slot is placed off the leader's nose and the throttle
+    // trims against the leader's speed, neither of which a point has — so an
+    // anchor alone never engages this maneuver.
+    engaged: root.target !== null
+
     // The station: degrees clockwise off the leader's nose and metres out —
     // the default is the leader's right-rear quarter.
     property real station: 135

--- a/app/briarthorn/qml/model/ManeuverNotch.qml
+++ b/app/briarthorn/qml/model/ManeuverNotch.qml
@@ -1,13 +1,13 @@
 import QtQml
 
-// Notching: hold the target on the beam — flight path perpendicular to its
-// bearing, the zero-closure aspect — turning whichever way is the shorter
-// swing from the current heading.
+// Notching: hold the focus — a target, or an anchored point — on the beam,
+// flight path perpendicular to its bearing, the zero-closure aspect —
+// turning whichever way is the shorter swing from the current heading.
 Maneuver {
     id: root
 
     function desiredHeading(entity: Entity): real {
-        const bearing = Geo.bearing(entity, root.target);
+        const bearing = Geo.bearingFrom(entity.posX, entity.posY, root.focusX(), root.focusY());
         const right = Geo.wrap180(Geo.perpendicularRight(bearing) - entity.heading);
         const left = Geo.wrap180(Geo.perpendicularLeft(bearing) - entity.heading);
         return Math.abs(right) <= Math.abs(left) ? Geo.perpendicularRight(bearing) : Geo.perpendicularLeft(bearing);

--- a/app/briarthorn/qml/model/ManeuverOrbit.qml
+++ b/app/briarthorn/qml/model/ManeuverOrbit.qml
@@ -1,0 +1,31 @@
+import QtQml
+
+// Patrol orbit: fly to the focus — a target, or an anchored station — and
+// ride a ring at the standoff around it, easing onto the cruise throttle on
+// station. A ring is only flyable above the airframe's turning circle
+// (speed over turn rate), which is what cruise is for: slower buys tighter.
+Maneuver {
+    id: root
+
+    // The ring radius, metres — named as ManeuverEvade's so a personality
+    // stance prices it the same way.
+    property real standoff: 9000
+
+    // Throttle ridden on station; the transit out to the ring flies at
+    // full and blends down on arrival.
+    property real cruise: 0.6
+
+    // Which way the ring is ridden, as seen on the scope.
+    property bool clockwise: true
+
+    function fly(entity: Entity, dt: real) {
+        const range = Geo.distanceFrom(entity.posX, entity.posY, root.focusX(), root.focusY());
+        const bearing = Geo.bearingFrom(entity.posX, entity.posY, root.focusX(), root.focusY());
+        const excess = Math.max(-1, Math.min(1, (range - root.standoff) / (root.standoff / 2)));
+        // The 0..180 swing off the focus bearing, as ManeuverEvade's; its
+        // sign picks the ring direction.
+        const swing = 90 * (1 - excess);
+        root.steerToward(entity, bearing + (root.clockwise ? -swing : swing));
+        entity.commandedThrottle = root.cruise + (1 - root.cruise) * Math.max(0, excess);
+    }
+}

--- a/app/briarthorn/qml/model/ManeuverPursue.qml
+++ b/app/briarthorn/qml/model/ManeuverPursue.qml
@@ -1,11 +1,11 @@
 import QtQml
 
-// Pure pursuit: fly straight at the target, steer saturating once it sits
-// more than cutAngle off the nose.
+// Pure pursuit: fly straight at the focus — a target, or an anchored
+// waypoint — steer saturating once it sits more than cutAngle off the nose.
 Maneuver {
     id: root
 
     function desiredHeading(entity: Entity): real {
-        return Geo.bearing(entity, root.target);
+        return Geo.bearingFrom(entity.posX, entity.posY, root.focusX(), root.focusY());
     }
 }

--- a/app/briarthorn/qml/model/Maneuvers.qml
+++ b/app/briarthorn/qml/model/Maneuvers.qml
@@ -21,6 +21,10 @@ QtObject {
         ManeuverNotch {}
     }
 
+    readonly property Component orbit: Component {
+        ManeuverOrbit {}
+    }
+
     readonly property Component flee: Component {
         ManeuverFlee {}
     }
@@ -33,6 +37,7 @@ QtObject {
             "pursue": root.pursue,
             "evade": root.evade,
             "notch": root.notch,
+            "orbit": root.orbit,
             "flee": root.flee,
             "formation": root.formation
         })


### PR DESCRIPTION
## Summary

- **Maneuvers can now fly a fixed world point.** The `Maneuver` base gains an anchor (`anchorX`/`anchorY`/`anchored`), `engaged` becomes target-or-anchor, and a `focusX()`/`focusY()` accessor resolves to the target''s position or the anchor. Pursue, Evade, Notch and Flee read the focus, so each gains a position mode that means something: anchored Pursue is fly-to-waypoint, anchored Flee is avoid-this-area, anchored Evade/Orbit is a patrol station. Formation pins itself entity-only (it reads the leader''s heading and speed, which a point does not have).
- **New `ManeuverOrbit`**: transit to the focus at full throttle, then ride a ring at `standoff` on a `cruise` throttle, `clockwise` picking the direction as seen on the scope. The cruise knob is what makes tight rings flyable — a ring is only holdable above the airframe''s turning circle (speed over turn rate), so slower buys tighter. The ring distance is named `standoff`, matching Evade, so a personality stance flying `orbit` gets envelope pricing through the existing `Stance.standoff` seam for free (an adversarial-review catch — `radius` would have silently defeated the pricer''s duck-type).
- **Ownership rule documented**: anchors belong to scenario- and director-armed maneuvers. A personality disengages its stances by nulling `target`, so personality-owned maneuvers stay anchor-free; `Maneuvers.make` passes no anchor props, keeping that structural.

Stacked on #84 (the `Maneuvers` registry lives there); retargets to main when it merges.

## Verification

- An 11-assertion flight harness (qml.exe driving `SystemManeuver` + `SystemMovement` off the source tree): the orbit converges onto the ring within a tenth of standoff and rides cruise speed around both an anchored point and a live entity, circulation direction flips with `clockwise` (measured independently via swept bearing about the anchor), an anchored Pursue reaches its waypoint, and the engaged matrix is exact — bare anchor engages Orbit, never Formation, and a maneuver with neither leaves the stick alone.
- The 50-assertion personality harness still passes untouched; adversarial review''s two lenses found no behavior breaks (its naming catch and two stale headers are fixed); debug build, qmllint gate, and all 111 ctest cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)