### PR TITLE
Narrow the condition arcs to a third of a circle and give ownship a fuel flank

### DIFF
--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -638,6 +638,7 @@ Window {
             showOwnshipPulse: false
             showTrackLabels: false
             showTrackHealth: false
+            showOwnshipCondition: false
             showEngagements: false
             showTrails: false
 

--- a/app/briarthorn/qml/database/Data.qml
+++ b/app/briarthorn/qml/database/Data.qml
@@ -3,7 +3,7 @@ import QtQml
 // The row shape every database entry satisfies: one classification's render
 // definition, as the symbol outline in unit-box points centred on the origin
 // (nose toward -y, coordinates in [-0.5, 0.5]), the fallback label, the scale
-// the symbol draws at and whether the mark carries a hull gauge alongside it.
+// the symbol draws at and whether the mark carries condition arcs alongside it.
 // Instantiated bare it is a presentation-only row a
 // sensor plots but nothing ever spawns; spawnable kinds use DataEntity.
 QtObject {
@@ -14,8 +14,8 @@ QtObject {
     property string label: ""
     property real symbolScale: 1
 
-    // Whether a resolved mark of this kind carries a hull-condition gauge.
-    // An airframe's condition is worth reading straight off the picture; a
-    // round in flight, a lure and an unresolved return all plot bare.
-    property bool hullGauge: false
+    // Whether a resolved mark of this kind carries condition arcs on its
+    // flanks. An airframe's condition is worth reading straight off the
+    // picture; a round in flight, a lure and an unresolved return plot bare.
+    property bool conditionGauge: false
 }

--- a/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
+++ b/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
@@ -9,7 +9,7 @@ DataEntity {
     classification: Classification.Kind.AircraftFighter
     outline: [Qt.point(0, -0.5), Qt.point(0.4, 0.45), Qt.point(0, 0.18), Qt.point(-0.4, 0.45)]
     label: qsTr("FIGHTER")
-    hullGauge: true
+    conditionGauge: true
 
     // A +/- 60 degree radar cone: it has to point at what it wants to see, and
     // a semi-active round of its own only tracks what it keeps inside this.

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -125,6 +125,12 @@ QtObject {
     property real maxFuel: GameRules.fuelCapacityFor(root.durable)
     property real fuel: root.maxFuel
 
+    // Condition as fractions of full, 0..1, and zero where there is nothing to
+    // fill — every gauge and readout reads these rather than dividing for
+    // itself and clamping again.
+    readonly property real healthFrac: root.maxHealth > 0 ? Math.max(0, Math.min(1, root.health / root.maxHealth)) : 0
+    readonly property real fuelFrac: root.maxFuel > 0 ? Math.max(0, Math.min(1, root.fuel / root.maxFuel)) : 0
+
     // The entity that launched or deployed this one; null for craft. Fuzes
     // ignore anything the owner also owns, the blast spares the owner and a
     // guided seeker sees only what the owner's radar illuminates.

--- a/app/briarthorn/qml/ui/Symbol.qml
+++ b/app/briarthorn/qml/ui/Symbol.qml
@@ -9,11 +9,11 @@ import "../themes"
 
 // A scope symbol: the classification's outline polygon stroked in its side's
 // colour over a window-background fill, nose turned to noseAngle, with a
-// screen-upright label below and an optional hull gauge hugging its left.
-// Centre it on the plot point; an empty label falls back to the
-// classification's. Inside a rotated view, bind viewRotation to the
-// container's rotation so the label and the gauge counter-rotate and hold
-// their screen-upright places.
+// screen-upright label below and optional condition arcs on its flanks — hull
+// left, fuel right. Centre it on the plot point; an empty label falls back to
+// the classification's. Inside a rotated view, bind viewRotation to the
+// container's rotation so the label and the arcs counter-rotate and hold their
+// screen-upright places.
 Item {
     id: root
 
@@ -29,13 +29,16 @@ Item {
     property string label: ""
     property bool showLabel: true
 
-    // Hull condition: whether the caller holds a reading for this contact at
-    // all, and the reading itself as a fraction of full hull. Whether that
+    // Condition arcs: whether the caller holds a hull or fuel reading for this
+    // contact, and the readings themselves as fractions of full. Whether a
     // reading is worth drawing is the kind's call, not the caller's — only a
-    // row asking for a gauge gets one, so a munition mark and the bare
-    // instrument marks plot without.
+    // row asking for gauges gets them, so a munition mark and the bare
+    // instrument marks plot without. Fuel is ownship's alone: no sensor ever
+    // reports what is in another aircraft's tanks.
     property bool hasHealth: false
     property real healthFrac: 1
+    property bool hasFuel: false
+    property real fuelFrac: 1
 
     // Symbol size in px, before the classification's symbolScale.
     property real symbolSize: 36
@@ -61,33 +64,55 @@ Item {
         }
     }
 
-    readonly property bool showHealth: root.hasHealth && root.def.hullGauge
+    readonly property bool showHealth: root.hasHealth && root.def.conditionGauge
+    readonly property bool showFuel: root.hasFuel && root.def.conditionGauge
 
-    // A hull this far down reads as a casualty, and the gauge goes to the warn
-    // colour — the same threshold the ownship condition instrument uses.
+    // A reading this far down goes to the warn colour — the same thresholds
+    // the ownship condition instrument reads at.
     readonly property bool healthLow: root.healthFrac <= 0.3
+    readonly property bool fuelLow: root.fuelFrac <= 0.2
 
-    // Gauge geometry: an arc standing just clear of the symbol's own extent,
-    // weighted off the mark so a mark drawn small carries a thin arc.
-    readonly property real healthStrokeWidth: Math.max(2, root.width * 0.1)
-    readonly property real healthRadius: root.width * 0.62
+    // Gauge geometry: arcs standing just clear of the symbol's own extent,
+    // weighted off the mark so a mark drawn small carries a thin arc. A third
+    // of a circle each, so a flank reads as a bar beside the mark rather than
+    // a ring around it.
+    readonly property real gaugeStrokeWidth: Math.max(2, root.width * 0.1)
+    readonly property real gaugeRadius: root.width * 0.62
+    readonly property real gaugeSweep: 120
 
-    // A semicircle on the left necessarily tips at 6 o'clock, below the mark's
-    // own bounds; this is how far. The caption clears it, so a gauged mark's
-    // label seats exactly that much lower than a bare one's.
-    readonly property real healthOverhang: root.healthRadius + root.healthStrokeWidth / 2 - root.height / 2
+    // How far a flank's lower end hangs below the mark's own bounds. The span
+    // is centred on its flank, so the ends sit sin(half-span) of the radius
+    // below the centre. The caption clears it, so a gauged mark's label seats
+    // exactly that much lower than a bare one's.
+    readonly property real gaugeOverhang: Math.max(0, root.gaugeRadius * Math.sin(root.gaugeSweep * Math.PI / 360) + root.gaugeStrokeWidth / 2 - root.height / 2)
     readonly property real labelGap: Math.max(2, root.symbolSize * 0.07)
 
-    readonly property Component healthGauge: Component {
+    // The box either arc needs, so both flanks seat off one number.
+    readonly property real gaugeSide: 2 * (root.gaugeRadius + root.gaugeStrokeWidth / 2)
+
+    // Hull on the left flank, swept clockwise up from 7 o'clock so damage
+    // drains the arc downward.
+    readonly property Component healthArc: Component {
         ShapeGauge {
-            strokeWidth: root.healthStrokeWidth
-            // A left-hand semicircle filling clockwise from 6 o'clock up to
-            // 12, so damage eats the arc back down toward the bottom.
-            angleStart: 180
-            angleSweep: 180
+            strokeWidth: root.gaugeStrokeWidth
+            angleStart: 270 - root.gaugeSweep / 2
+            angleSweep: root.gaugeSweep
             value: root.healthFrac
             trackColor: Style.theme.gaugeTrack
             fillColor: root.healthLow ? Style.theme.warn : root.sideColor
+        }
+    }
+
+    // Fuel mirrors it on the right, so ownship carries the pair as one
+    // instrument and both readings drain toward the bottom together.
+    readonly property Component fuelArc: Component {
+        ShapeGauge {
+            strokeWidth: root.gaugeStrokeWidth
+            angleStart: 90 + root.gaugeSweep / 2
+            angleSweep: -root.gaugeSweep
+            value: root.fuelFrac
+            trackColor: Style.theme.gaugeTrack
+            fillColor: root.fuelLow ? Style.theme.warn : Style.theme.fuel
         }
     }
 
@@ -113,15 +138,23 @@ Item {
         anchors.fill: parent
         rotation: -root.viewRotation
 
-        // The hull gauge, loaded only for a kind that carries one: a scope in
-        // a dogfight plots far more missile marks than aircraft, and a shape
-        // each of those builds only to keep hidden is a shape too many.
+        // The condition arcs, loaded on demand — a scope in a dogfight plots
+        // far more ungauged marks than gauged ones, and a shape each of those
+        // builds only to keep hidden is a shape too many.
         Loader {
             anchors.centerIn: parent
-            width: 2 * (root.healthRadius + root.healthStrokeWidth / 2)
+            width: root.gaugeSide
             height: width
             active: root.showHealth
-            sourceComponent: root.healthGauge
+            sourceComponent: root.healthArc
+        }
+
+        Loader {
+            anchors.centerIn: parent
+            width: root.gaugeSide
+            height: width
+            active: root.showFuel
+            sourceComponent: root.fuelArc
         }
 
         Text {
@@ -139,7 +172,7 @@ Item {
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 top: parent.bottom
-                topMargin: root.labelGap + (root.showHealth ? root.healthOverhang : 0)
+                topMargin: root.labelGap + (root.showHealth || root.showFuel ? root.gaugeOverhang : 0)
             }
         }
     }

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -68,6 +68,7 @@ Item {
     property bool showOwnshipPulse: true
     property bool showTrackLabels: true
     property bool showTrackHealth: true
+    property bool showOwnshipCondition: true
     property bool showNorth: false
     property bool closedRings: false
 
@@ -216,6 +217,12 @@ Item {
         classification: root.observer ? root.observer.classification : Classification.Kind.Unknown
         side: root.observer ? root.observer.side : Side.Kind.Unknown
         showLabel: false
+        // Ownship carries both flanks — hull left, fuel right — the one mark
+        // on the scope with a tank reading to show.
+        hasHealth: root.showOwnshipCondition && root.observer && root.observer.maxHealth > 0
+        healthFrac: root.observer ? root.observer.healthFrac : 1
+        hasFuel: root.showOwnshipCondition && root.observer && root.observer.maxFuel > 0
+        fuelFrac: root.observer ? root.observer.fuelFrac : 1
     }
 
     // North marker: an 'N' seated just outside the rim at the north bearing,

--- a/app/briarthorn/qml/ui/ViewStatus.qml
+++ b/app/briarthorn/qml/ui/ViewStatus.qml
@@ -21,8 +21,8 @@ Item {
     readonly property real cy: height / 2
     readonly property real ringWidth: shortSide * 0.055
 
-    readonly property real healthFrac: ownship && ownship.maxHealth > 0 ? Math.max(0, Math.min(1, ownship.health / ownship.maxHealth)) : 0
-    readonly property real fuelFrac: ownship && ownship.maxFuel > 0 ? Math.max(0, Math.min(1, ownship.fuel / ownship.maxFuel)) : 0
+    readonly property real healthFrac: ownship ? ownship.healthFrac : 0
+    readonly property real fuelFrac: ownship ? ownship.fuelFrac : 0
     readonly property bool hullLow: healthFrac <= 0.3
     readonly property bool fuelLow: fuelFrac <= 0.2
 


### PR DESCRIPTION
Follow-up to #91, which plotted a full semicircular hull gauge on aircraft track marks. Two changes on top of it.

## The arc narrows to 120 degrees

The semicircle read as a ring around the mark rather than a bar beside it. The span is now a `gaugeSweep` property at a third of a circle, centred on the flank, so hull runs 210 to 330.

The caption's clearance derives from the span instead of assuming a semicircle: an arc centred on a flank drops `sin(half-span)` of the radius below the mark's centre, which is the full radius at 180 degrees and about 0.87 of it at 120. A gauged mark's label now seats ~0.09 of the mark width lower than a bare one's, against ~0.17 before — much closer to the ungauged spacing.

## Ownship carries hull and fuel

`Symbol` grew a `hasFuel` / `fuelFrac` pair alongside the hull one, drawn on the right flank as a mirror of hull on the left. Both flanks fill upward from their lower end — hull sweeps clockwise, fuel counter-clockwise — so both readings drain toward the bottom together.

`ViewSituation` gained `showOwnshipCondition`, on for the attack scope and off for the corner minimap. Fuel is caller-driven and only ownship ever sets it: no sensor reports what is in another aircraft's tanks, so there is no path for a contact to acquire a fuel arc.

## Incidental

- The database row flag `hullGauge` is renamed `conditionGauge`, since it now gates both flanks.
- `Entity` exposes `healthFrac` and `fuelFrac` as clamped read-only properties. `ViewStatus` was already doing that division and clamping inline, so it reads them now instead.

## On removing the top-left status panel

This does not remove `ViewStatus`, and the geometry argues against doing so as-is. The scope's ownship mark is `symbolSize: height * 0.04` — about 40 px on a 1080p window, giving a 25 px arc radius on a 4 px stroke, against the 150 px `ViewStatus` instrument. The arcs read as "roughly half" at that size but not as a number, and dropping the panel would lose the hull hit points and fuel percent entirely. Freeing that corner would want a larger ownship mark plus readouts beneath it, which is a separate change.

## Verification

Parse-checked only — `qmlformat` round-trips all seven changed files, and the arc geometry was checked against a reimplementation of the same math. **Not built and not run:** the session had no Qt toolchain, and the egress policy blocks both the container registry blob CDN and `download.qt.io`, so neither the devcontainer nor a vcpkg/aqt Qt could be fetched. Worth a local build before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtHnhECvRAQWKVCY8UkWG1)_