### PR TITLE
Stroke scope marks hollow, fin the guided missile, enlarge bearing labels

### DIFF
--- a/app/briarthorn/qml/database/weapons/DataMissileGuided.qml
+++ b/app/briarthorn/qml/database/weapons/DataMissileGuided.qml
@@ -7,7 +7,9 @@ DataWeapon {
     id: root
 
     classification: Classification.Kind.MissileGuided
-    outline: [Qt.point(0, -0.5), Qt.point(0.15, 0.5), Qt.point(-0.15, 0.5)]
+    // A finned dart — the steering surfaces tell it from the kinetic slug's
+    // plain triangle on the scope.
+    outline: [Qt.point(0, -0.5), Qt.point(0.12, 0.1), Qt.point(0.32, 0.5), Qt.point(0, 0.32), Qt.point(-0.32, 0.5), Qt.point(-0.12, 0.1)]
     label: qsTr("MSL")
     symbolScale: 0.55
 

--- a/app/briarthorn/qml/ui/RangeRing.qml
+++ b/app/briarthorn/qml/ui/RangeRing.qml
@@ -7,10 +7,14 @@ import "../themes"
 ShapeRing {
     id: root
 
-    // Tick geometry scales with the ring, so bearing labels stay legible on a
-    // large window instead of shrinking to a static 10px. Floored at the design
-    // sizes, so a default-size scope looks unchanged.
+    // Tick geometry scales with the ring rather than sitting at static pixel
+    // sizes, floored so a small scope stays legible.
     property real padding: Math.max(10, radius * 0.018)
+
+    // The bearing labels' seat inset past the tick inner ends, budgeted off
+    // the label text size (~0.9x its pixel size) so the widest label — and
+    // the 1.5x-scaled 'N' — clears its tick at any radius.
+    property real labelPadding: Math.max(16, radius * 0.03)
     property real range: 40
     property alias enableTicks: ticks.visible
     // Screen rotation of the tick assembly — bind -ownship.heading for a
@@ -42,13 +46,13 @@ ShapeRing {
             Text {
                 required property int index
                 readonly property real bearing: index * ticks.stepAngle
-                property point anchor: ticks.tickPoint(bearing, ticks.radius - ticks.length - root.padding)
+                property point anchor: ticks.tickPoint(bearing, ticks.radius - ticks.length - root.labelPadding)
 
                 visible: !root.inGap(bearing + ticks.angleOffset)
                 text: Math.round(bearing) === 0 ? "N" : Math.round(bearing)
                 color: Style.theme.textPrimary
                 font {
-                    pixelSize: Math.max(10, root.radius * 0.02)
+                    pixelSize: Math.max(15, root.radius * 0.03)
                     family: Style.monospace
                 }
                 scale: Math.round(bearing) === 0 ? 1.5 : 1

--- a/app/briarthorn/qml/ui/Symbol.qml
+++ b/app/briarthorn/qml/ui/Symbol.qml
@@ -1,14 +1,16 @@
 import QtQuick
+import QtQuick.Shapes
 import awen.shapes
 import "../database"
 import "../model"
 import "../themes"
 
-// A scope symbol: the classification's outline polygon coloured by side,
-// nose turned to noseAngle, with a screen-upright label below. Centre it on
-// the plot point; an empty label falls back to the classification's. Inside
-// a rotated view, bind viewRotation to the container's rotation so the
-// label counter-rotates and stays upright.
+// A scope symbol: the classification's outline polygon stroked in its side's
+// colour over a window-background fill, nose turned to noseAngle, with a
+// screen-upright label below. Centre it on the plot point; an empty label
+// falls back to the classification's. Inside a rotated view, bind
+// viewRotation to the container's rotation so the label counter-rotates and
+// stays upright.
 Item {
     id: root
 
@@ -27,7 +29,26 @@ Item {
     // Symbol size in px, before the classification's symbolScale.
     property real symbolSize: 36
 
+    // Outline stroke width in px; starts at the range rings' weight so marks
+    // and rings share one line weight on the scope.
+    property real strokeWidth: 2
+
     readonly property Data def: Database.dataFor(root.classification)
+
+    readonly property color sideColor: {
+        switch (root.side) {
+        case Side.Kind.Ownship:
+            return Style.theme.factionOwnship;
+        case Side.Kind.Friendly:
+            return Style.theme.factionFriendly;
+        case Side.Kind.Neutral:
+            return Style.theme.factionNeutral;
+        case Side.Kind.Hostile:
+            return Style.theme.factionHostile;
+        default:
+            return Style.theme.factionUnknown;
+        }
+    }
 
     width: root.symbolSize * root.def.symbolScale
     height: width
@@ -36,20 +57,13 @@ Item {
         anchors.fill: parent
         rotation: root.noseAngle
         points: root.def.outline
-        fillColor: {
-            switch (root.side) {
-            case Side.Kind.Ownship:
-                return Style.theme.factionOwnship;
-            case Side.Kind.Friendly:
-                return Style.theme.factionFriendly;
-            case Side.Kind.Neutral:
-                return Style.theme.factionNeutral;
-            case Side.Kind.Hostile:
-                return Style.theme.factionHostile;
-            default:
-                return Style.theme.factionUnknown;
-            }
-        }
+        fillColor: Style.theme.windowBackground
+        strokeColor: root.sideColor
+        strokeWidth: root.strokeWidth
+        // Round joins: the missiles' acute noses exceed the default miter
+        // limit and would chop flat, and the fighter's tips would spike past
+        // the item bounds the views seat marks by.
+        joinStyle: ShapePath.RoundJoin
     }
 
     // Counter-rotating frame: cancels the view rotation so the label reads

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -52,6 +52,11 @@ Item {
     // Symbol size in px before each classification's own scale.
     property real symbolSize: 36
 
+    // Line weights: the rings', and the marks' outline stroke, which starts
+    // at the rings' weight so the whole scope draws with one line.
+    property real ringStrokeWidth: 2
+    property real symbolStrokeWidth: ringStrokeWidth
+
     // Feature toggles — the minimap turns most of these off for a clean
     // overview. closedRings drops the range-label gap for a plain closed ring.
     property bool showInnerRing: true
@@ -116,7 +121,7 @@ Item {
         centerX: root.centerX
         centerY: root.centerY
         radius: root.outerRadius
-        strokeWidth: 2
+        strokeWidth: root.ringStrokeWidth
         gapLength: root.ringGapLength
         gapAngle: 20
         range: root.projection ? root.projection.rangeKm : 0
@@ -131,7 +136,7 @@ Item {
         centerX: root.centerX
         centerY: root.centerY
         radius: root.outerRadius / 2
-        strokeWidth: 2
+        strokeWidth: root.ringStrokeWidth
         gapLength: root.ringGapLength
         gapAngle: 20
         range: root.projection ? root.projection.innerRangeKm : 0
@@ -178,6 +183,7 @@ Item {
         viewRotation: root.viewRotation
         tracks: root.tracks
         symbolSize: root.symbolSize
+        symbolStrokeWidth: root.symbolStrokeWidth
         showLabels: root.showTrackLabels
         clampRadius: root.gutterClamp ? root.outerRadius : 0
         clampMargin: root.gutterClampMargin
@@ -203,6 +209,7 @@ Item {
         x: root.centerX - width / 2
         y: root.centerY - height / 2
         symbolSize: root.symbolSize
+        strokeWidth: root.symbolStrokeWidth
         noseAngle: root.headingUp ? 0 : (root.observer ? root.observer.heading : 0)
         classification: root.observer ? root.observer.classification : Classification.Kind.Unknown
         side: root.observer ? root.observer.side : Side.Kind.Unknown

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -29,6 +29,9 @@ Item {
     // Symbol size in px before the classification's own scale.
     property real symbolSize: 36
 
+    // Outline stroke width each mark draws with.
+    property real symbolStrokeWidth: 2
+
     // Whether track symbols carry their contact-id labels.
     property bool showLabels: true
 
@@ -71,6 +74,7 @@ Item {
         readonly property Component symbolMark: Component {
             Symbol {
                 symbolSize: root.symbolSize
+                strokeWidth: root.symbolStrokeWidth
                 noseAngle: mark.track ? mark.track.heading : 0
                 viewRotation: root.viewRotation
                 classification: mark.track ? mark.track.classification : Classification.Kind.Unknown


### PR DESCRIPTION
## What changed

- **Hollow scope marks**: `Symbol` now fills every track/ownship polygon with the window background and strokes the outline in its side's colour, through a new configurable `strokeWidth` (default 2 — the range rings' weight). The width threads down as `symbolStrokeWidth` in `ViewTracks`/`ViewSituation`, where a new `ringStrokeWidth` drives both rings and seeds the symbol default so the scope draws with one line weight until a view overrides it.
- **Guided vs kinetic missiles**: the guided round gets a six-point finned-dart outline; the kinetic slug keeps its plain triangle, so the two read apart on the scope.
- **Bearing tick labels**: raised 50% (`max(10, r*0.02)` -> `max(15, r*0.03)`).

## Why

Marks drawn as solid faction fills read heavier than the instrument linework around them; stroking them over the background makes the scope one consistent line drawing and leaves the weight tunable per view. The two missile kinds previously shared one outline and could only be told apart by behaviour.

## Reviewer notes

- The larger labels no longer fit the old seat inset, so `RangeRing` gained a `labelPadding` budgeted off the label size — without it the tick ink runs into the glyphs (270 reads as -270) at attack-scope radii.
- `Symbol`'s polygon uses `RoundJoin`: with strokes now visible, the missiles' acute noses exceed ShapePath's default miter limit and chop flat, while the fighter's tips would spike past the item bounds the views seat marks by.
- At minimap size (~7px) the 2px stroke fills the missile marks solid — same as their pre-change solid look, and the fin silhouette still distinguishes them; pass a thinner `symbolStrokeWidth` there if hollowness is wanted later.
- Verified on the live debug build and a qml.exe harness (screenshots in session); `qmllint-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)