### PR TITLE
Fly the tactical withdraw as flee so pursuit cannot stall it short of rejoin

### DIFF
--- a/app/briarthorn/qml/database/personalities/PersonalityTactical.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityTactical.qml
@@ -54,11 +54,13 @@ Personality {
                 }
             ]
         },
+        // Withdraw reopens the band dead away — flee, not evade: evade
+        // trades radial speed for perimeter riding as it nears its ring, and
+        // a merely-jogging pursuer stalls that inside the rejoin edge forever.
         Stance {
             name: Names.stance.withdraw
-            maneuver: Names.maneuver.evade
+            maneuver: Names.maneuver.flee
             holdFire: true
-            standoff: 0.9
             switches: [
                 SwitchRange {
                     inside: false


### PR DESCRIPTION
## What

Swaps the tactical personality's withdraw stance from the evade maneuver (standoff 0.9 of own weapon reach) to flee, dropping the standoff and keeping the existing 0.6 / 0.85 hysteresis band and 1.5 s rejoin dwell. Same shape as the duelist's withdraw extension.

## Why

ManeuverEvade blends from nose-in through perimeter-riding to tail-out across half its standoff, so a withdrawing runner gives up radial speed as it nears its ring. The opening rate reaches equilibrium with a pure-pursuit chaser at range standoff·(1 + (1 − θ/90)/2) where cos θ = −v_pursuer/v_runner — and with the rejoin edge (0.85) only 0.05 under the standoff (0.9), any pursuer above ~17% of the runner's speed parks the equilibrium inside the rejoin edge. The stance then never exits: the entity kites forever, trigger cold, without re-attacking. No standoff/rejoin retune fixes this across the span of pursuer speeds (equal-speed pursuit drags the equilibrium to standoff/2), so flee — which opens unconditionally whenever the runner is strictly faster — is the right maneuver, not a retune.

Tactical is currently unused by any scenario, so this is tuning debt rather than a live bug.

## Verification

Headless qml.exe harness (plugin-less awen.entity import, awen.gamepad JS stub, absolute directory imports of database/model/systems, manual system.update loop): a tactical fighter (300 m/s, 40 km reach) against a scripted pure-pursuit chaser at 200 m/s over 600 sim-seconds.

- Pre-fix: advance → strike at 36 km → withdraw at 24 km, then range flatlines at 27.87 km (predicted equilibrium 27.6 km), inside the 34 km rejoin edge — pinned in withdraw for the remaining 528 s.
- Post-fix: three full withdraw → strike rejoins at a ~175 s period, each at 34.15 km — the 34.00 km edge plus exactly the 1.5 s dwell of overshoot at the ~100 m/s opening rate.

qmllint clean on the edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)