### PR TITLE
Make the duel bandit fight in paced exchanges and warn the player of inbound missiles

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -42,6 +42,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/database/Switch.qml
         qml/database/SwitchAmmoOut.qml
         qml/database/SwitchHealth.qml
+        qml/database/SwitchOutbound.qml
         qml/database/SwitchRange.qml
         qml/database/SwitchThreat.qml
         qml/database/abilities/AbilityFlare.qml
@@ -53,6 +54,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/database/entities/DataUnknown.qml
         qml/database/personalities/PersonalityAggressive.qml
         qml/database/personalities/PersonalityDefensive.qml
+        qml/database/personalities/PersonalityDuelist.qml
         qml/database/personalities/PersonalityFearful.qml
         qml/database/personalities/PersonalityTactical.qml
         qml/database/weapons/DataMissileGuided.qml
@@ -64,6 +66,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/model/Detonation.qml
         qml/model/Entity.qml
         qml/model/Maneuver.qml
+        qml/model/ManeuverCrank.qml
         qml/model/ManeuverEvade.qml
         qml/model/ManeuverFlee.qml
         qml/model/ManeuverFormation.qml

--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -115,6 +115,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/ui/ViewSituation.qml
         qml/ui/ViewSituationAttack.qml
         qml/ui/ViewStatus.qml
+        qml/ui/ViewThreat.qml
         qml/ui/ViewTopBar.qml
         qml/ui/ViewTracks.qml
         qml/ui/ViewTrails.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -479,6 +479,23 @@ Window {
             }
         }
 
+        // The missile warning, top-centre under the band: flashes the moment
+        // a homing round is marked inbound on ownship, with its bearing and
+        // closing range — the reaction window the scope alone buries in a
+        // small mark.
+        ViewThreat {
+            id: threatAlert
+
+            visible: !root.inMenu && threatAlert.active
+            ownship: game.ownship
+
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                top: topBar.bottom
+                topMargin: 12
+            }
+        }
+
         // The ability rack, bottom-right: one square button per carried
         // ability, capped with the key or pad button that fires it and posting
         // the same ability record those bindings post — no second invocation

