### PR TITLE
Add a radar-occluding, collideable pillar arena to the duel scenario

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -73,6 +73,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/model/ManeuverNotch.qml
         qml/model/ManeuverOrbit.qml
         qml/model/ManeuverPursue.qml
+        qml/model/Obstacle.qml
         qml/model/PersonalityState.qml
         qml/model/RangeProjection.qml
         qml/model/Side.qml
@@ -84,6 +85,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/scenarios/ScenarioDuel.qml
         qml/scenarios/ScenarioMenu.qml
         qml/systems/SystemAbility.qml
+        qml/systems/SystemCollision.qml
         qml/systems/SystemCountermeasure.qml
         qml/systems/SystemDetection.qml
         qml/systems/SystemEngage.qml
@@ -110,6 +112,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/ui/ViewEngagements.qml
         qml/ui/ViewHints.qml
         qml/ui/ViewMenu.qml
+        qml/ui/ViewObstacles.qml
         qml/ui/ViewPause.qml
         qml/ui/ViewSettings.qml
         qml/ui/ViewSituation.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -333,8 +333,9 @@ Window {
         // conditions, judge the duel, then run the one set of shared systems
         // — threat marks first so minds and reflexes read fresh inbounds,
         // personalities pick their stances, behaviour by entity aspect,
-        // ability clocks, fuel, poses, weapons, countermeasures and the
-        // radar sweep, detection last so tracks see the tick's outcome.
+        // ability clocks, fuel, poses, arena collision on the fresh poses,
+        // weapons, countermeasures and the radar sweep, detection last so
+        // tracks see the tick's outcome.
         // Every system runs in every mode and processes exactly the entities
         // carrying its aspect; the scenarios only shape the world and never
         // load systems of their own.
@@ -377,6 +378,7 @@ Window {
 
             SystemThreat {
                 entities: root.entities
+                obstacles: root.world.obstacles
             }
 
             SystemPersonality {
@@ -389,6 +391,7 @@ Window {
 
             SystemEngage {
                 entities: root.entities
+                obstacles: root.world.obstacles
             }
 
             SystemAbility {
@@ -401,6 +404,10 @@ Window {
 
             SystemMovement {
                 entities: root.entities
+            }
+
+            SystemCollision {
+                world: root.world
             }
 
             SystemWeapon {
@@ -417,6 +424,7 @@ Window {
                 id: detection
                 observer: game.ownship
                 entities: root.entities
+                obstacles: root.world.obstacles
             }
         }
 
@@ -450,6 +458,7 @@ Window {
             tracks: detection.tracks
             entities: root.entities
             detonations: weapons.detonations
+            obstacles: root.world.obstacles
             symbolSize: height * 0.04
             trailsRunning: !settings.open && !root.inMenu && !root.paused && !root.ended
 
@@ -625,6 +634,7 @@ Window {
             projection: projection
             observer: game.ownship
             tracks: detection.tracks
+            obstacles: root.world.obstacles
 
             radiusFraction: 0.45
             symbolSize: height * 0.08
@@ -675,6 +685,7 @@ Window {
             tracks: detection.tracks
             entities: root.entities
             detonations: weapons.detonations
+            obstacles: root.world.obstacles
             radiusFraction: 0.64
             verticalShift: 0.18
             horizontalShift: 0.25
@@ -765,6 +776,8 @@ Window {
         root.dropInput();
         root.paused = false;
         demo.restart();
+        // The demo plays an open sky: the duel's arena leaves with the duel.
+        root.world.obstacles = [];
         projection.step = 1;
         root.inMenu = true;
     }
@@ -795,6 +808,7 @@ Window {
         root.world.add(game.ownship);
         for (let i = 0; i < scenario.entities.length; ++i)
             root.world.add(scenario.entities[i]);
+        root.world.obstacles = scenario.obstacles;
         projection.step = 2;
         root.inMenu = false;
         root.dropInput();

--- a/app/briarthorn/qml/model/Geo.qml
+++ b/app/briarthorn/qml/model/Geo.qml
@@ -60,6 +60,25 @@ QtObject {
         return root.wrap360(bearing - 90);
     }
 
+    // Whether the straight line between two entities is clear of every
+    // pillar — the one radar line-of-sight test the sensor, seeker and
+    // trigger gates all share. A pillar cuts the line when the segment's
+    // closest point to its centre falls inside its radius.
+    function lineOfSight(a: Entity, b: Entity, obstacles: list<Obstacle>): bool {
+        for (let i = 0; i < obstacles.length; ++i) {
+            const o = obstacles[i];
+            const dx = b.posX - a.posX;
+            const dy = b.posY - a.posY;
+            const len2 = dx * dx + dy * dy;
+            const t = len2 > 0 ? Math.max(0, Math.min(1, ((o.posX - a.posX) * dx + (o.posY - a.posY) * dy) / len2)) : 0;
+            const nx = a.posX + t * dx - o.posX;
+            const ny = a.posY + t * dy - o.posY;
+            if (nx * nx + ny * ny <= o.radius * o.radius)
+                return false;
+        }
+        return true;
+    }
+
     // The axis offsets of a step along a bearing.
     function offsetX(bearing: real, range: real): real {
         return Math.sin(bearing * Math.PI / 180) * range;

--- a/app/briarthorn/qml/model/Obstacle.qml
+++ b/app/briarthorn/qml/model/Obstacle.qml
@@ -1,0 +1,15 @@
+import QtQml
+
+// One piece of arena geometry: an impassable pillar, a disc in world metres.
+// Pure state — SystemCollision wrecks entities on it, the radar systems lose
+// line of sight behind it and the scope draws it as terrain.
+QtObject {
+    id: root
+
+    // Centre in world metres (1 px = 1 m, +x east, +y south).
+    property real posX: 0
+    property real posY: 0
+
+    // The disc's radius, metres.
+    property real radius: 1000
+}

--- a/app/briarthorn/qml/model/World.qml
+++ b/app/briarthorn/qml/model/World.qml
@@ -10,6 +10,11 @@ QtObject {
     // Every live entity, in no meaningful order.
     property list<Entity> entities
 
+    // The arena geometry every system tests against and every scope draws —
+    // assigned wholesale when a scenario carrying an arena takes the stage,
+    // cleared when one without leaves it. Terrain, so no spawn machinery.
+    property list<Obstacle> obstacles
+
     // Entities this world created and therefore destroys.
     property var spawned: new Set()
 

--- a/app/briarthorn/qml/scenarios/Scenario.qml
+++ b/app/briarthorn/qml/scenarios/Scenario.qml
@@ -13,4 +13,8 @@ SystemGroup {
 
     // The level-owned entities; the player's craft is referenced, not owned.
     property list<Entity> entities
+
+    // The level's arena geometry; empty is an open sky. The shell hands the
+    // active scenario's list to the world with the entities.
+    property list<Obstacle> obstacles
 }

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -26,7 +26,11 @@ Scenario {
         callsign: "BANDIT 1"
         classification: Classification.Kind.AircraftFighterLight
         side: Side.Kind.Hostile
-        posY: -65000
+        // Seated a shade east of true north: the closing line to the merge
+        // then passes the north pillar with kilometres to spare, where the
+        // axis itself would fly the pursuit straight into it.
+        posX: 10000
+        posY: -64000
         heading: 180
         personality: Names.personality.duelist
         engageTarget: root.ownship
@@ -51,6 +55,32 @@ Scenario {
     }
 
     entities: [root.bandit]
+
+    // The arena: four large pillars boxing the fight at 60 km on the
+    // cardinals, a picket of smaller ones every 45 degrees at 120 km, and
+    // four more on the intercardinals at 30 km — off the cardinal axes, so
+    // the opening lane from the north stays flyable. Static terrain, so
+    // reset() never touches it.
+    readonly property Component pillarFactory: Component {
+        Obstacle {}
+    }
+
+    obstacles: [...root.pillarRing(4, 0, 60000, 6000), ...root.pillarRing(8, 0, 120000, 3000), ...root.pillarRing(4, 45, 30000, 3000)]
+
+    // count pillars of one radius, evenly spaced around the origin at range,
+    // the first seated at startBearing.
+    function pillarRing(count: int, startBearing: real, range: real, radius: real): list<Obstacle> {
+        const ring = [];
+        for (let i = 0; i < count; ++i) {
+            const bearing = startBearing + i * 360 / count;
+            ring.push(root.pillarFactory.createObject(root, {
+                posX: Geo.offsetX(bearing, range),
+                posY: Geo.offsetY(bearing, range),
+                radius: radius
+            }));
+        }
+        return ring;
+    }
 
     // Replaces the bandit with a factory-fresh one — QML's constructor — so a
     // duel entered from the menu always opens the same fight, with nothing to

--- a/app/briarthorn/qml/systems/SystemCollision.qml
+++ b/app/briarthorn/qml/systems/SystemCollision.qml
@@ -1,0 +1,24 @@
+import awen.entity
+import "../model"
+
+// Arena collision: any entity flying inside a pillar's wall is wrecked on
+// it — health zeroed, so SystemWeapon's reap despawns it and the mission
+// judge reads the impact exactly like a kill. Runs after SystemMovement so
+// it tests the tick's fresh poses.
+System {
+    id: root
+
+    // The world whose roster is tested against its arena geometry.
+    required property World world
+
+    function update(dt: real) {
+        for (let i = 0; i < root.world.obstacles.length; ++i) {
+            const pillar = root.world.obstacles[i];
+            for (let j = 0; j < root.world.entities.length; ++j) {
+                const entity = root.world.entities[j];
+                if (entity.health > 0 && Geo.distanceFrom(entity.posX, entity.posY, pillar.posX, pillar.posY) <= pillar.radius)
+                    entity.health = 0;
+            }
+        }
+    }
+}

--- a/app/briarthorn/qml/systems/SystemDetection.qml
+++ b/app/briarthorn/qml/systems/SystemDetection.qml
@@ -21,6 +21,9 @@ System {
     required property Entity observer
     property list<Entity> entities
 
+    // The arena geometry radar cannot see through.
+    property list<Obstacle> obstacles
+
     // The track picture, one Track per contact.
     property list<Track> tracks
 
@@ -49,7 +52,7 @@ System {
             }
             track.range = Geo.distance(root.observer, entity);
             track.azimuth = Geo.wrap360(Geo.bearing(root.observer, entity));
-            const seen = entity.owner === root.observer || root.detected(track);
+            const seen = entity.owner === root.observer || root.detected(track, entity);
             track.classification = seen ? entity.classification : Classification.Kind.Unknown;
             track.side = seen ? entity.side : Side.Kind.Unknown;
             // Condition rides with the resolution: lose the contact and the
@@ -72,10 +75,11 @@ System {
             root.tracks = Object.values(root.held);
     }
 
-    // Whether a measurement falls inside the observer's radar volume: within
-    // half the FOV cone off the nose and inside sensor range.
-    function detected(track: Track): bool {
+    // Whether a measurement falls inside the observer's radar volume — within
+    // half the FOV cone off the nose and inside sensor range — with the line
+    // to the contact clear of the arena's pillars.
+    function detected(track: Track, entity: Entity): bool {
         const off = Geo.wrap180(track.azimuth - root.observer.heading);
-        return Math.abs(off) <= root.observer.radarFov / 2 && track.range <= root.observer.detectionRange;
+        return Math.abs(off) <= root.observer.radarFov / 2 && track.range <= root.observer.detectionRange && Geo.lineOfSight(root.observer, entity, root.obstacles);
     }
 }

--- a/app/briarthorn/qml/systems/SystemEngage.qml
+++ b/app/briarthorn/qml/systems/SystemEngage.qml
@@ -13,6 +13,9 @@ System {
     // The world's roster; entities without the aspect are passed over.
     property list<Entity> entities
 
+    // The arena geometry radar cannot see through.
+    property list<Obstacle> obstacles
+
     // The launch ability invoked, by registry name, and the round it spawns;
     // the cast is null for a name that is not a launch at all.
     property string ability: "guided"
@@ -35,6 +38,10 @@ System {
                 continue;
             const off = Geo.wrap180(Geo.bearing(entity, entity.engageTarget) - entity.heading);
             if (Math.abs(off) > entity.radarFov / 2)
+                continue;
+            // A pillar between shooter and target breaks the radar picture
+            // the shot needs, so ducking behind one denies the launch.
+            if (!Geo.lineOfSight(entity, entity.engageTarget, root.obstacles))
                 continue;
             root.fire(entity);
         }

--- a/app/briarthorn/qml/systems/SystemThreat.qml
+++ b/app/briarthorn/qml/systems/SystemThreat.qml
@@ -19,6 +19,9 @@ System {
     // for the rounds homing on them.
     property list<Entity> entities
 
+    // The arena geometry radar cannot see through.
+    property list<Obstacle> obstacles
+
     // Metres at which an inbound homing round triggers a pop.
     property real threatRange: 9000
 
@@ -69,11 +72,12 @@ System {
         }
     }
 
-    // Holds the round against the target's mark if the target detects it and
-    // no nearer round is already held.
+    // Holds the round against the target's mark if the target detects it —
+    // inside its detection range with a clear line to it — and no nearer
+    // round is already held.
     function consider(nearest: var, target: Entity, missile: Entity) {
         const range = Geo.distance(missile, target);
-        if (range > target.detectionRange)
+        if (range > target.detectionRange || !Geo.lineOfSight(target, missile, root.obstacles))
             return;
         const held = nearest.get(target);
         if (held === undefined || range < Geo.distance(target, held))

--- a/app/briarthorn/qml/systems/SystemWeapon.qml
+++ b/app/briarthorn/qml/systems/SystemWeapon.qml
@@ -201,6 +201,10 @@ System {
             const d = Geo.distance(at, contact);
             if (d > range || !root.illuminated(illuminator, contact))
                 continue;
+            // The seeker is a radar receiver too: a return behind a pillar
+            // reaches neither it nor the illuminator.
+            if (!Geo.lineOfSight(at, contact, root.world.obstacles))
+                continue;
             if (best === null || contact.stealth < best.stealth || (contact.stealth === best.stealth && d < bestDist)) {
                 best = contact;
                 bestDist = d;
@@ -229,13 +233,14 @@ System {
         return best;
     }
 
-    // Whether the illuminator's radar cone paints the contact; a missing
-    // illuminator is lenient, per briardart.
+    // Whether the illuminator's radar cone paints the contact — inside the
+    // cone with a clear line past the arena's pillars; a missing illuminator
+    // is lenient, per briardart.
     function illuminated(illuminator: Entity, contact: Entity): bool {
         if (illuminator === null)
             return true;
         const off = Geo.wrap180(Geo.bearing(illuminator, contact) - illuminator.heading);
-        return Math.abs(off) <= illuminator.radarFov / 2;
+        return Math.abs(off) <= illuminator.radarFov / 2 && Geo.lineOfSight(illuminator, contact, root.world.obstacles);
     }
 
     // Whether two sides shoot at each other: ownship and friendly versus

--- a/app/briarthorn/qml/themes/Aurora.qml
+++ b/app/briarthorn/qml/themes/Aurora.qml
@@ -28,6 +28,11 @@ QtObject {
     property color factionNeutral: "#FFFFD23F"
     property color factionHostile: "#FFFF3B6B"
     property color rangeRing: "#FF11566A"
+    // Arena terrain: a burnt-orange rim over a dark leather fill — earthy
+    // against the cyan instrument lines, and dimmer than warn so a pillar
+    // never reads as an alert.
+    property color terrain: "#FFB86A38"
+    property color terrainFill: "#FF2E1B0D"
     property color cursorFree: "#FFFFC23D"
     property color cursorLatched: "#FF6CFBFF"
     property color detonation: "#FFFF6FA8"

--- a/app/briarthorn/qml/ui/ViewObstacles.qml
+++ b/app/briarthorn/qml/ui/ViewObstacles.qml
@@ -1,0 +1,64 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import "../model"
+import "../themes"
+
+// The arena geometry: every pillar as a disc at true world scale about the
+// observer, terrain-brown under the air picture. Ground truth rather than a
+// sensor product — the arena is mapped, so it draws resolved at any range.
+Item {
+    id: root
+
+    // The observer at the scope centre.
+    property Entity observer
+
+    // The pillars to draw.
+    property list<Obstacle> obstacles
+
+    // Scope centre in item coordinates and the world-to-screen scale.
+    property real centerX: width / 2
+    property real centerY: height / 2
+    property real pxPerMeter: 0
+
+    // Screen rotation of the picture about the scope centre.
+    property real viewRotation: 0
+
+    // Rim stroke width, matching the scope's line weight.
+    property real strokeWidth: 2
+
+    // When positive, a pillar draws only while it fits wholly inside this
+    // pixel radius — the minimap's backing disc, so terrain never spills
+    // past that mask onto the scope beneath.
+    property real cullRadius: 0
+
+    transform: Rotation {
+        origin.x: root.centerX
+        origin.y: root.centerY
+        angle: root.viewRotation
+    }
+
+    Repeater {
+        model: root.obstacles
+
+        Rectangle {
+            id: pillar
+
+            required property Obstacle modelData
+
+            readonly property real edge: pillar.modelData.radius * root.pxPerMeter
+            readonly property real screenX: root.observer ? root.centerX + (pillar.modelData.posX - root.observer.posX) * root.pxPerMeter : 0
+            readonly property real screenY: root.observer ? root.centerY + (pillar.modelData.posY - root.observer.posY) * root.pxPerMeter : 0
+
+            visible: root.cullRadius <= 0 || Math.hypot(pillar.screenX - root.centerX, pillar.screenY - root.centerY) + pillar.edge <= root.cullRadius
+            x: pillar.screenX - pillar.edge
+            y: pillar.screenY - pillar.edge
+            width: pillar.edge * 2
+            height: width
+            radius: width / 2
+            color: Style.theme.terrainFill
+            border.color: Style.theme.terrain
+            border.width: root.strokeWidth
+        }
+    }
+}

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -31,6 +31,9 @@ Item {
     property list<Entity> entities
     property list<Detonation> detonations
 
+    // The arena's pillars, drawn as terrain under the air picture.
+    property list<Obstacle> obstacles
+
     // Geometry. The outer ring's radius is a fraction of the short side; the
     // centre drops by verticalShift (and slides by horizontalShift) so the
     // attack scope can push ownship down and crop the rear off the bottom edge.
@@ -155,6 +158,21 @@ Item {
         angleSpan: root.observer ? root.observer.radarFov : 0
         radius: root.observer ? Math.min(root.observer.detectionRange * root.pxPerMeter, root.outerRadius) : 0
         fillColor: Style.theme.gaugeTrack
+    }
+
+    // The arena terrain, over the rings and cone but under everything that
+    // flies. Culled to the backing disc where one masks the picture, so a
+    // pillar never spills past the minimap onto the scope beneath.
+    ViewObstacles {
+        anchors.fill: parent
+        observer: root.observer
+        obstacles: root.obstacles
+        centerX: root.centerX
+        centerY: root.centerY
+        pxPerMeter: root.pxPerMeter
+        viewRotation: root.viewRotation
+        strokeWidth: root.ringStrokeWidth
+        cullRadius: root.backgroundColor.a > 0 ? root.discRadius : 0
     }
 
     // The motion wakes, under the marks they trail: each object's recent


### PR DESCRIPTION
## What

Boxes the 1v1 duel in an arena of 16 pillars — four large (6 km radius) at 60 km on the cardinals, a picket of eight small (3 km) every 45° at 120 km, and four small on the intercardinals at 30 km. Pillars block radar line of sight and destroy anything that flies into them, and draw as burnt-orange terrain on both scopes.

## How

- **`Obstacle`** (`model/`) is a plain disc in world metres, deliberately *not* an `Entity`: entities are point-shaped in every range test (blast, fuze, seeker), and fixed terrain must not enter the track picture as Unknown contacts. No database row either — arena geometry is scenario-authored in metres, like spawn positions, so the stats-are-ratings rule is untouched. `World.obstacles` carries the active arena; the shell assigns `scenario.obstacles` on `startDuel()` and clears it on `startMenu()`, so the menu demo keeps its open sky.
- **One LOS test, four radar gates.** `Geo.lineOfSight` (segment–circle) now gates `SystemDetection` (a contact behind a pillar drops to Unknown), `SystemThreat` (a hidden round triggers no warning or flare), `SystemEngage` (ducking behind a pillar denies the AI's launch) and `SystemWeapon` (both the seeker's own line and the illuminator's), so terrain breaks locks mid-flight.
- **`SystemCollision`** runs between `SystemMovement` and `SystemWeapon` and only zeroes health inside a pillar wall; the existing reap despawns the wreck and the mission judge reads a player impact as a loss. Missiles carry hull, so they smash on walls with no special casing.
- **`ViewObstacles`** draws ground truth at true scale under the air picture; on the minimap it culls to the backing disc so terrain never spills past the round mask. Two new Aurora roles (`terrain`/`terrainFill`) keep the brown-orange dimmer than `warn` so a pillar never reads as an alert.
- **The bandit spawns a shade east of true north** (was dead on the axis): its old closing line ran straight through the north pillar's centre — a guaranteed opening suicide. The offset keeps the pursuit ~3 km clear of the enlarged wall.

## Reviewer notes

- Personalities have no terrain avoidance yet; only the spawn offset protects the opening. A headless 180 s hands-off run of the real scenario confirms the bandit survives, closes and launches (plus LOS geometry, occlusion-to-Unknown, and kill-at-the-wall checks — 14/14).
- qmllint clean, full debug build green, all 111 ctest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)