### PR TITLE
Fix the web shell's Fullscreen button on iPhone

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
             "runtimeExecutable": "python",
             "runtimeArgs": ["-m", "http.server", "8730", "--directory", "build/web-release/installed/web/briarthorn"],
             "port": 8730
+        },
+        {
+            "name": "briarthorn-web-debug",
+            "runtimeExecutable": "python",
+            "runtimeArgs": ["-m", "http.server", "8731", "--directory", "build/web-debug/installed/web/briarthorn"],
+            "port": 8731
         }
     ]
 }

--- a/app/briarthorn/web/index.html
+++ b/app/briarthorn/web/index.html
@@ -10,8 +10,10 @@ js/wasm files are referenced, so the installed web/ directory serves as-is.
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <!-- 1:1 CSS-pixel to Qt device-independent-pixel mapping on mobile. -->
-    <meta name="viewport" content="width=device-width, height=device-height, user-scalable=0"/>
+    <!-- 1:1 CSS-pixel to Qt device-independent-pixel mapping on mobile.
+         viewport-fit=cover lets the fullscreen view reach the edges of a notched
+         phone; the safe-area insets below keep content out of the notch itself. -->
+    <meta name="viewport" content="width=device-width, height=device-height, user-scalable=0, viewport-fit=cover"/>
     <!-- Tab icon as a data URI; source of truth: assets/icon/briarthorn.svg. -->
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+DQogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjMwIiBmaWxsPSIjMGQxODIwIiBzdHJva2U9IiMzZmI4YjMiIHN0cm9rZS13aWR0aD0iMiIvPg0KICA8Y2lyY2xlIGN4PSIzMiIgY3k9IjMyIiByPSIyMCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjM2ZiOGIzIiBzdHJva2Utd2lkdGg9IjEiIG9wYWNpdHk9IjAuNSIvPg0KICA8Y2lyY2xlIGN4PSIzMiIgY3k9IjMyIiByPSIxMCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjM2ZiOGIzIiBzdHJva2Utd2lkdGg9IjEiIG9wYWNpdHk9IjAuNCIvPg0KICA8cGF0aCBkPSJNMzIgMTYgTDMyIDQ4IE0xNiAzMiBMNDggMzIiIHN0cm9rZT0iIzNmYjhiMyIgc3Ryb2tlLXdpZHRoPSIwLjc1IiBvcGFjaXR5PSIwLjM1Ii8+DQogIDxwYXRoIGQ9Ik0zMiAyMiBMNDAgNDQgTDMyIDM4IEwyNCA0NCBaIiBmaWxsPSIjM2ZiOGIzIi8+DQo8L3N2Zz4NCg==">
     <title>Briarthorn</title>
@@ -31,7 +33,8 @@ js/wasm files are referenced, so the installed web/ directory serves as-is.
 
       body {
         margin: 0;
-        padding: 16px;
+        /* Widened where a notch intrudes, which in landscape is a side edge. */
+        padding: 16px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
         background-color: var(--bg);
         color: var(--text);
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -47,11 +50,22 @@ js/wasm files are referenced, so the installed web/ directory serves as-is.
         border: 1px solid var(--border);
         background: var(--bg-deep);
       }
-      /* Fullscreen drops the frame; Qt follows the container size automatically. */
-      .view:fullscreen {
+      /* Fullscreen drops the frame; Qt follows the container size automatically.
+         The second selector is awen-shell's fallback for browsers with no element
+         Fullscreen API — iPhone Safari — where the view pins itself instead. */
+      .view:fullscreen,
+      .view.pseudo-fullscreen {
         max-width: none;
         aspect-ratio: auto;
         border: none;
+      }
+      .view.pseudo-fullscreen {
+        position: fixed;
+        inset: 0;
+        z-index: 1;
+        box-sizing: border-box;
+        /* Cover puts the page under the notch; hold the game clear of it. */
+        padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
       }
       #screen { display: none; width: 100%; height: 100%; }
 
@@ -98,6 +112,22 @@ js/wasm files are referenced, so the installed web/ directory serves as-is.
         cursor: pointer;
       }
       input[type="button"]:hover { filter: brightness(1.08); }
