### PR TITLE
Teach the duelist to open back out before re-attempting a close guided launch

### DIFF
--- a/app/briarthorn/qml/database/personalities/PersonalityDuelist.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityDuelist.qml
@@ -2,8 +2,9 @@ import ".."
 
 // Fights one exchange at a time: presses to fire, then cranks — trigger held,
 // target ridden at the cone's edge — until the round in flight dies, so no
-// magazine ever streams. Beams genuine inbounds early enough to watch, and
-// breaks off dry.
+// magazine ever streams. Beams genuine inbounds early enough to watch, breaks
+// off dry, and opens a too-close merge back out to launch distance rather
+// than wasting a round that cannot make its turn.
 Personality {
     name: Names.personality.duelist
 
@@ -27,6 +28,14 @@ Personality {
                 SwitchOutbound {
                     present: true
                     to: Names.stance.crank
+                },
+                // A launch from inside ~half the round's reach cannot make
+                // its turn; no dwell, so the crossing tick holds fire before
+                // the trigger system runs.
+                SwitchRange {
+                    inside: true
+                    at: 0.55
+                    to: Names.stance.withdraw
                 }
             ]
         },
@@ -48,15 +57,42 @@ Personality {
                 }
             ]
         },
+        // Guard holds the trigger too: a notch that sweeps the cone across
+        // the target would otherwise stream rounds — at whatever range the
+        // fight has closed to — outside the press-crank exchange rhythm.
         Stance {
             name: Names.stance.guard
             maneuver: Names.maneuver.notch
             reference: Stance.Reference.Threat
+            holdFire: true
             switches: [
                 SwitchThreat {
                     present: false
                     within: 0.45
                     dwell: 0.5
+                    to: Names.stance.press
+                }
+            ]
+        },
+        // The extension: run dead away — trigger cold — and press again once
+        // comfortably clear of the failure band. Flee, not evade: evade
+        // trades radial speed for perimeter riding as it nears its ring, and
+        // a merely-jogging pursuer stalls that inside the rejoin edge forever.
+        Stance {
+            name: Names.stance.withdraw
+            maneuver: Names.maneuver.flee
+            holdFire: true
+            switches: [
+                SwitchThreat {
+                    present: true
+                    within: 0.45
+                    dwell: 0.3
+                    to: Names.stance.guard
+                },
+                SwitchRange {
+                    inside: false
+                    at: 0.8
+                    dwell: 1
                     to: Names.stance.press
                 }
             ]


### PR DESCRIPTION
## What

In the 1v1 duel, guided missiles launched inside ~10 km typically fail to make their turn — accepted behaviour, but the bandit kept launching from there anyway. The duelist personality now knows its round's failure band and repositions instead, entirely within the personality vocabulary (fractions of the priced weapon envelope, never metres):

- `press` gains a `SwitchRange`: target inside **0.55 of own weapon reach** (~10.6 km on the guided round's 19.2 km) switches to a new `withdraw` stance. No dwell — SystemPersonality arms `engageHold` before SystemEngage runs, so the crossing tick cannot leak a launch.
- `withdraw` flies `flee` with the trigger cold, still beams genuine inbounds (`SwitchThreat` → `guard`), and rejoins `press` once outside **0.8 of reach** (~15.4 km) held for 1 s, so re-launches land comfortably clear of the band.
- `guard` now also holds fire: a notch that sweeps the cone across the target streamed launches from guard (one observed at 5.9 km), violating both the failure-band discipline and the duelist's own "no magazine ever streams" contract. Press is now the duelist's only firing stance; aggressive keeps its trigger-hot guard deliberately.

## Why flee, not evade

The first cut mirrored tactical's withdraw (`evade` at a standoff ring), but evade trades radial speed for perimeter-riding as it nears its ring: against a pursuer at ~2/3 the bandit's speed the extension reached equilibrium at 12.8 km — inside the 15.4 km rejoin edge — and the bandit kited forever without re-attacking. `flee` keeps full outward speed and lets the rejoin switch end the extension. (Tactical's withdraw carries the same latent stall; tracked separately since no scenario uses it yet.)

## Verification

Headless `qml.exe` harness driving the real database/model/systems off the source tree, three scenarios:

- **Part-throttle pursuer:** launch at 19.2 km → crank → withdraw fires at 10,538 m with zero in-band launches → extends → re-launches at ~14.5 km, cycle repeats sustainably.
- **Full-throttle pursuer (faster than the bandit):** extension physically denied; the bandit kites with the trigger cold rather than reverting to wasted close shots.
- **Ownship shooting back:** guards through the threat without streaming, refuses the 4.6 km snap shot the instant the threat clears, and holds a steady launch–crank–withdraw rhythm over 600 s.

`qmllint` is clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
