### PR TITLE
Single-source the personality, stance and maneuver names

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -5,6 +5,7 @@ set(QML_SINGLETONS
     qml/database/Abilities.qml
     qml/database/Database.qml
     qml/database/GameRules.qml
+    qml/database/Names.qml
     qml/database/Personalities.qml
     qml/model/Geo.qml
     qml/model/Maneuvers.qml

--- a/app/briarthorn/qml/database/Names.qml
+++ b/app/briarthorn/qml/database/Names.qml
@@ -1,0 +1,55 @@
+pragma Singleton
+
+import QtQml
+
+// The behaviour vocabulary: every personality, maneuver and stance name
+// written once, referenced everywhere a definition, registry or spawn site
+// would otherwise retype the string. Grouped by family — typed groups, so
+// the linter vouches for every reference — because families may share a
+// word (the evade stance and the evade maneuver).
+QtObject {
+    id: root
+
+    // The personality names spawn sites and kind rows route on.
+    component PersonalityNames: QtObject {
+        readonly property string aggressive: "aggressive"
+        readonly property string defensive: "defensive"
+        readonly property string fearful: "fearful"
+        readonly property string tactical: "tactical"
+    }
+
+    // The maneuver names stances fly — the keys of the model's Maneuvers
+    // factory table.
+    component ManeuverNames: QtObject {
+        readonly property string evade: "evade"
+        readonly property string flee: "flee"
+        readonly property string formation: "formation"
+        readonly property string notch: "notch"
+        readonly property string orbit: "orbit"
+        readonly property string pursue: "pursue"
+    }
+
+    // The stance names personalities switch between.
+    component StanceNames: QtObject {
+        readonly property string abscond: "abscond"
+        readonly property string advance: "advance"
+        readonly property string bail: "bail"
+        readonly property string defend: "defend"
+        readonly property string depart: "depart"
+        readonly property string disengage: "disengage"
+        readonly property string evade: "evade"
+        readonly property string guard: "guard"
+        readonly property string monitor: "monitor"
+        readonly property string press: "press"
+        readonly property string repel: "repel"
+        readonly property string retire: "retire"
+        readonly property string shadow: "shadow"
+        readonly property string snipe: "snipe"
+        readonly property string strike: "strike"
+        readonly property string withdraw: "withdraw"
+    }
+
+    readonly property PersonalityNames personality: PersonalityNames {}
+    readonly property ManeuverNames maneuver: ManeuverNames {}
+    readonly property StanceNames stance: StanceNames {}
+}

--- a/app/briarthorn/qml/database/personalities/PersonalityAggressive.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityAggressive.qml
@@ -4,43 +4,43 @@ import ".."
 // backs off only once staying engaged stops paying — an empty rack. guard
 // keeps the trigger; the radar cone is what disciplines a beaming shot.
 Personality {
-    name: "aggressive"
+    name: Names.personality.aggressive
 
     switches: [
         SwitchAmmoOut {
-            to: "disengage"
+            to: Names.stance.disengage
         }
     ]
 
     stances: [
         Stance {
-            name: "press"
-            maneuver: "pursue"
+            name: Names.stance.press
+            maneuver: Names.maneuver.pursue
             switches: [
                 SwitchThreat {
                     present: true
                     within: 0.2
                     dwell: 0.3
-                    to: "guard"
+                    to: Names.stance.guard
                 }
             ]
         },
         Stance {
-            name: "guard"
-            maneuver: "notch"
+            name: Names.stance.guard
+            maneuver: Names.maneuver.notch
             reference: Stance.Reference.Threat
             switches: [
                 SwitchThreat {
                     present: false
                     within: 0.2
                     dwell: 0.5
-                    to: "press"
+                    to: Names.stance.press
                 }
             ]
         },
         Stance {
-            name: "disengage"
-            maneuver: "flee"
+            name: Names.stance.disengage
+            maneuver: Names.maneuver.flee
             holdFire: true
         }
     ]

--- a/app/briarthorn/qml/database/personalities/PersonalityDefensive.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityDefensive.qml
@@ -6,27 +6,27 @@ import ".."
 // Against an unarmed target the range switches never fire and monitor's
 // standoff falls back to the carrier's own reach.
 Personality {
-    name: "defensive"
+    name: Names.personality.defensive
 
     switches: [
         SwitchThreat {
             present: true
             within: 1
-            to: "break"
+            to: Names.stance.defend
         },
         SwitchHealth {
             below: 0.5
-            to: "abscond"
+            to: Names.stance.abscond
         },
         SwitchAmmoOut {
-            to: "abscond"
+            to: Names.stance.abscond
         }
     ]
 
     stances: [
         Stance {
-            name: "monitor"
-            maneuver: "evade"
+            name: Names.stance.monitor
+            maneuver: Names.maneuver.evade
             holdFire: true
             standoff: 1.15
             standoffOf: Envelope.Kind.TargetWeapon
@@ -36,13 +36,13 @@ Personality {
                     at: 0.9
                     of: Envelope.Kind.TargetWeapon
                     dwell: 1
-                    to: "repel"
+                    to: Names.stance.repel
                 }
             ]
         },
         Stance {
-            name: "repel"
-            maneuver: "pursue"
+            name: Names.stance.repel
+            maneuver: Names.maneuver.pursue
             holdoff: 4
             switches: [
                 SwitchRange {
@@ -50,13 +50,13 @@ Personality {
                     at: 1
                     of: Envelope.Kind.TargetWeapon
                     dwell: 2
-                    to: "monitor"
+                    to: Names.stance.monitor
                 }
             ]
         },
         Stance {
-            name: "break"
-            maneuver: "notch"
+            name: Names.stance.defend
+            maneuver: Names.maneuver.notch
             reference: Stance.Reference.Threat
             holdFire: true
             switches: [
@@ -64,13 +64,13 @@ Personality {
                     present: false
                     within: 1
                     dwell: 3
-                    to: "monitor"
+                    to: Names.stance.monitor
                 }
             ]
         },
         Stance {
-            name: "abscond"
-            maneuver: "flee"
+            name: Names.stance.abscond
+            maneuver: Names.maneuver.flee
             holdFire: true
         }
     ]

--- a/app/briarthorn/qml/database/personalities/PersonalityFearful.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityFearful.qml
@@ -5,23 +5,23 @@ import ".."
 // moment danger shows. The orbit at 0.8 sits clear of the snipe gate at 0.9
 // so the entry holds solidly rather than flickering on the rim.
 Personality {
-    name: "fearful"
+    name: Names.personality.fearful
 
     switches: [
         SwitchThreat {
             present: true
             within: 0.6
-            to: "bail"
+            to: Names.stance.bail
         },
         SwitchAmmoOut {
-            to: "depart"
+            to: Names.stance.depart
         }
     ]
 
     stances: [
         Stance {
-            name: "shadow"
-            maneuver: "evade"
+            name: Names.stance.shadow
+            maneuver: Names.maneuver.evade
             holdFire: true
             standoff: 0.8
             switches: [
@@ -29,31 +29,31 @@ Personality {
                     inside: true
                     at: 0.9
                     dwell: 2
-                    to: "snipe"
+                    to: Names.stance.snipe
                 }
             ]
         },
         Stance {
-            name: "snipe"
-            maneuver: "pursue"
+            name: Names.stance.snipe
+            maneuver: Names.maneuver.pursue
             holdoff: 8
             switches: [
                 SwitchRange {
                     inside: true
                     at: 0.5
-                    to: "shadow"
+                    to: Names.stance.shadow
                 },
                 SwitchRange {
                     inside: false
                     at: 1
                     dwell: 1
-                    to: "shadow"
+                    to: Names.stance.shadow
                 }
             ]
         },
         Stance {
-            name: "bail"
-            maneuver: "notch"
+            name: Names.stance.bail
+            maneuver: Names.maneuver.notch
             reference: Stance.Reference.Threat
             holdFire: true
             switches: [
@@ -61,13 +61,13 @@ Personality {
                     present: false
                     within: 0.6
                     dwell: 1.5
-                    to: "shadow"
+                    to: Names.stance.shadow
                 }
             ]
         },
         Stance {
-            name: "depart"
-            maneuver: "flee"
+            name: Names.stance.depart
+            maneuver: Names.maneuver.flee
             holdFire: true
         }
     ]

--- a/app/briarthorn/qml/database/personalities/PersonalityTactical.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityTactical.qml
@@ -4,59 +4,59 @@ import ".."
 // paced, withdraw when pressed — with overlapped band edges as hysteresis,
 // notches only genuine inbounds, and retires hurt or dry.
 Personality {
-    name: "tactical"
+    name: Names.personality.tactical
 
     switches: [
         SwitchThreat {
             present: true
             within: 0.4
-            to: "evade"
+            to: Names.stance.evade
         },
         // Hurt is one solid hit: flat warhead damage quantizes the hull, so
         // a deeper threshold would never be seen alive.
         SwitchHealth {
             below: 0.45
-            to: "retire"
+            to: Names.stance.retire
         },
         SwitchAmmoOut {
-            to: "retire"
+            to: Names.stance.retire
         }
     ]
 
     stances: [
         Stance {
-            name: "advance"
-            maneuver: "pursue"
+            name: Names.stance.advance
+            maneuver: Names.maneuver.pursue
             holdFire: true
             switches: [
                 SwitchRange {
                     inside: true
                     at: 0.9
-                    to: "strike"
+                    to: Names.stance.strike
                 }
             ]
         },
         Stance {
-            name: "strike"
-            maneuver: "pursue"
+            name: Names.stance.strike
+            maneuver: Names.maneuver.pursue
             holdoff: 10
             switches: [
                 SwitchRange {
                     inside: true
                     at: 0.6
-                    to: "withdraw"
+                    to: Names.stance.withdraw
                 },
                 SwitchRange {
                     inside: false
                     at: 1
                     dwell: 1
-                    to: "advance"
+                    to: Names.stance.advance
                 }
             ]
         },
         Stance {
-            name: "withdraw"
-            maneuver: "evade"
+            name: Names.stance.withdraw
+            maneuver: Names.maneuver.evade
             holdFire: true
             standoff: 0.9
             switches: [
@@ -64,13 +64,13 @@ Personality {
                     inside: false
                     at: 0.85
                     dwell: 1.5
-                    to: "strike"
+                    to: Names.stance.strike
                 }
             ]
         },
         Stance {
-            name: "evade"
-            maneuver: "notch"
+            name: Names.stance.evade
+            maneuver: Names.maneuver.notch
             reference: Stance.Reference.Threat
             holdFire: true
             switches: [
@@ -78,13 +78,13 @@ Personality {
                     present: false
                     within: 0.4
                     dwell: 1
-                    to: "advance"
+                    to: Names.stance.advance
                 }
             ]
         },
         Stance {
-            name: "retire"
-            maneuver: "flee"
+            name: Names.stance.retire
+            maneuver: Names.maneuver.flee
             holdFire: true
         }
     ]

--- a/app/briarthorn/qml/database/qmldir
+++ b/app/briarthorn/qml/database/qmldir
@@ -3,4 +3,5 @@
 singleton Abilities Abilities.qml
 singleton Database Database.qml
 singleton GameRules GameRules.qml
+singleton Names Names.qml
 singleton Personalities Personalities.qml

--- a/app/briarthorn/qml/model/Maneuvers.qml
+++ b/app/briarthorn/qml/model/Maneuvers.qml
@@ -1,6 +1,7 @@
 pragma Singleton
 
 import QtQml
+import "../database"
 
 // The maneuver factory registry: database stances name flights by string so
 // the database keeps importing nothing back, and this table turns a name
@@ -34,12 +35,12 @@ QtObject {
     }
 
     readonly property var table: ({
-            "pursue": root.pursue,
-            "evade": root.evade,
-            "notch": root.notch,
-            "orbit": root.orbit,
-            "flee": root.flee,
-            "formation": root.formation
+            [Names.maneuver.pursue]: root.pursue,
+            [Names.maneuver.evade]: root.evade,
+            [Names.maneuver.notch]: root.notch,
+            [Names.maneuver.orbit]: root.orbit,
+            [Names.maneuver.flee]: root.flee,
+            [Names.maneuver.formation]: root.formation
         })
 
     // A fresh maneuver of the named kind under the given owner, or null with

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -27,7 +27,7 @@ Scenario {
         side: Side.Kind.Hostile
         posY: -65000
         heading: 180
-        personality: "aggressive"
+        personality: Names.personality.aggressive
         engageTarget: root.ownship
         threatReflex: true
 


### PR DESCRIPTION
## Summary

- **New `Names` singleton** in `database/` (the `Verbs.qml` pattern): every personality, maneuver and stance name written once, in typed groups — `Names.personality.aggressive`, `Names.maneuver.pursue`, `Names.stance.press`. Groups are typed inline components so qmllint vouches for every reference: a typo''d constant is now a lint error instead of a silent runtime miss. Grouping also disambiguates the shared word (`evade` is both a stance and a maneuver).
- All four personality definitions, the duel''s spawn site, and the `Maneuvers` factory table now reference the constants — the table keys off `Names.maneuver.*`, making the singleton the load-bearing source of truth rather than a mirror.
- **One stance renamed**: Defensive''s `break` became `defend` — `break` is a JS reserved word and cannot be a QML property name; `defend` is the brevity word for reacting to an inbound anyway.

## Verification

Debug build, qmllint gate (the anonymous-group form tripped 20+ missing-property warnings; the typed-component form is what shipped), all 111 ctest cases, and both headless harnesses pass — 50 personality assertions and 11 flight assertions. The harnesses deliberately keep literal strings in their checks, so they now also pin the constants'' values against drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)