+
+      /* The way out of the pinned fallback, which no browser gesture exits.
+         Centred on the game's top band, whose middle carries nothing — the
+         corners either side of it hold the condition gauge and the minimap. */
+      #exit-fullscreen { display: none; }
+      .view.pseudo-fullscreen #exit-fullscreen {
+        display: block;
+        position: absolute;
+        top: calc(env(safe-area-inset-top) + 5px);
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 1;
+        padding: 2px 12px;
+        font-size: 12px;
+        opacity: 0.75;
+      }
     </style>
   </head>
   <body onload="awenShell.init({ name: 'briarthorn', entry: window.briarthorn_entry, wasm: 'briarthorn.wasm' })">
@@ -110,11 +140,12 @@ js/wasm files are referenced, so the installed web/ directory serves as-is.
         <noscript>JavaScript is disabled. Please enable JavaScript to run Briarthorn.</noscript>
       </div>
       <div id="screen"></div>
+      <!-- Inside the view, so the pinned fallback keeps it reachable; styled
+           away entirely on the paths that have a browser exit gesture. -->
+      <input type="button" id="exit-fullscreen" value="Exit Fullscreen" onclick="awenShell.toggleFullscreen(document.getElementById('view'))">
     </div>
     <div class="controls">
-      <!-- Swallow the rejection when the browser denies fullscreen, and either
-           way hand keyboard focus back to the game. -->
-      <input type="button" value="Fullscreen" onclick="document.getElementById('view').requestFullscreen().catch(() => {}).finally(() => awenShell.focusApp())">
+      <input type="button" value="Fullscreen" onclick="awenShell.toggleFullscreen(document.getElementById('view'))">
     </div>
 
     <script src="awen-shell.js"></script>

--- a/cmake/wasm/awen-shell.js
+++ b/cmake/wasm/awen-shell.js
@@ -1,9 +1,10 @@
 // awen-shell.js — the shared machinery for awen app entry pages: loader overlay
