### PR TITLE
Stand the hull gauge further off the mark and drop the ownship arcs

### DIFF
--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -638,7 +638,6 @@ Window {
             showOwnshipPulse: false
             showTrackLabels: false
             showTrackHealth: false
-            showOwnshipCondition: false
             showEngagements: false
             showTrails: false
 

--- a/app/briarthorn/qml/database/Data.qml
+++ b/app/briarthorn/qml/database/Data.qml
@@ -3,7 +3,7 @@ import QtQml
 // The row shape every database entry satisfies: one classification's render
 // definition, as the symbol outline in unit-box points centred on the origin
 // (nose toward -y, coordinates in [-0.5, 0.5]), the fallback label, the scale
-// the symbol draws at and whether the mark carries condition arcs alongside it.
+// the symbol draws at and whether the mark carries a hull gauge alongside it.
 // Instantiated bare it is a presentation-only row a
 // sensor plots but nothing ever spawns; spawnable kinds use DataEntity.
 QtObject {
@@ -14,8 +14,8 @@ QtObject {
     property string label: ""
     property real symbolScale: 1
 
-    // Whether a resolved mark of this kind carries condition arcs on its
-    // flanks. An airframe's condition is worth reading straight off the
-    // picture; a round in flight, a lure and an unresolved return plot bare.
-    property bool conditionGauge: false
+    // Whether a resolved mark of this kind carries a hull gauge on its left.
+    // An airframe's condition is worth reading straight off the picture; a
+    // round in flight, a lure and an unresolved return all plot bare.
+    property bool hullGauge: false
 }

--- a/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
+++ b/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
@@ -9,7 +9,7 @@ DataEntity {
     classification: Classification.Kind.AircraftFighter
     outline: [Qt.point(0, -0.5), Qt.point(0.4, 0.45), Qt.point(0, 0.18), Qt.point(-0.4, 0.45)]
     label: qsTr("FIGHTER")
-    conditionGauge: true
+    hullGauge: true
 
     // A +/- 60 degree radar cone: it has to point at what it wants to see, and
     // a semi-active round of its own only tracks what it keeps inside this.

--- a/app/briarthorn/qml/ui/Symbol.qml
+++ b/app/briarthorn/qml/ui/Symbol.qml
@@ -9,11 +9,11 @@ import "../themes"
 
 // A scope symbol: the classification's outline polygon stroked in its side's
 // colour over a window-background fill, nose turned to noseAngle, with a
-// screen-upright label below and optional condition arcs on its flanks — hull
-// left, fuel right. Centre it on the plot point; an empty label falls back to
-// the classification's. Inside a rotated view, bind viewRotation to the
-// container's rotation so the label and the arcs counter-rotate and hold their
-// screen-upright places.
+// screen-upright label below and an optional hull gauge standing off its left.
+// Centre it on the plot point; an empty label falls back to the
+// classification's. Inside a rotated view, bind viewRotation to the
+// container's rotation so the label and the gauge counter-rotate and hold
+// their screen-upright places.
 Item {
     id: root
 
@@ -29,16 +29,13 @@ Item {
     property string label: ""
     property bool showLabel: true
 
-    // Condition arcs: whether the caller holds a hull or fuel reading for this
-    // contact, and the readings themselves as fractions of full. Whether a
+    // Hull condition: whether the caller holds a reading for this contact at
+    // all, and the reading itself as a fraction of full hull. Whether that
     // reading is worth drawing is the kind's call, not the caller's — only a
-    // row asking for gauges gets them, so a munition mark and the bare
-    // instrument marks plot without. Fuel is ownship's alone: no sensor ever
-    // reports what is in another aircraft's tanks.
+    // row asking for a gauge gets one, so a munition mark and the bare
+    // instrument marks plot without.
     property bool hasHealth: false
     property real healthFrac: 1
-    property bool hasFuel: false
-    property real fuelFrac: 1
 
     // Symbol size in px, before the classification's symbolScale.
     property real symbolSize: 36
@@ -64,31 +61,25 @@ Item {
         }
     }
 
-    readonly property bool showHealth: root.hasHealth && root.def.conditionGauge
-    readonly property bool showFuel: root.hasFuel && root.def.conditionGauge
+    readonly property bool showHealth: root.hasHealth && root.def.hullGauge
 
-    // A reading this far down goes to the warn colour — the same thresholds
-    // the ownship condition instrument reads at.
+    // A hull this far down reads as a casualty, and the gauge goes to the warn
+    // colour — the same threshold the ownship condition instrument uses.
     readonly property bool healthLow: root.healthFrac <= 0.3
-    readonly property bool fuelLow: root.fuelFrac <= 0.2
 
-    // Gauge geometry: arcs standing just clear of the symbol's own extent,
-    // weighted off the mark so a mark drawn small carries a thin arc. A third
-    // of a circle each, so a flank reads as a bar beside the mark rather than
-    // a ring around it.
+    // Gauge geometry: an arc standing well off the symbol's own extent, so it
+    // reads as a bar beside the mark rather than a ring around it. Weighted
+    // and seated off the mark, so a mark drawn small carries a thin close arc.
     readonly property real gaugeStrokeWidth: Math.max(2, root.width * 0.1)
-    readonly property real gaugeRadius: root.width * 0.62
+    readonly property real gaugeRadius: root.width * 0.85
     readonly property real gaugeSweep: 120
 
-    // How far a flank's lower end hangs below the mark's own bounds. The span
-    // is centred on its flank, so the ends sit sin(half-span) of the radius
+    // How far the arc's lower end hangs below the mark's own bounds. The span
+    // is centred on the flank, so the ends sit sin(half-span) of the radius
     // below the centre. The caption clears it, so a gauged mark's label seats
     // exactly that much lower than a bare one's.
     readonly property real gaugeOverhang: Math.max(0, root.gaugeRadius * Math.sin(root.gaugeSweep * Math.PI / 360) + root.gaugeStrokeWidth / 2 - root.height / 2)
     readonly property real labelGap: Math.max(2, root.symbolSize * 0.07)
-
-    // The box either arc needs, so both flanks seat off one number.
-    readonly property real gaugeSide: 2 * (root.gaugeRadius + root.gaugeStrokeWidth / 2)
 
     // Hull on the left flank, swept clockwise up from 7 o'clock so damage
     // drains the arc downward.
@@ -100,19 +91,6 @@ Item {
             value: root.healthFrac
             trackColor: Style.theme.gaugeTrack
             fillColor: root.healthLow ? Style.theme.warn : root.sideColor
-        }
-    }
-
-    // Fuel mirrors it on the right, so ownship carries the pair as one
-    // instrument and both readings drain toward the bottom together.
-    readonly property Component fuelArc: Component {
-        ShapeGauge {
-            strokeWidth: root.gaugeStrokeWidth
-            angleStart: 90 + root.gaugeSweep / 2
-            angleSweep: -root.gaugeSweep
-            value: root.fuelFrac
-            trackColor: Style.theme.gaugeTrack
-            fillColor: root.fuelLow ? Style.theme.warn : Style.theme.fuel
         }
     }
 
@@ -138,23 +116,15 @@ Item {
         anchors.fill: parent
         rotation: -root.viewRotation
 
-        // The condition arcs, loaded on demand — a scope in a dogfight plots
-        // far more ungauged marks than gauged ones, and a shape each of those
+        // The hull gauge, loaded on demand — a scope in a dogfight plots far
+        // more ungauged marks than gauged ones, and a shape each of those
         // builds only to keep hidden is a shape too many.
         Loader {
             anchors.centerIn: parent
-            width: root.gaugeSide
+            width: 2 * (root.gaugeRadius + root.gaugeStrokeWidth / 2)
             height: width
             active: root.showHealth
             sourceComponent: root.healthArc
-        }
-
-        Loader {
-            anchors.centerIn: parent
-            width: root.gaugeSide
-            height: width
-            active: root.showFuel
-            sourceComponent: root.fuelArc
         }
 
         Text {
@@ -172,7 +142,7 @@ Item {
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 top: parent.bottom
-                topMargin: root.labelGap + (root.showHealth || root.showFuel ? root.gaugeOverhang : 0)
+                topMargin: root.labelGap + (root.showHealth ? root.gaugeOverhang : 0)
             }
         }
     }

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -68,7 +68,6 @@ Item {
     property bool showOwnshipPulse: true
     property bool showTrackLabels: true
     property bool showTrackHealth: true
-    property bool showOwnshipCondition: true
     property bool showNorth: false
     property bool closedRings: false
 
@@ -217,12 +216,6 @@ Item {
         classification: root.observer ? root.observer.classification : Classification.Kind.Unknown
         side: root.observer ? root.observer.side : Side.Kind.Unknown
         showLabel: false
-        // Ownship carries both flanks — hull left, fuel right — the one mark
-        // on the scope with a tank reading to show.
-        hasHealth: root.showOwnshipCondition && root.observer && root.observer.maxHealth > 0
-        healthFrac: root.observer ? root.observer.healthFrac : 1
-        hasFuel: root.showOwnshipCondition && root.observer && root.observer.maxFuel > 0
-        fuelFrac: root.observer ? root.observer.fuelFrac : 1
     }
 
     // North marker: an 'N' seated just outside the rim at the north bearing,


### PR DESCRIPTION
Follow-up to #92. Two changes, one of them a revert.

## The gauge stands further off the mark

`gaugeRadius` goes from `width * 0.62` to `width * 0.85`, so the arc's inner edge sits 0.80 of the mark width from centre rather than 0.57 — clear of the fighter's wingtips at 0.4 instead of nearly touching them.

The caption follows automatically: `gaugeOverhang` already derives the label's clearance from the radius and span, so a gauged mark's label now seats 0.29 of the mark width lower instead of 0.09. That is the visible cost of the extra standoff, and the whole knob is the one `0.85` — 0.75 gives a 0.20 drop, 1.00 gives 0.42, if this reads as too far or not far enough.

## The ownship arcs come back out

#92 gave the scope's ownship mark a hull and fuel pair. Removed. Since fuel was ownship's alone, nothing else ever set it, so the whole fuel path goes with it rather than staying as unreachable code:

- `Symbol` loses `hasFuel`, `fuelFrac`, `showFuel`, `fuelLow` and `fuelArc`, and is back to one arc behind one `Loader`.
- `ViewSituation` loses `showOwnshipCondition` and the ownship mark's condition bindings; `Main.qml` loses the matching minimap override.
- The database row flag goes back to `hullGauge` from `conditionGauge`, since it gates one gauge again.

`ViewStatus` is untouched and remains the ownship condition readout. `Entity.healthFrac` / `Entity.fuelFrac` from #92 stay — `ViewStatus` reads both, and they are what kept the division and clamping out of the view.

## Verification

Parse-checked only — `qmlformat` round-trips all five changed files, and the arc geometry and caption clearance were checked against a reimplementation of the same math. **Not built and not run:** this session has no Qt toolchain, and the egress policy blocks both the container registry blob CDN and `download.qt.io`, so neither the devcontainer nor a vcpkg/aqt Qt could be fetched. Worth a local build before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtHnhECvRAQWKVCY8UkWG1)_