--- a/app/briarthorn/qml/database/Names.qml
+++ b/app/briarthorn/qml/database/Names.qml
@@ -14,6 +14,7 @@ QtObject {
     component PersonalityNames: QtObject {
         readonly property string aggressive: "aggressive"
         readonly property string defensive: "defensive"
+        readonly property string duelist: "duelist"
         readonly property string fearful: "fearful"
         readonly property string tactical: "tactical"
     }
@@ -21,6 +22,7 @@ QtObject {
     // The maneuver names stances fly — the keys of the model's Maneuvers
     // factory table.
     component ManeuverNames: QtObject {
+        readonly property string crank: "crank"
         readonly property string evade: "evade"
         readonly property string flee: "flee"
         readonly property string formation: "formation"
@@ -34,6 +36,7 @@ QtObject {
         readonly property string abscond: "abscond"
         readonly property string advance: "advance"
         readonly property string bail: "bail"
+        readonly property string crank: "crank"
         readonly property string defend: "defend"
         readonly property string depart: "depart"
         readonly property string disengage: "disengage"

--- a/app/briarthorn/qml/database/Personalities.qml
+++ b/app/briarthorn/qml/database/Personalities.qml
@@ -13,6 +13,7 @@ QtObject {
     readonly property list<Personality> registry: [
         PersonalityAggressive {},
         PersonalityDefensive {},
+        PersonalityDuelist {},
         PersonalityFearful {},
         PersonalityTactical {}
     ]

--- a/app/briarthorn/qml/database/SwitchOutbound.qml
+++ b/app/briarthorn/qml/database/SwitchOutbound.qml
@@ -1,0 +1,12 @@
+// Fires while a round of the entity's own is still in flight (present), or
+// once the sky is clear of them (present false) — the calm side of the same
+// test, for the switch back.
+Switch {
+    id: root
+
+    property bool present: true
+
+    function holds(s: var): bool {
+        return root.present ? s.outbound : !s.outbound;
+    }
+}

--- a/app/briarthorn/qml/database/personalities/PersonalityDuelist.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityDuelist.qml
@@ -1,0 +1,70 @@
+import ".."
+
+// Fights one exchange at a time: presses to fire, then cranks — trigger held,
+// target ridden at the cone's edge — until the round in flight dies, so no
+// magazine ever streams. Beams genuine inbounds early enough to watch, and
+// breaks off dry.
+Personality {
+    name: Names.personality.duelist
+
+    switches: [
+        SwitchAmmoOut {
+            to: Names.stance.disengage
+        }
+    ]
+
+    stances: [
+        Stance {
+            name: Names.stance.press
+            maneuver: Names.maneuver.pursue
+            switches: [
+                SwitchThreat {
+                    present: true
+                    within: 0.45
+                    dwell: 0.3
+                    to: Names.stance.guard
+                },
+                SwitchOutbound {
+                    present: true
+                    to: Names.stance.crank
+                }
+            ]
+        },
+        Stance {
+            name: Names.stance.crank
+            maneuver: Names.maneuver.crank
+            holdFire: true
+            switches: [
+                SwitchThreat {
+                    present: true
+                    within: 0.45
+                    dwell: 0.3
+                    to: Names.stance.guard
+                },
+                SwitchOutbound {
+                    present: false
+                    dwell: 0.5
+                    to: Names.stance.press
+                }
+            ]
+        },
+        Stance {
+            name: Names.stance.guard
+            maneuver: Names.maneuver.notch
+            reference: Stance.Reference.Threat
+            switches: [
+                SwitchThreat {
+                    present: false
+                    within: 0.45
+                    dwell: 0.5
+                    to: Names.stance.press
+                }
+            ]
+        },
+        Stance {
+            name: Names.stance.disengage
+            maneuver: Names.maneuver.flee
+            holdFire: true
+        }
+    ]
+}

--- a/app/briarthorn/qml/model/ManeuverCrank.qml
+++ b/app/briarthorn/qml/model/ManeuverCrank.qml
@@ -1,0 +1,21 @@
+import QtQml
+
+// Cranking: hold the focus — a target, or an anchored point — near the edge
+// of the own radar cone instead of on the nose, guidance kept while the
+// closure is cut — offsetting to whichever side is the shorter swing from
+// the current heading.
+Maneuver {
+    id: root
+
+    // Degrees kept inside the cone's half-angle, so wander never drops the
+    // focus out of illumination.
+    property real margin: 10
+
+    function desiredHeading(entity: Entity): real {
+        const bearing = Geo.bearingFrom(entity.posX, entity.posY, root.focusX(), root.focusY());
+        const offset = Math.max(0, entity.radarFov / 2 - root.margin);
+        const right = Geo.wrap180(bearing + offset - entity.heading);
+        const left = Geo.wrap180(bearing - offset - entity.heading);
+        return Math.abs(right) <= Math.abs(left) ? bearing + offset : bearing - offset;
+    }
+}

--- a/app/briarthorn/qml/model/Maneuvers.qml
+++ b/app/briarthorn/qml/model/Maneuvers.qml
@@ -14,6 +14,10 @@ QtObject {
         ManeuverPursue {}
     }
 
+    readonly property Component crank: Component {
+        ManeuverCrank {}
+    }
+
     readonly property Component evade: Component {
         ManeuverEvade {}
     }
@@ -35,6 +39,7 @@ QtObject {
     }
 
     readonly property var table: ({
+            [Names.maneuver.crank]: root.crank,
             [Names.maneuver.pursue]: root.pursue,
             [Names.maneuver.evade]: root.evade,
             [Names.maneuver.notch]: root.notch,

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -6,11 +6,12 @@ import QtQml
 import "../database"
 import "../model"
 
-// The 1v1 duel: one hostile fighter boring in from the north, spawned just
+// The 1v1 duel: one hostile fighter closing from the north, spawned just
 // past sensor range so it opens as an Unknown contact. Pure initial
 // conditions — the bandit's declaration carries its behaviour aspects
-// (pursue the player, shoot inside the envelope, flare at inbound rounds)
-// and the shared systems do the rest; this scenario loads nothing of its own.
+// (press to fire, crank behind the round in flight, beam inbounds, flare at
+// them) and the shared systems do the rest; this scenario loads nothing of
+// its own.
 Scenario {
     id: root
 
@@ -27,7 +28,7 @@ Scenario {
         side: Side.Kind.Hostile
         posY: -65000
         heading: 180
-        personality: Names.personality.aggressive
+        personality: Names.personality.duelist
         engageTarget: root.ownship
         threatReflex: true
 

--- a/app/briarthorn/qml/systems/SystemPersonality.qml
+++ b/app/briarthorn/qml/systems/SystemPersonality.qml
@@ -89,8 +89,20 @@ System {
             threatRange: entity.threatInbound !== null ? Geo.distance(entity, entity.threatInbound) : Infinity,
             // A hull never given health is unkillable, so it is never hurt.
             healthFrac: entity.maxHealth > 0 ? entity.health / entity.maxHealth : 1,
-            rounds: root.roundsOf(entity)
+            rounds: root.roundsOf(entity),
+            outbound: root.outboundOf(entity)
         };
+    }
+
+    // Whether a round of the entity's own is still in flight — what a
+    // shoot-look-shoot stance cranks behind.
+    function outboundOf(entity: Entity): bool {
+        for (let i = 0; i < root.entities.length; ++i) {
+            const e = root.entities[i];
+            if (e.weapon !== null && e.owner === entity)
+                return true;
+        }
+        return false;
     }
 
     // Rounds left across the launch rack; any unlimited slot reads Infinity.

--- a/app/briarthorn/qml/systems/SystemThreat.qml
+++ b/app/briarthorn/qml/systems/SystemThreat.qml
@@ -37,10 +37,11 @@ System {
     }
 
     // Pins each entity's nearest homing round within its detection range,
-    // clearing yesterday's marks first so a defeated round drops off.
+    // writing only real changes — a defeated round drops off, but a held mark
+    // is never cleared and repinned in place, which would flicker every
+    // binding on it (and restart any animation gated by one) once a tick.
     function mark() {
-        for (let i = 0; i < root.entities.length; ++i)
-            root.entities[i].threatInbound = null;
+        const nearest = new Map();
         for (let i = 0; i < root.entities.length; ++i) {
             const missile = root.entities[i];
             if (missile.weapon === null || missile.weapon.target === null)
@@ -49,8 +50,16 @@ System {
             const range = Geo.distance(missile, target);
             if (range > target.detectionRange)
                 continue;
-            if (target.threatInbound === null || range < Geo.distance(target, target.threatInbound))
-                target.threatInbound = missile;
+            const held = nearest.get(target);
+            if (held === undefined || range < Geo.distance(target, held))
+                nearest.set(target, missile);
+        }
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            const mark = nearest.get(entity);
+            const next = mark !== undefined ? mark : null;
+            if (entity.threatInbound !== next)
+                entity.threatInbound = next;
         }
     }
 

--- a/app/briarthorn/qml/ui/ViewThreat.qml
+++ b/app/briarthorn/qml/ui/ViewThreat.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import awen.shapes
+import "../model"
+import "../themes"
+
+// Missile warning: flashes while a homing round is marked inbound on the
+// ownship — the mark SystemThreat pins each tick — with an arrow swinging to
+// the threat's bearing in the scope's heading-up frame and the closing range
+// beside it.
+Item {
+    id: root
+
+    // The defended craft whose threatInbound this announces.
+    property Entity ownship
+
+    readonly property Entity threat: root.ownship ? root.ownship.threatInbound : null
+    readonly property bool active: root.threat !== null
+
+    // Degrees the threat sits off the nose — the arrow's swing.
+    readonly property real threatBearing: root.active ? Geo.wrap180(Geo.bearing(root.ownship, root.threat) - root.ownship.heading) : 0
+    readonly property real threatRange: root.active ? Geo.distance(root.ownship, root.threat) : 0
+
+    implicitWidth: content.implicitWidth + 32
+    implicitHeight: content.implicitHeight + 14
+    visible: root.active
+
+    Rectangle {
+        anchors.fill: parent
+        radius: Style.theme.panelRadius
+        color: Style.theme.panelBackground
+        border.color: Style.theme.factionHostile
+        border.width: 2
+    }
+
+    Row {
+        id: content
+        anchors.centerIn: parent
+        spacing: 12
+
+        ShapePolygon {
+            anchors.verticalCenter: parent.verticalCenter
+            width: 22
+            height: width
+            rotation: root.threatBearing
+            points: [Qt.point(0, -0.5), Qt.point(0.38, 0.34), Qt.point(0, 0.14), Qt.point(-0.38, 0.34)]
+            fillColor: Style.theme.factionHostile
+        }
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("MISSILE")
+            color: Style.theme.factionHostile
+            font { pixelSize: 16; family: Style.monospace; bold: true; letterSpacing: Style.theme.capsTracking }
+        }
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("%1 KM").arg((root.threatRange / 1000).toFixed(1))
+            color: Style.theme.textBright
+            font { pixelSize: 13; family: Style.monospace }
+        }
+    }
+
+    SequentialAnimation on opacity {
+        running: root.visible
+        loops: Animation.Infinite
+
+        NumberAnimation {
+            from: 1
+            to: 0.35
+            duration: 320
+        }
+
+        NumberAnimation {
+            from: 0.35
+            to: 1
+            duration: 320
+        }
+    }
+}


### PR DESCRIPTION
## What

Makes the 1v1 duel an actual duel instead of a missile stream from a bandit boring straight in:

- **Duelist personality** for the duel bandit (`PersonalityDuelist`): presses to fire, then **cranks** — the new `ManeuverCrank` holds the target near the edge of its own radar cone (`radarFov / 2 - margin`), keeping its round guided while cutting closure — until that round dies, then re-presses. Threat response starts at 0.45 of detection range (aggressive waits until a terminal 0.2), so the beam is visible play; a dry rack still breaks off.
- **Shoot-look-shoot pacing** expressed in the FSM, not hard-coded doctrine: a new `SwitchOutbound` fires on a new `outbound` situation fact (a round of the entity's own still in flight) and the crank stance carries `holdFire`. The bandit never streams its magazine; the old behaviour was a launch every 6 s against a 24 s flight time, up to four rounds airborne.
- **Missile warning** (`ViewThreat`): flashing MISSILE box top-centre with a heading-up bearing arrow and closing range, reading the `threatInbound` mark SystemThreat already maintained but nothing displayed.
- **SystemThreat fix** (own commit): `mark()` cleared every `threatInbound` and re-pinned it each tick. The transient is observable, so any binding on the mark flickered once a tick — which silently restarted the warning's blink animation at phase zero every tick, pinning it at one opacity. Marks now write only on real change.

## Why

The duel wasn't fun: the enemy flew straight at the player firing every 6 seconds, made no attempt to defend, and missiles arrived with no warning. Now each exchange is readable — shot, warning, defence, his round dies, your turn — and firing back matters: a bandit forced onto the beam swings its radar off the player and its own in-flight round goes ballistic.

## Reviewer notes

- Shoot-look-shoot deliberately lives in the personality layer rather than SystemEngage: ScenarioMenu already paces the demo ownship via `engageHold` and pins trigger discipline on the personalities, so the menu demo is untouched by this branch.
- Verified by build + ctest (111/111) + qmllint, plus a 17-assertion headless qml.exe harness driving the real systems through a scripted duel: envelope-gated launch, crank rides the cone edge with the round still guided, guard under return fire, never two rounds concurrent, >= 8 s between exchanges, threat mark raised, dry break-off. The warning UI was screenshot-verified in the running app, including the blink actually cycling (which is what exposed the SystemThreat flicker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)