### PR TITLE
Steer maneuvering entities around the arena's pillars

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -85,6 +85,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/scenarios/ScenarioDuel.qml
         qml/scenarios/ScenarioMenu.qml
         qml/systems/SystemAbility.qml
+        qml/systems/SystemAvoidance.qml
         qml/systems/SystemCollision.qml
         qml/systems/SystemCountermeasure.qml
         qml/systems/SystemDetection.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -389,6 +389,11 @@ Window {
                 entities: root.entities
             }
 
+            SystemAvoidance {
+                entities: root.entities
+                obstacles: root.world.obstacles
+            }
+
             SystemEngage {
                 entities: root.entities
                 obstacles: root.world.obstacles

--- a/app/briarthorn/qml/systems/SystemAvoidance.qml
+++ b/app/briarthorn/qml/systems/SystemAvoidance.qml
@@ -1,0 +1,93 @@
+import awen.entity
+import "../model"
+
+// Pillar avoidance: after SystemManeuver has flown the stick, any entity with
+// a pillar standing in its path steers around it instead of into it. The
+// override is local and temporary — a maneuver keeps flying whatever it wants
+// and simply loses the stick for the seconds the wall is ahead — so no
+// maneuver, personality or scenario knows the arena geometry exists.
+System {
+    id: root
+
+    // The world's roster; only entities that fly maneuvers are steered.
+    property list<Entity> entities
+
+    // The arena geometry to be flown around.
+    property list<Obstacle> obstacles
+
+    // Metres of margin held outside a pillar's wall, so an entity rounds it
+    // with room rather than shaving the stone.
+    property real clearance: 2000
+
+    // Seconds of straight flight looked ahead on top of the entity's own turn
+    // radius: the distance within which a wall is worth turning for.
+    property real reaction: 3
+
+    // Bearing error, in degrees, at which the avoidance steer saturates —
+    // tighter than a maneuver's, since a wall does not wait.
+    readonly property real cutAngle: 20
+
+    function update(dt: real) {
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (entity.health <= 0 || entity.maneuvers.length === 0 || entity.speed <= 0)
+                continue;
+            const pillar = root.blocker(entity);
+            if (pillar !== null)
+                root.avoid(entity, pillar);
+        }
+    }
+
+    // The pillar the entity's current heading runs into soonest, or null for
+    // a clear path. The reach is measured to where the nose would enter the
+    // cleared wall, not to the pillar's centre — a wide pillar has to be seen
+    // from outside it, not from within.
+    function blocker(entity: Entity): Obstacle {
+        const ux = Geo.offsetX(entity.heading, 1);
+        const uy = Geo.offsetY(entity.heading, 1);
+        const reach = root.lookahead(entity);
+        let nearest = null;
+        let nearestEntry = Infinity;
+        for (let i = 0; i < root.obstacles.length; ++i) {
+            const pillar = root.obstacles[i];
+            const dx = pillar.posX - entity.posX;
+            const dy = pillar.posY - entity.posY;
+            const along = dx * ux + dy * uy;
+            if (along <= 0)
+                continue;
+            const wall = pillar.radius + root.clearance;
+            const lateral = Math.hypot(dx - along * ux, dy - along * uy);
+            if (lateral >= wall)
+                continue;
+            const entry = along - Math.sqrt(wall * wall - lateral * lateral);
+            if (entry <= reach && entry < nearestEntry) {
+                nearest = pillar;
+                nearestEntry = entry;
+            }
+        }
+        return nearest;
+    }
+
+    // How far ahead a wall matters: the radius of the entity's own hardest
+    // turn, plus the ground it covers while the turn is being set up.
+    function lookahead(entity: Entity): real {
+        const rate = entity.turnRate * Math.PI / 180;
+        const radius = rate > 0 ? entity.speed / rate : 0;
+        return radius + entity.speed * root.reaction;
+    }
+
+    // Steers onto the tangent of the pillar's cleared wall, rounding it on
+    // whichever side the nose already favours, and yields to the maneuver's
+    // own steer when that turns away harder than the tangent asks.
+    function avoid(entity: Entity, pillar: Obstacle) {
+        const bearing = Geo.bearingFrom(entity.posX, entity.posY, pillar.posX, pillar.posY);
+        const range = Geo.distanceFrom(entity.posX, entity.posY, pillar.posX, pillar.posY);
+        const wall = pillar.radius + root.clearance;
+        const tangent = range > wall ? Math.asin(wall / range) * 180 / Math.PI : 90;
+        const side = Geo.wrap180(entity.heading - bearing) >= 0 ? 1 : -1;
+        const error = Geo.wrap180(bearing + side * tangent - entity.heading);
+        const steer = Math.max(-1, Math.min(1, error / root.cutAngle));
+        if (Math.sign(entity.commandedSteer) !== Math.sign(steer) || Math.abs(entity.commandedSteer) < Math.abs(steer))
+            entity.commandedSteer = steer;
+    }
+}


### PR DESCRIPTION
Entities flew straight through the duel arena's pillars: a maneuver knew only its target, so pursuing ownship across a pillar meant flying into it and being wrecked by `SystemCollision`.

## Design

Avoidance is a system, not a maneuver. `SystemAvoidance` runs right after `SystemManeuver` and before movement, overriding `commandedSteer` only for the ticks a wall is actually ahead — so every maneuver, personality and scenario stays ignorant of arena geometry. A top-priority `ManeuverAvoid` was the alternative, but it would need every personality's stance list edited and would suppress the flying behaviour outright rather than nudge it.

Per tick, for each entity carrying maneuvers:

- **Blocker test** — a pillar blocks when the forward ray passes inside `radius + clearance` and the entry point into that cleared wall falls within the lookahead. Lookahead is the entity's own hardest turn radius (`speed / turnRate`) plus `reaction` seconds of straight flight, so a slower-turning craft starts its turn earlier.
- **Steer** — onto the tangent of the cleared wall, rounding on whichever side the nose already favours, saturating at 20 degrees of error (tighter than a maneuver's 30). A maneuver's own steer is left alone when it already turns away harder.

Tunables (`clearance`, `reaction`) live on the system, not in the database — this is arena-geometry behaviour, not an entity rating. Missiles are out of scope: the gate is `maneuvers.length > 0`, so rounds still fly straight into stone.

## Verification

The QML harness route was blocked (release `qml.exe` cannot load debug plugins, and the release preset does not configure on this machine), so the loop was re-run as a standalone sim using the same formulas, then wiring was checked in the real app.

| case | no avoidance | with avoidance |
| --- | --- | --- |
| head-on into a 6 km pillar | crash | reached target, 1987 m wall clearance |
| offset pillar | crash | reached, 1994 m |
| three-pillar gauntlet | crash | reached, 1989 m |
| target close behind a pillar | crash | reached, 1987 m |

That sim caught a real bug in the first draft: the lookahead measured to the pillar's centre, so a 6 km pillar was only noticed from inside it. The shipped code measures to the wall entry point.

A 12-second debug run of the app produced no QML warnings or type errors. Not verified end-to-end: the live duel with personalities driving the maneuvers, since the harness path for that is blocked by the plugin mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)