-// wiring, wasm prefetch with real download progress, and keyboard-focus routing
-// into Qt's shadow DOM. The page supplies #loader/#status/#progress/#screen,
-// includes this script at the end of body BEFORE the app's <target>.js and
-// qtloader.js (so the elements exist and the error hooks cover those scripts),
-// and calls awenShell.init({ name, entry, wasm }) from body onload.
+// wiring, wasm prefetch with real download progress, keyboard-focus routing into
+// Qt's shadow DOM, and fullscreen toggling. The page supplies
+// #loader/#status/#progress/#screen and a .pseudo-fullscreen style (see
+// toggleFullscreen), includes this script at the end of body BEFORE the app's
+// <target>.js and qtloader.js (so the elements exist and the error hooks cover
+// those scripts), and calls awenShell.init({ name, entry, wasm }) from body onload.
 window.awenShell = (() => {
   let appName = 'app';
   const loaderElement = document.getElementById('loader');
@@ -61,6 +62,31 @@ window.awenShell = (() => {
 
   // Fullscreen transitions move focus around; keep the keyboard on the app.
   document.addEventListener('fullscreenchange', () => focusApp());
+
+  // iPhone Safari implements the Fullscreen API on no element but <video>, so
+  // requestFullscreen is absent there rather than merely denied. The page styles
+  // this class to pin the element over the viewport instead, and supplies its own
+  // way back out — the fallback has no browser-level exit gesture.
+  const PseudoFullscreen = 'pseudo-fullscreen';
+
+  function setPseudoFullscreen(element, on) {
+    element.classList.toggle(PseudoFullscreen, on);
+    focusApp(); // no fullscreenchange fires for this path
+  }
+
+  // Toggle @p element between fullscreen and normal, by whichever path the
+  // browser allows. Qt follows its container's size, so both look the same to it.
+  function toggleFullscreen(element) {
+    if (element.classList.contains(PseudoFullscreen))
+      setPseudoFullscreen(element, false);
+    else if (document.fullscreenElement === element)
+      document.exitFullscreen();
+    else if (element.requestFullscreen)
+      // A refusal (an iframe lacking the permission, say) falls back as well.
+      element.requestFullscreen().catch(() => setPseudoFullscreen(element, true)).finally(() => focusApp());
+    else
+      setPseudoFullscreen(element, true);
+  }
 
   // Nothing on the page needs the keyboard except the app, so refocus it
   // after any click — including clicks on the app itself, which Qt 6.11 does
@@ -160,5 +186,5 @@ window.awenShell = (() => {
     }
   }
 
-  return { init, focusApp };
+  return { init, focusApp, toggleFullscreen };
 })();


### PR DESCRIPTION
A user reported that Fullscreen does nothing on their iPhone.

## Cause

Safari on iPhone implements the Fullscreen API on no element but `<video>` — not unprefixed, not `webkitRequestFullscreen`. (iPad Safari does support it, which is likely why this went unnoticed; Chrome and Firefox on iOS are WebKit underneath and inherit the gap.)

So `view.requestFullscreen` is `undefined` there, and the old handler threw a `TypeError` **synchronously** — before any promise existed:

```html
onclick="document.getElementById('view').requestFullscreen().catch(() => {}).finally(() => awenShell.focusApp())"
```

The `.catch()` never ran, because this was a throw and not a rejection, and neither did the `.finally()`. The exception reached `window.onerror` in awen-shell.js, which by design ignores errors once `appLoaded` is true. The button did nothing, silently. The `.view:fullscreen` rule was dead for the same reason.

## Change

`awenShell.toggleFullscreen(element)` now owns this. It probes for the API instead of calling it blind, and pins the view under a `pseudo-fullscreen` class when the API is absent — or when it rejects, which also covers an iframe that lacks the permission. Qt follows its container size either way, so it sees no difference between the two paths.

The pinned path has no browser exit gesture, so the page supplies an `#exit-fullscreen` control. It lives *inside* `.view` — `.controls` sits outside and would be buried under the pinned overlay. It is centred on the game's top band, whose middle carries nothing; the corners either side hold the condition gauge and the minimap.

Also added `viewport-fit=cover` with safe-area insets on `body` (the landscape notch) and on the pinned view, since the view now reaches the screen edges.

The second commit adds a `briarthorn-web-debug` preview server entry. The existing one points at `build/web-release/...`, so there was nothing to serve a debug bundle with. Independent of the fix — drop that commit if unwanted.

## Verification

Served the existing web-debug wasm bundle with the updated shell and drove it in a browser, deleting `Element.prototype.requestFullscreen` to reproduce iPhone Safari:

| | before | after |
|---|---|---|
| iPhone path (1280x720) | throws `TypeError`, nothing happens | no throw; `.qt-screen` 1024x576 → **1280x720** |
| iPhone path (375x812) | same throw | view 343x194 → **375x812**, no horizontal overflow |
| Exit control | n/a | appears centred (111x20 at top 5px), restores to 1024x576, hides again |
| API present | worked | still preferred, pseudo class never applied |
| API rejects | silent no-op | falls back to pinned |

No console errors on any path.

## For the reviewer

Two things I could not exercise locally:

- Screenshots. The browser pane was not displayed, so the page never composited frames and the Qt `<canvas>` reads 0x0 in that environment. Everything above is DOM geometry and computed styles rather than pixels.
- `env(safe-area-inset-*)` resolves to 0 in the emulator, so the notch handling is correct by construction but untested. Worth confirming on a real iPhone, landscape especially.

Deliberately left out: `apple-mobile-web-app-capable` plus a manifest, the Add-to-Home-Screen route to a chromeless game on iOS. It complements this rather than replacing it, and is a separate change.

Prefixed `webkitRequestFullscreen` is also not handled — it would only serve iPadOS before Safari 16.4, and those get the pinned fallback, which works.
