### PR TITLE
Fix fighter stat comments drifted from GameRules pricing

### DIFF
--- a/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
+++ b/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
@@ -16,9 +16,9 @@ DataEntity {
     radarFov: 120
 
     stats: Stats {
-        kinetic: 3 // 500 m/s, burning 0.5 units/s at cruise
+        kinetic: 3 // 300 m/s, burning 0.3 units/s at cruise
         maneuver: 5 // 12 deg/s and 100 m/s^2
-        durable: 5 // 100 hp on 100 units of fuel
+        durable: 5 // 100 hp on 200 units of fuel
         compute: 6
         sensor: 5 // a 60 km radar
         stealth: 5

--- a/app/briarthorn/qml/database/entities/DataAircraftFighterLight.qml
+++ b/app/briarthorn/qml/database/entities/DataAircraftFighterLight.qml
@@ -10,7 +10,7 @@ DataAircraftFighter {
     classification: Classification.Kind.AircraftFighterLight
 
     stats: Stats {
-        kinetic: 2.5 // 450 m/s against the stock fighter's 500
+        kinetic: 2.5 // 250 m/s against the stock fighter's 300
         maneuver: 4 // 9.6 deg/s against its 12
         durable: 5
         compute: 6


### PR DESCRIPTION
## What changed

Comment-only fix: three priced-number annotations in the fighter database rows had drifted from what `GameRules.qml` actually prices.

- `DataAircraftFighter.qml` — `kinetic: 3` now annotated **300 m/s, burning 0.3 units/s at cruise** (was 500 / 0.5, stale since c28d9a5 lowered kinetic from 5) and `durable: 5` now annotated **100 hp on 200 units of fuel** (was 100 units, stale since PR #94 raised `maxFuel` to 400).
- `DataAircraftFighterLight.qml` — `kinetic: 2.5` now annotated **250 m/s against the stock fighter's 300** (was 450 vs 500).

## Why

The stat comments are the human-readable record of what a rating buys; stale figures mislead anyone tuning the database.

## Reviewer notes

Every figure was recomputed from `GameRules.qml` (maxSpeed 1000, maxFuelBurn 1, maxHealth 200, maxFuel 400, maxTurnRate 24, maxAcceleration 200, maxDetectionRange 120000, maxGuidedRange 150000). The rest of `qml/database/` was swept for the same drift — the maneuver/sensor comments in these two files and the annotations in `DataDecoy`, `DataMissileGuided`, and `DataMissileKinetic` all still match, so no other edits were needed. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)