### PR TITLE
Shadow-cast the radar volume behind the arena's pillars

### DIFF
--- a/app/briarthorn/qml/ui/ViewObstacles.qml
+++ b/app/briarthorn/qml/ui/ViewObstacles.qml
@@ -32,6 +32,17 @@ Item {
     // past that mask onto the scope beneath.
     property real cullRadius: 0
 
+    // Whether this layer draws a given pillar. The shadow caster asks the
+    // same question before occluding with one, so a bite never lands on a
+    // scope where no disc was drawn.
+    function draws(posX: real, posY: real, radius: real): bool {
+        if (cullRadius <= 0)
+            return true;
+        if (!observer)
+            return false;
+        return Math.hypot(posX - observer.posX, posY - observer.posY) * pxPerMeter + radius * pxPerMeter <= cullRadius;
+    }
+
     transform: Rotation {
         origin.x: root.centerX
         origin.y: root.centerY
@@ -50,7 +61,7 @@ Item {
             readonly property real screenX: root.observer ? root.centerX + (pillar.modelData.posX - root.observer.posX) * root.pxPerMeter : 0
             readonly property real screenY: root.observer ? root.centerY + (pillar.modelData.posY - root.observer.posY) * root.pxPerMeter : 0
 
-            visible: root.cullRadius <= 0 || Math.hypot(pillar.screenX - root.centerX, pillar.screenY - root.centerY) + pillar.edge <= root.cullRadius
+            visible: root.draws(pillar.modelData.posX, pillar.modelData.posY, pillar.modelData.radius)
             x: pillar.screenX - pillar.edge
             y: pillar.screenY - pillar.edge
             width: pillar.edge * 2

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -34,6 +34,24 @@ Item {
     // The arena's pillars, drawn as terrain under the air picture.
     property list<Obstacle> obstacles
 
+    // The same pillars as plain disc rows for awen.shapes' shadow cast, held
+    // to the ones the terrain layer draws so a bite always has its disc under
+    // it. Unmasked, that is every pillar and the rows rebuild only when a
+    // scenario swaps its arena; a masked scope re-culls as ownship moves.
+    readonly property var occluderRows: {
+        const rows = [];
+        for (let i = 0; i < obstacles.length; ++i) {
+            const pillar = obstacles[i];
+            if (terrain.draws(pillar.posX, pillar.posY, pillar.radius))
+                rows.push({
+                    x: pillar.posX,
+                    y: pillar.posY,
+                    r: pillar.radius
+                });
+        }
+        return rows;
+    }
+
     // Geometry. The outer ring's radius is a fraction of the short side; the
     // centre drops by verticalShift (and slides by horizontalShift) so the
     // attack scope can push ownship down and crop the rear off the bottom edge.
@@ -147,7 +165,8 @@ Item {
         enableTicks: false
     }
 
-    // Ownship's radar volume: a wedge off the nose (straight up, heading-up),
+    // Ownship's commanded radar volume, faint: where the antenna points even
+    // where terrain masks it. A wedge off the nose (straight up, heading-up),
     // reaching the sensor's detection range, capped at the outer ring.
     ShapeSector {
         anchors.fill: parent
@@ -157,13 +176,39 @@ Item {
         angleAt: root.headingUp ? 0 : (root.observer ? root.observer.heading : 0)
         angleSpan: root.observer ? root.observer.radarFov : 0
         radius: root.observer ? Math.min(root.observer.detectionRange * root.pxPerMeter, root.outerRadius) : 0
+        fillColor: Qt.alpha(Style.theme.gaugeTrack, 0.035)
+    }
+
+    // What the radar actually sees: the same wedge shadow-cast behind the
+    // pillars, computed in world bearings and turned by the rotation
+    // ViewObstacles carries, so every bite lands exactly on its drawn disc.
+    ShapeSectorOccluded {
+        anchors.fill: parent
+        visible: root.showRadarCone && root.observer
+        centerX: root.centerX
+        centerY: root.centerY
+        angleAt: root.observer ? root.observer.heading : 0
+        angleSpan: root.observer ? root.observer.radarFov : 0
+        radius: root.observer ? Math.min(root.observer.detectionRange * root.pxPerMeter, root.outerRadius) : 0
+        sourceX: root.observer ? root.observer.posX : 0
+        sourceY: root.observer ? root.observer.posY : 0
+        positionScale: root.pxPerMeter
+        occluders: root.occluderRows
         fillColor: Style.theme.gaugeTrack
+
+        transform: Rotation {
+            origin.x: root.centerX
+            origin.y: root.centerY
+            angle: root.viewRotation
+        }
     }
 
     // The arena terrain, over the rings and cone but under everything that
     // flies. Culled to the backing disc where one masks the picture, so a
     // pillar never spills past the minimap onto the scope beneath.
     ViewObstacles {
+        id: terrain
+
         anchors.fill: parent
         observer: root.observer
         obstacles: root.obstacles

--- a/src/awen/shapes/CMakeLists.txt
+++ b/src/awen/shapes/CMakeLists.txt
@@ -17,6 +17,7 @@ awen_add_qml_module(awen-shapes
         ShapeReticle.qml
         ShapeRing.qml
         ShapeSector.qml
+        ShapeSectorOccluded.qml
         ShapeSparkline.qml
         ShapeTicks.qml
         ShapeTrail.qml

--- a/src/awen/shapes/ShapeSectorOccluded.qml
+++ b/src/awen/shapes/ShapeSectorOccluded.qml
@@ -1,0 +1,161 @@
+import QtQuick
+import QtQuick.Shapes
+import "bearing.js" as Bearing
+
+// ShapeSector's shadow-cast twin: the same boresight-first wedge, but along
+// each bearing the fill stops at the first occluding disc, so the drawn volume
+// is what a sensor at the apex can actually see. Occluders are plain {x, y, r}
+// rows in source units about a moving apex (ShapeTrail's positionScale
+// convention), keeping the module free of app model types.
+Shape {
+    id: root
+
+    // Wedge reach in px; defaults to the largest circle that keeps the stroke
+    // inside the item's bounds.
+    property real radius: Math.min(width, height) / 2 - strokeWidth / 2
+
+    // Bearing of the wedge's centre, degrees clockwise from up, and its total
+    // angular width; a span of 360 draws an all-round occluded sweep.
+    property real angleAt: 0
+    property real angleSpan: 60
+
+    // The wedge's apex in item coordinates; defaults to the item's middle.
+    property real centerX: width / 2
+    property real centerY: height / 2
+
+    // The apex's position in source units and the source-to-px scale, so a
+    // static occluder set is assigned once, never rebuilt as the apex moves.
+    property real sourceX: 0
+    property real sourceY: 0
+    property real positionScale: 1
+
+    // The occluding discs: {x, y, r} rows in source units.
+    property var occluders: []
+
+    // Uniform ray pitch, degrees. Tangent and centre bearings are inserted
+    // exactly per disc, so this paces only the smooth arc stretches.
+    property real stepDeg: 3
+
+    property color fillColor: "white"
+
+    property alias strokeColor: path.strokeColor
+    property alias strokeWidth: path.strokeWidth
+
+    // The visible region's outline in item px: the apex, then one vertex per
+    // swept bearing at min(radius, nearest disc bite), closed back on the
+    // apex — or rim-to-rim with no apex for a full-circle span. A disc
+    // holding the apex empties the outline: such a sensor sees nothing.
+    readonly property list<point> polyline: {
+        // A hidden wedge sweeps nothing: bindings evaluate whether or not the
+        // item draws, and an app parking a second scope offscreen would
+        // otherwise pay for its march every tick.
+        if (!visible)
+            return [];
+
+        const span = Math.min(angleSpan, 360);
+        const full = span >= 360;
+        const reach = positionScale > 0 ? radius / positionScale : 0;
+        if (reach <= 0 || span <= 0)
+            return [];
+
+        // The uniform rays, as offsets from the wedge's start edge; both
+        // edges are always sampled exactly, so a straddling disc shortens
+        // the edge ray it crosses.
+        const step = Math.max(0.1, stepDeg);
+        const rays = [];
+        if (full) {
+            const n = Math.max(8, Math.ceil(360 / step));
+            for (let i = 0; i < n; ++i)
+                rays.push(i * 360 / n);
+        } else {
+            const n = Math.max(2, Math.ceil(span / step) + 1);
+            for (let i = 0; i < n; ++i)
+                rays.push(i * span / (n - 1));
+        }
+
+        const start = angleAt - span / 2;
+        const insert = b => {
+            const rel = Bearing.wrapDeg(b - start);
+            if (rel <= span)
+                rays.push(rel);
+        };
+
+        // Cull to discs that can bite: near rim inside reach and silhouette
+        // crossing the wedge. Survivors insert their critical bearings — the
+        // doubled tangent pair keeps the shadow's radial edge crisp, and the
+        // centre bearing pins the bite's bottom at exactly d - r.
+        const ox = [];
+        const oy = [];
+        const cr = [];
+        const c2 = [];
+        const occ = occluders || [];
+        for (let i = 0; i < occ.length; ++i) {
+            const dx = occ[i].x - sourceX;
+            const dy = occ[i].y - sourceY;
+            const r = occ[i].r;
+            const dd = dx * dx + dy * dy;
+            const d = Math.sqrt(dd);
+            if (d <= r)
+                return [];
+            if (d - r > reach)
+                continue;
+            const beta = Math.atan2(dx, -dy) * 180 / Math.PI;
+            const alpha = Math.asin(Math.min(1, r / d)) * 180 / Math.PI;
+            if (!full && Bearing.distanceDeg(beta, angleAt) > span / 2 + alpha)
+                continue;
+            ox.push(dx);
+            oy.push(dy);
+            cr.push(r);
+            c2.push(dd);
+            insert(beta - alpha - 0.05);
+            insert(beta - alpha);
+            insert(beta);
+            insert(beta + alpha);
+            insert(beta + alpha + 0.05);
+        }
+        rays.sort((a, b) => a - b);
+
+        // Per ray, the polar twin of the closest-point blocking rule: the
+        // near ray-disc intersection s - sqrt(r^2 - h^2), with rounding at
+        // exact tangency clamped so the rim never flickers past the disc.
+        const toRad = Math.PI / 180;
+        const out = [];
+        if (!full)
+            out.push(Qt.point(centerX, centerY));
+        for (let i = 0; i < rays.length; ++i) {
+            const a = (start + rays[i]) * toRad;
+            const ux = Math.sin(a);
+            const uy = -Math.cos(a);
+            let best = reach;
+            for (let k = 0; k < ox.length; ++k) {
+                const s = ox[k] * ux + oy[k] * uy;
+                if (s <= 0)
+                    continue;
+                let q = cr[k] * cr[k] - (c2[k] - s * s);
+                if (q < 0) {
+                    if (q < -1e-7 * cr[k] * cr[k])
+                        continue;
+                    q = 0;
+                }
+                const hit = s - Math.sqrt(q);
+                if (hit < best)
+                    best = hit;
+            }
+            out.push(Qt.point(centerX + ux * best * positionScale, centerY + uy * best * positionScale));
+        }
+        out.push(full ? out[0] : Qt.point(centerX, centerY));
+        return out;
+    }
+
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        id: path
+        fillColor: root.fillColor
+        strokeColor: "transparent"
+
+        PathPolyline {
+            path: root.polyline
+        }
+    }
+}

--- a/src/awen/shapes/test/CMakeLists.txt
+++ b/src/awen/shapes/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(awen-shapes-test
     ShapeLink.test.cpp
     ShapePolygon.test.cpp
     ShapeRing.test.cpp
+    ShapeSectorOccluded.test.cpp
     ShapeSparkline.test.cpp
     ShapeTicks.test.cpp
     ShapeTrail.test.cpp

--- a/src/awen/shapes/test/ShapeSectorOccluded.test.cpp
+++ b/src/awen/shapes/test/ShapeSectorOccluded.test.cpp
@@ -1,0 +1,357 @@
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <vector>
+
+#include <QList>
+#include <QPointF>
+#include <QQmlEngine>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+#include "Harness.h"
+
+namespace
+{
+    constexpr auto Pi = std::numbers::pi;
+
+    /// @brief One occluding disc, in source units about the apex.
+    struct Disc
+    {
+        double x{0};
+        double y{0};
+        double r{0};
+    };
+
+    /// @brief The blocking rule under test, restated independently: whether a
+    /// segment of the given length along bearing (ux, uy) from the origin
+    /// passes within r of any disc centre — Geo.lineOfSight's closest-point
+    /// test with the observer at the origin.
+    auto blocked(double ux, double uy, double length, const std::vector<Disc>& discs) -> bool
+    {
+        for (const auto& disc : discs)
+        {
+            const auto bx = ux * length;
+            const auto by = uy * length;
+            const auto len2 = bx * bx + by * by;
+            const auto t = len2 > 0 ? std::clamp((disc.x * bx + disc.y * by) / len2, 0.0, 1.0) : 0.0;
+            const auto nx = t * bx - disc.x;
+            const auto ny = t * by - disc.y;
+            if (nx * nx + ny * ny <= disc.r * disc.r)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Shortest angular distance between two bearings, degrees.
+    auto angularDistance(double a, double b) -> double
+    {
+        return std::abs(std::fmod(a - b + 540.0, 360.0) - 180.0);
+    }
+
+    /// @brief Radius of a polyline vertex about the (200, 200) apex, in px.
+    auto radiusOf(const QPointF& p) -> double
+    {
+        return std::hypot(p.x() - 200, p.y() - 200);
+    }
+
+    /// @brief Bearing of a polyline vertex about the apex, degrees clockwise
+    /// from up, in (-180, 180].
+    auto bearingOf(const QPointF& p) -> double
+    {
+        return std::atan2(p.x() - 200, -(p.y() - 200)) * 180 / Pi;
+    }
+
+    /// @brief The vertex angularly nearest a bearing, skipping the first and
+    /// last points (the apex, or the closing duplicate on a full circle).
+    auto vertexAt(const QList<QPointF>& polyline, double bearing) -> QPointF
+    {
+        auto best = polyline[1];
+        auto bestOff = 360.0;
+        for (auto i = 1; i < polyline.size() - 1; ++i)
+        {
+            const auto off = angularDistance(bearingOf(polyline[i]), bearing);
+            if (off < bestOff)
+            {
+                bestOff = off;
+                best = polyline[i];
+            }
+        }
+        return best;
+    }
+
+    // A 90-degree north wedge reaching 100 px at scale 1, apex at (200, 200).
+    constexpr auto Wedge = R"(
+import QtQuick
+import awen.shapes
+ShapeSectorOccluded {
+    width: 400
+    height: 400
+    angleAt: 0
+    angleSpan: 90
+    radius: 100
+    positionScale: 1
+    occluders: %1
+}
+)";
+
+    /// @brief Loads the wedge harness over the given occluders line.
+    auto loadWedge(QQmlEngine& engine, const char* occluders) -> std::unique_ptr<QObject>
+    {
+        return load(engine, QString{Wedge}.arg(occluders).toUtf8().constData());
+    }
+}
+
+TEST(ShapeSectorOccluded, ClearWedgeSweepsTheFullSector)
+{
+    auto engine = QQmlEngine{};
+    const auto item = loadWedge(engine, "[]");
+    ASSERT_NE(item, nullptr);
+
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_GE(polyline.size(), 3);
+    EXPECT_EQ(polyline.first(), QPointF(200, 200));
+    EXPECT_EQ(polyline.first(), polyline.last());
+    for (auto i = 1; i < polyline.size() - 1; ++i)
+    {
+        EXPECT_NEAR(radiusOf(polyline[i]), 100, 1e-6);
+    }
+    EXPECT_NEAR(bearingOf(polyline[1]), -45, 1e-6);
+    EXPECT_NEAR(bearingOf(polyline[polyline.size() - 2]), 45, 1e-6);
+    // The rim is swept, not chorded across: two edge rays alone would satisfy
+    // every assertion above while cutting half the wedge's area.
+    for (auto i = 2; i < polyline.size() - 1; ++i)
+    {
+        EXPECT_LE(bearingOf(polyline[i]) - bearingOf(polyline[i - 1]), 3 + 1e-6);
+    }
+}
+
+TEST(ShapeSectorOccluded, RayPitchFollowsStepDeg)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeSectorOccluded {
+    width: 400
+    height: 400
+    angleAt: 0
+    angleSpan: 90
+    radius: 100
+    positionScale: 1
+    stepDeg: 10
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // A clear 90-degree wedge at a 10-degree pitch: both edges plus the eight
+    // steps between them, and no gap wider than the pitch asked for.
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_EQ(polyline.size(), 12);
+    for (auto i = 2; i < polyline.size() - 1; ++i)
+    {
+        EXPECT_NEAR(bearingOf(polyline[i]) - bearingOf(polyline[i - 1]), 10, 1e-6);
+    }
+}
+
+TEST(ShapeSectorOccluded, PillarBitesToItsNearFaceAndTangents)
+{
+    auto engine = QQmlEngine{};
+    // Dead ahead at 50 with radius 10: tangents at asin(10/50) = 11.537
+    // degrees, tangent length sqrt(2400), near face at 40.
+    const auto item = loadWedge(engine, "[{ x: 0, y: -50, r: 10 }]");
+    ASSERT_NE(item, nullptr);
+
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_GE(polyline.size(), 3);
+    const auto alpha = std::asin(0.2) * 180 / Pi;
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, 0)), 40, 1e-6);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, -alpha)), std::sqrt(2400.0), 1e-3);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, alpha)), std::sqrt(2400.0), 1e-3);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, -30)), 100, 1e-6);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, 30)), 100, 1e-6);
+}
+
+TEST(ShapeSectorOccluded, TangentPadHoldsTheShadowEdgeRadial)
+{
+    auto engine = QQmlEngine{};
+    const auto item = loadWedge(engine, "[{ x: 0, y: -50, r: 10 }]");
+    ASSERT_NE(item, nullptr);
+
+    // Each shadow edge is a pair of rays a twentieth of a degree apart: the
+    // tangent itself at the tangent length, and one just outside it back at
+    // full reach. Without the outer ray the edge slants to the next uniform
+    // ray up to stepDeg away and the shadow detaches from its pillar.
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    const auto alpha = std::asin(0.2) * 180 / Pi;
+    for (const auto side : {-1.0, 1.0})
+    {
+        const auto tangent = vertexAt(polyline, side * alpha);
+        const auto pad = vertexAt(polyline, side * (alpha + 0.05));
+        EXPECT_NEAR(radiusOf(tangent), std::sqrt(2400.0), 1e-3);
+        EXPECT_NEAR(radiusOf(pad), 100, 1e-6);
+        EXPECT_NEAR(angularDistance(bearingOf(tangent), bearingOf(pad)), 0.05, 1e-6);
+    }
+}
+
+TEST(ShapeSectorOccluded, OccludersMapThroughTheApexAndScale)
+{
+    auto engine = QQmlEngine{};
+    // Apex off the origin at half scale, so neither the source-unit offset
+    // nor the px conversion can cancel: reach is 100 px / 0.5 = 200 units.
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeSectorOccluded {
+    width: 400
+    height: 400
+    angleAt: 0
+    angleSpan: 90
+    radius: 100
+    positionScale: 0.5
+    sourceX: 100
+    sourceY: 100
+    occluders: [{ x: 100, y: 50, r: 10 }, { x: 120, y: 60, r: 5 }]
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // Relative to the apex the first pillar is 50 units dead ahead (near face
+    // 40) and the second 20 east by 40 north (near face hypot(20,40) - 5);
+    // radii come back in px, so each halves.
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_GE(polyline.size(), 3);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, 0)), 20, 1e-6);
+    const auto beta = std::atan2(20.0, 40.0) * 180 / Pi;
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, beta)), (std::hypot(20.0, 40.0) - 5) * 0.5, 1e-6);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, -40)), 100, 1e-6);
+}
+
+TEST(ShapeSectorOccluded, WedgeWrappingPastNorthStillInsertsExactRays)
+{
+    auto engine = QQmlEngine{};
+    // Boresight 340 with a 90-degree span opens at 295 and closes at 25, so a
+    // pillar at bearing 11 sits inside only once its critical bearings wrap.
+    // 11 is off the uniform grid, so a dropped centre ray shows in the radius.
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeSectorOccluded {
+    width: 400
+    height: 400
+    angleAt: 340
+    angleSpan: 90
+    radius: 100
+    positionScale: 1
+    occluders: [{ x: 9.540449, y: -49.081357, r: 10 }]
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_GE(polyline.size(), 3);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, 11)), 40, 1e-5);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, -50)), 100, 1e-6);
+}
+
+TEST(ShapeSectorOccluded, RimAgreesWithTheLineOfSightRule)
+{
+    auto engine = QQmlEngine{};
+    // A mixed picture: overlapping shadows about the boresight, a wedge-edge
+    // straddler, a disc whose centre sits past reach, and one behind.
+    const auto discs = std::vector<Disc>{
+        {0, -50, 10}, {-8, -80, 20}, {45, -45, 15}, {30, -101, 8}, {0, 60, 20},
+    };
+    const auto item = loadWedge(engine,
+                                "[{ x: 0, y: -50, r: 10 }, { x: -8, y: -80, r: 20 }, "
+                                "{ x: 45, y: -45, r: 15 }, { x: 30, y: -101, r: 8 }, { x: 0, y: 60, r: 20 }]");
+    ASSERT_NE(item, nullptr);
+
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_GE(polyline.size(), 3);
+    for (auto i = 1; i < polyline.size() - 1; ++i)
+    {
+        const auto rim = radiusOf(polyline[i]);
+        const auto bearing = bearingOf(polyline[i]);
+        const auto ux = std::sin(bearing * Pi / 180);
+        const auto uy = -std::cos(bearing * Pi / 180);
+        // Tangent rays sit on the rule's boundary, where rounding can land
+        // either side; the margins below only hold away from that cliff.
+        auto tangent = false;
+        for (const auto& disc : discs)
+        {
+            const auto d = std::hypot(disc.x, disc.y);
+            const auto beta = std::atan2(disc.x, -disc.y) * 180 / Pi;
+            const auto alpha = std::asin(std::min(1.0, disc.r / d)) * 180 / Pi;
+            tangent = tangent || std::abs(angularDistance(bearing, beta) - alpha) < 0.06;
+        }
+        if (tangent)
+        {
+            continue;
+        }
+        // Shy of the rim the line is clear; past a shadowed rim it is not.
+        EXPECT_FALSE(blocked(ux, uy, rim * 0.98, discs)) << "bearing " << bearing;
+        if (rim < 99)
+        {
+            EXPECT_TRUE(blocked(ux, uy, rim * 1.05, discs)) << "bearing " << bearing;
+        }
+    }
+}
+
+TEST(ShapeSectorOccluded, ApexInsideAPillarSeesNothing)
+{
+    auto engine = QQmlEngine{};
+    const auto item = loadWedge(engine, "[{ x: 3, y: -3, r: 8 }]");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_TRUE(item->property("polyline").value<QList<QPointF>>().isEmpty());
+}
+
+TEST(ShapeSectorOccluded, FullCircleClosesRimToRim)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeSectorOccluded {
+    width: 400
+    height: 400
+    angleSpan: 360
+    radius: 100
+    positionScale: 1
+    occluders: [{ x: 0, y: 50, r: 10 }]
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    // No apex vertex on an all-round sweep: the loop closes rim to rim, and
+    // the southern pillar still bites to its near face.
+    const auto polyline = item->property("polyline").value<QList<QPointF>>();
+    ASSERT_GE(polyline.size(), 3);
+    EXPECT_EQ(polyline.first(), polyline.last());
+    EXPECT_GT(radiusOf(polyline.first()), 1);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, 180)), 40, 1e-6);
+    EXPECT_NEAR(radiusOf(vertexAt(polyline, 0)), 100, 1e-6);
+}
+
+TEST(ShapeSectorOccluded, EmptyWithoutReach)
+{
+    auto engine = QQmlEngine{};
+    const auto item = load(engine, R"(
+import QtQuick
+import awen.shapes
+ShapeSectorOccluded {
+    width: 400
+    height: 400
+    angleSpan: 90
+    radius: 100
+    positionScale: 0
+}
+)");
+    ASSERT_NE(item, nullptr);
+
+    EXPECT_TRUE(item->property("polyline").value<QList<QPointF>>().isEmpty());
+}


