### PR TITLE
Ownship speed ring and idle-centred throttle lever

### DIFF
--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -176,7 +176,6 @@ Window {
 
         Axis {
             id: axisThrottle
-            minimum: 0
         }
 
         // The scope's range control, the one object every ranging source —
@@ -211,6 +210,7 @@ Window {
             ActionKey {
                 control: axisThrottle
                 positive: root.keymap.flight.throttle.key.positive
+                negative: root.keymap.flight.throttle.key.negative
             }
 
             ActionButton {
@@ -568,9 +568,9 @@ Window {
             // over — including on a laptop that has both.
             visible: TouchScreen.available && root.device.touch && !settings.open && !root.inMenu
             onValueXChanged: axisSteer.invoke(valueX)
-            // The stick has no reverse, so a downward pull must not subtract
-            // from a throttle another source (keys, pad) is holding up.
-            onValueYChanged: axisThrottle.invoke(Math.max(0, valueY))
+            // The stick's whole travel is the lever: pushed past centre
+            // throttles up, pulled back brakes.
+            onValueYChanged: axisThrottle.invoke(valueY)
             onActiveChanged: {
                 if (stick.active)
                     root.device.kind = ActiveDevice.Touch;

--- a/app/briarthorn/qml/commands/CommandThrottle.qml
+++ b/app/briarthorn/qml/commands/CommandThrottle.qml
@@ -1,11 +1,12 @@
 import awen.command
 
-// Throttle intent: sets the flown entity's throttle input, 0 to 1.
+// Throttle intent: the flight lever's position, -1 (full brake) to 1 (full
+// throttle); the store prices it into the commanded speed fraction.
 // Continuous, so re-posts within a frame coalesce to the newest value.
 Command {
     id: root
 
-    // The throttle setpoint the record carries.
+    // The lever position the record carries.
     property real value: 0
 
     name: Verbs.throttle

--- a/app/briarthorn/qml/database/GameRules.qml
+++ b/app/briarthorn/qml/database/GameRules.qml
@@ -22,7 +22,11 @@ QtObject {
     // Multiplier on the cruise burn at full throttle — the draw is
     // fuelBurnFor(kinetic) * (1 + fuelThrottleBurn * throttle), so pushing the
     // airframe costs far more than loitering does.
-    readonly property real fuelThrottleBurn: 8
+    readonly property real fuelThrottleBurn: 2
+
+    // The speed fraction a hands-off lever commands: the airframe cruises at
+    // half its ceiling, full brake pulls it to a stop and full throttle to max.
+    readonly property real throttleIdle: 0.5
 
     // maneuver buys agility: the full-deflection turn rate (deg/s) and the
     // acceleration (m/s^2) speed closes on the commanded setting with.
@@ -32,7 +36,7 @@ QtObject {
     // durable buys survivability: hull integrity (hit points) and the fuel
     // capacity (units) of one airframe.
     readonly property real maxHealth: 200
-    readonly property real maxFuel: 200
+    readonly property real maxFuel: 400
 
     // sensor buys the radar's detection range (m).
     readonly property real maxDetectionRange: 120000
@@ -48,6 +52,13 @@ QtObject {
 
     function topSpeedFor(kinetic: real): real {
         return root.maxSpeed * root.fraction(kinetic);
+    }
+
+    // Prices a throttle lever, -1 (full brake) to 1 (full throttle), into the
+    // commanded speed fraction swinging around the idle cruise.
+    function throttleFor(lever: real): real {
+        const swing = Math.max(-1, Math.min(1, lever));
+        return root.throttleIdle + swing * (swing >= 0 ? 1 - root.throttleIdle : root.throttleIdle);
     }
 
     function fuelBurnFor(kinetic: real): real {

--- a/app/briarthorn/qml/input/Keymap.qml
+++ b/app/briarthorn/qml/input/Keymap.qml
@@ -52,10 +52,11 @@ QtObject {
             throttle: {
                 key: {
                     positive: [Qt.Key_W, Qt.Key_Up],
-                    negative: []
+                    negative: [Qt.Key_S, Qt.Key_Down]
                 },
                 // No button of its own: the d-pad's vertical ranges the scope
-                // and the left stick already throttles by how far it is pushed.
+                // and the left stick is the whole lever — pushed throttles up,
+                // pulled back brakes.
                 pad: {
                     positive: [],
                     negative: []

--- a/app/briarthorn/qml/model/StoreGame.qml
+++ b/app/briarthorn/qml/model/StoreGame.qml
@@ -22,6 +22,9 @@ Store {
         classification: Classification.Kind.AircraftFighter
         side: Side.Kind.Ownship
         radarFov: 60
+        // Spawned already at cruise: the lever at rest commands idle, not a
+        // stop, and the first post overwrites this binding.
+        commandedThrottle: GameRules.throttleIdle
     }
 
     // The live craft. reset() owns the swap; everything else binds through
@@ -39,7 +42,7 @@ Store {
 
     CommandHandler {
         name: Verbs.throttle
-        onHandle: payload => root.ownship.commandedThrottle = payload.value
+        onHandle: payload => root.ownship.commandedThrottle = GameRules.throttleFor(payload.value)
     }
 
     // Ability invocation routes to the named slot; activation is a no-op

--- a/app/briarthorn/qml/ui/ViewHints.qml
+++ b/app/briarthorn/qml/ui/ViewHints.qml
@@ -13,7 +13,7 @@ Text {
     // craft on entirely different controls.
     required property ActiveDevice device
 
-    text: root.device.pad ? qsTr("LEFT STICK fly · D-PAD range · START pause") : qsTr("W thrust · A/D turn · WHEEL range · ESC pause")
+    text: root.device.pad ? qsTr("LEFT STICK fly · D-PAD range · START pause") : qsTr("W/S throttle · A/D turn · WHEEL range · ESC pause")
     color: Style.theme.textMuted
     elide: Text.ElideRight // the caller caps width where the line would collide
     font { pixelSize: 12; family: Style.monospace }

--- a/app/briarthorn/qml/ui/ViewStatus.qml
+++ b/app/briarthorn/qml/ui/ViewStatus.qml
@@ -6,10 +6,15 @@ import "../themes"
 
 // Ownship condition readout: a round instrument that mirrors the corner minimap
 // opposite it — same footprint, so the two read as a matched pair and the whole
-// thing stays compact on a phone. Two concentric arc dials around the ownship
-// symbol — HULL outer (cyan), FUEL inner (gold) — each sweeping 270° and opening
-// at the bottom, with the values seated in that open mouth. A low reading shifts
-// its ring and value to the warn colour. Reads live from the ownship entity.
+// thing stays compact on a phone. Three concentric arc dials around the ownship
+// symbol — HULL outer (cyan), FUEL middle (gold), SPEED inner (pale cyan) —
+// each sweeping 270° and opening at the bottom, with the values seated in that
+// open mouth, stacked inner-to-outer so each number sits with its ring —
+// speed smallest by the symbol, hull largest at the rim. A white tick on the
+// speed ring marks the commanded throttle; speed closes on exactly that mark,
+// so the gap to the fill tip is the spool still in progress. A low hull or
+// fuel reading shifts its ring and value to the warn colour. Reads live from
+// the ownship entity.
 Item {
     id: root
 
@@ -23,6 +28,10 @@ Item {
 
     readonly property real healthFrac: ownship ? ownship.healthFrac : 0
     readonly property real fuelFrac: ownship ? ownship.fuelFrac : 0
+    readonly property real speedFrac: ownship && ownship.topSpeed > 0 ? Math.min(1, ownship.speed / ownship.topSpeed) : 0
+    // Clamped here: maneuvers write the entity directly, not through the
+    // priced throttle handler.
+    readonly property real throttleFrac: ownship ? Math.max(0, Math.min(1, ownship.commandedThrottle)) : 0
     readonly property bool hullLow: healthFrac <= 0.3
     readonly property bool fuelLow: fuelFrac <= 0.2
 
@@ -57,19 +66,51 @@ Item {
         fillColor: root.fuelLow ? Style.theme.warn : Style.theme.fuel
     }
 
+    // SPEED — the innermost dial. No warn colour: nothing in the rules
+    // degrades speed, so unlike hull and fuel there is no threshold to flag.
+    ShapeGauge {
+        id: speedGauge
+
+        anchors.fill: parent
+        centerX: root.cx
+        centerY: root.cy
+        radius: root.shortSide * 0.27
+        strokeWidth: root.ringWidth
+        angleStart: 225
+        angleSweep: 270
+        value: root.speedFrac
+        trackColor: Style.theme.gaugeTrack
+        fillColor: Style.theme.accentBright
+    }
+
+    // The commanded-throttle bug: a radial tick riding the speed ring at the
+    // setpoint's bearing, proud of the stroke so it reads over track and fill.
+    Rectangle {
+        readonly property real bearing: 225 + 270 * root.throttleFrac
+        readonly property point mark: speedGauge.pointAt(bearing, speedGauge.radius)
+
+        width: 2
+        height: root.ringWidth + root.shortSide * 0.02
+        x: mark.x - width / 2
+        y: mark.y - height / 2
+        rotation: bearing
+        color: Style.theme.textBright
+    }
+
     // Ownship symbol, nose up, lifted just above centre so it clears the mouth
-    // readouts below.
+    // readouts below and sized to sit inside the speed ring.
     Symbol {
         x: root.cx - width / 2
         y: root.cy - height / 2 - root.shortSide * 0.09
-        symbolSize: root.shortSide * 0.26
+        symbolSize: root.shortSide * 0.24
         classification: root.ownship ? root.ownship.classification : Classification.Kind.AircraftFighter
         side: root.ownship ? root.ownship.side : Side.Kind.Ownship
         showLabel: false
     }
 
-    // Readouts in the open mouth at the bottom: hull number over fuel percent,
-    // colour-keyed to their rings.
+    // Readouts in the open mouth at the bottom, stacked inner-to-outer like
+    // the rings they read: speed in m/s by the symbol, then fuel percent, then
+    // the hull number at the rim, colour-keyed to their rings.
     Column {
         anchors.horizontalCenter: parent.horizontalCenter
         y: root.cy + root.shortSide * 0.08
@@ -77,9 +118,10 @@ Item {
 
         Text {
             anchors.horizontalCenter: parent.horizontalCenter
-            text: root.ownship ? Math.round(root.ownship.health) : "--"
-            color: root.hullLow ? Style.theme.warn : Style.theme.accent
-            font { pixelSize: Math.max(11, root.shortSide * 0.15); family: Style.monospace; bold: true }
+            text: root.ownship ? Math.round(root.ownship.speed) : "--"
+            color: Style.theme.accentBright
+            font.pixelSize: Math.max(9, root.shortSide * 0.085)
+            font.family: Style.monospace
         }
 
         Text {
@@ -88,6 +130,13 @@ Item {
             color: root.fuelLow ? Style.theme.warn : Style.theme.fuel
             font.pixelSize: Math.max(9, root.shortSide * 0.11)
             font.family: Style.monospace
+        }
+
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: root.ownship ? Math.round(root.ownship.health) : "--"
+            color: root.hullLow ? Style.theme.warn : Style.theme.accent
+            font { pixelSize: Math.max(11, root.shortSide * 0.15); family: Style.monospace; bold: true }
         }
     }
 }


### PR DESCRIPTION
## What changed

**Status gauge** (`ViewStatus.qml`): a third concentric ring inside the fuel arc shows actual speed as a fraction of the airframe's ceiling, with a white radial tick riding the ring at the commanded throttle's bearing — the gap between fill tip and tick is the spool still in progress. The mouth readouts are restacked inner-to-outer to match the rings: speed (smallest, by the symbol), fuel percent, hull number (largest, at the rim), each colour-keyed to its ring.

**Throttle model**: the throttle is now a lever, priced by two new rules in `GameRules.qml` (`throttleIdle: 0.5`, `throttleFor(lever)`). A resting lever commands half the top speed, full brake commands a stop, full throttle the maximum. The store handler prices the posted lever; `Entity.commandedThrottle` keeps its 0..1 fraction-of-max semantics, so AI maneuvers and the menu demo's director are untouched. Wiring: the throttle axis spans −1..1 (brake side un-floored), S/Down are the brake keys (auto-refused for ability rebinding), the gamepad stick's and touch stick's pull-back now brake, the player craft spawns at idle cruise, and the hint bar teaches W/S. Also carries the fuel retune this builds on: `fuelThrottleBurn` 8 → 2 on a 200 → 400 tank.

## Why

The fuel retune made throttle discipline cheaper but speed awareness more important; the gauge grew the one ring that shows both. Speed and throttle converge at steady state (no drag or turn bleed), so one fill plus one setpoint marker is the honest display — and the tick doubles as the burn cue, since draw scales with the commanded setting.

## Reviewer notes

- No warn colour on the speed ring: nothing in the rules degrades speed, and an orange state would dilute the hull/fuel warn semantics.
- The view clamps `commandedThrottle` on read because maneuvers write the entity directly, not through the priced handler.
- Hands-off flight now burns 2× the base cruise draw (idle commands 0.5); `fuelThrottleBurn` in `GameRules.qml` is the single retune knob if that reads too hungry.
- Verified with a qml.exe harness off the source tree at the default 158 px and floor 110 px instrument sizes: idle (tick atop the converged fill), full-throttle spool, and full-brake states all render and the lever pricing probes exact (−1→0, 0→0.5, 1→1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)