### PR DESCRIPTION
The radar already refused to detect anything behind the duel arena's pillars, but the cone was still drawn straight through them. It now carves shadows the way a point light would, so the drawn volume matches what the sensor can actually see.

## How

A new `awen.shapes` primitive, `ShapeSectorOccluded`, sweeps rays across the wedge and stops each one at the first occluding disc — `min(reach, s - sqrt(r² - h²))`, the polar restatement of the closest-point rule `Geo.lineOfSight` already shares between the sensor, seeker and trigger gates. The boundary feeds one persistent `PathPolyline` from a readonly binding, matching how every other primitive in the module computes its geometry.

Exact tangent bearings (`β ± asin(r/d)`, doubled a twentieth of a degree apart) and each disc's centre bearing are inserted alongside the uniform rays, so shadow edges stay radial and bites bottom out exactly on the near face without paying for a dense sweep. Occluders arrive as plain `{x, y, r}` rows in source units with a `positionScale`, keeping the framework module free of briarthorn's `Obstacle` type.

`ViewSituation` draws it in world bearings under the same rotation `ViewObstacles` carries, so every bite lands on its own drawn disc, and dims the pre-existing cone to a faint underlay — the scope now separates where the antenna points from what it can see.

## Notes

- The cone fill is ~10% alpha with the range rings showing through it, so shadows have to be real holes in the geometry; painting over them in the background colour would erase the rings.
- The shadow set is held to the pillars the terrain layer actually draws. The cull predicate lives once in `ViewObstacles.draws()` and is called by both, because the minimap's whole-fit cull hides pillars that are substantially inside the picture — casting from those produced a large bite with no visible cause.
- The polyline binding early-returns while the item is hidden. Bindings evaluate on invisible items, and three `ViewSituation` instances are alive at once.

## Verification

- 121/121 tests pass; `clang-format-check` and `qmllint-check` are clean.
- The ten new tests were mutation-tested: dropping the apex offset, flipping the pixel conversion, removing the wrap-around window, deleting either tangent pad, and collapsing the ray pitch are each caught. The first draft of the suite passed against all six of those.
- Checked in the running duel on both the attack scope and the minimap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)