### PR TITLE
Lean ownship into its turns

### DIFF
--- a/app/briarthorn/qml/database/GameRules.qml
+++ b/app/briarthorn/qml/database/GameRules.qml
@@ -33,6 +33,13 @@ QtObject {
     readonly property real maxTurnRate: 24
     readonly property real maxAcceleration: 200
 
+    // The roll a turn is flown with: the bank (deg) full stick deflection
+    // leans an airframe over to, and the rate (deg/s) it rolls there and back
+    // level at. Attitude alone — a rating buys no part of it and nothing flies
+    // off it — so it is one lean for every airframe, tuned to taste.
+    readonly property real maxBank: 45
+    readonly property real bankRate: 90
+
     // durable buys survivability: hull integrity (hit points) and the fuel
     // capacity (units) of one airframe.
     readonly property real maxHealth: 200

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -23,6 +23,11 @@ QtObject {
     property real posY: 0
     property real heading: 0
 
+    // Roll in degrees, positive right wing down: SystemMovement leans it into
+    // the turn off the same steer that swings the heading. Attitude only —
+    // nothing flies off it — it is what a mark of this entity leans by.
+    property real bank: 0
+
     // Ground speed in m/s: SystemMovement eases it toward what the throttle
     // commands and integrates the pose from it.
     property real speed: 0

--- a/app/briarthorn/qml/systems/SystemMovement.qml
+++ b/app/briarthorn/qml/systems/SystemMovement.qml
@@ -1,11 +1,13 @@
 import awen.entity
+import "../database"
 import "../model"
 
 // Integrates every entity's control inputs into its pose each tick, scaled by
 // frame time, within the limits its stats afford: heading turns at
-// commandedSteer of the entity's turn rate, and speed closes on
-// commandedThrottle of its top speed at the acceleration its maneuver rating
-// buys. Every limit is read live, so a stat change takes effect the next tick.
+// commandedSteer of the entity's turn rate, the airframe banks into that turn,
+// and speed closes on commandedThrottle of its top speed at the acceleration
+// its maneuver rating buys. Every limit is read live, so a stat change takes
+// effect the next tick.
 System {
     id: root
 
@@ -20,6 +22,15 @@ System {
     function advance(entity: Entity, dt: real) {
         const steer = Math.max(-1, Math.min(1, entity.commandedSteer));
         entity.heading = Geo.wrap360(entity.heading + (steer * entity.turnRate * dt));
+
+        // The airframe rolls into the turn rather than snapping over: full
+        // deflection leans it to full bank, a centred stick rolls it level
+        // again, and both take the same rate. Attitude only — the heading
+        // above turns on the stick, not on the lean — but it is integrated
+        // here with the rest of the pose so a paused game holds its bank.
+        const bank = steer * GameRules.maxBank;
+        const roll = GameRules.bankRate * dt;
+        entity.bank = bank > entity.bank ? Math.min(bank, entity.bank + roll) : Math.max(bank, entity.bank - roll);
 
         // Throttle commands a speed the airframe has to fly up to — and coast
         // back down to — rather than one it snaps to.

--- a/app/briarthorn/qml/ui/Symbol.qml
+++ b/app/briarthorn/qml/ui/Symbol.qml
@@ -23,6 +23,15 @@ Item {
     // Rotation of the symbol's nose, degrees clockwise from the frame's up.
     property real noseAngle: 0
 
+    // The bank the outline leans by, degrees, positive right wing down.
+    property real bankAngle: 0
+
+    // How far the outline cants per degree of that bank. Straight overhead a
+    // roll only foreshortens the span, and it foreshortens it the same either
+    // way, so the mark also cants a fraction of the bank — the one part of the
+    // lean that says which way the craft went over.
+    readonly property real bankCant: 0.3
+
     // The containing view's rotation.
     property real viewRotation: 0
 
@@ -99,7 +108,6 @@ Item {
 
     ShapePolygon {
         anchors.fill: parent
-        rotation: root.noseAngle
         points: root.def.outline
         fillColor: Style.theme.windowBackground
         strokeColor: root.sideColor
@@ -108,6 +116,24 @@ Item {
         // limit and would chop flat, and the fighter's tips would spike past
         // the item bounds the views seat marks by.
         joinStyle: ShapePath.RoundJoin
+
+        // Roll first, in the mark's own axes — span across x, nose up the
+        // page — and turn the nose after: a transform list applies first to
+        // last, so the squash lands on the wings whatever heading the mark
+        // ends up drawn at. The rotation here is what the plain unbanked mark
+        // used to carry as its rotation property.
+        transform: [
+            Scale {
+                origin.x: root.width / 2
+                origin.y: root.height / 2
+                xScale: Math.cos(root.bankAngle * Math.PI / 180)
+            },
+            Rotation {
+                origin.x: root.width / 2
+                origin.y: root.height / 2
+                angle: root.noseAngle + root.bankAngle * root.bankCant
+            }
+        ]
     }
 
     // Counter-rotating frame: cancels the view rotation so the label reads

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -327,7 +327,10 @@ Item {
         viewRotation: root.viewRotation
     }
 
-    // Ownship, pinned at the scope centre; nose up on a heading-up scope.
+    // Ownship, pinned at the scope centre; nose up on a heading-up scope. It
+    // holds its place through a turn, so its bank is the one thing on the
+    // scope that shows the turn as the pilot's own — the picture swinging
+    // round is what everyone else's looks like.
     Symbol {
         visible: root.showOwnship && root.observer
         x: root.centerX - width / 2
@@ -335,6 +338,7 @@ Item {
         symbolSize: root.symbolSize
         strokeWidth: root.symbolStrokeWidth
         noseAngle: root.headingUp ? 0 : (root.observer ? root.observer.heading : 0)
+        bankAngle: root.observer ? root.observer.bank : 0
         classification: root.observer ? root.observer.classification : Classification.Kind.Unknown
         side: root.observer ? root.observer.side : Side.Kind.Unknown
         showLabel: false

--- a/app/briarthorn/qml/ui/ViewStatus.qml
+++ b/app/briarthorn/qml/ui/ViewStatus.qml
@@ -103,6 +103,7 @@ Item {
         x: root.cx - width / 2
         y: root.cy - height / 2 - root.shortSide * 0.09
         symbolSize: root.shortSide * 0.24
+        bankAngle: root.ownship ? root.ownship.bank : 0
         classification: root.ownship ? root.ownship.classification : Classification.Kind.AircraftFighter
         side: root.ownship ? root.ownship.side : Side.Kind.Ownship
         showLabel: false


### PR DESCRIPTION
Ownship's mark sat perfectly still through every turn — the picture swinging round it was the only cue that the craft was turning at all, which is what everyone *else's* turn looks like on a heading-up scope. This gives the pilot's own craft a bank.

## What changed

The lean is pose, not view state, so it integrates with the rest of the pose and freezes with a paused sim.

- `GameRules` — two constants beside the agility ones: `maxBank` (45°, what full stick deflection leans an airframe to) and `bankRate` (90 °/s, how fast it rolls there and back level). Attitude buys nothing and no rating prices it, so it is one lean for every airframe; retuning it stays a one-file edit.
- `Entity.bank` — degrees, positive right wing down, in the pose block with `heading`.
- `SystemMovement` — eases `bank` toward `steer * maxBank` at `bankRate`, in the same easing idiom the throttle already uses. The heading still turns on the stick, not on the lean.
- `Symbol.bankAngle` — the mark squashes by `cos(bank)` and cants `bankCant` (0.3) of the bank. Straight overhead a roll only foreshortens the span, and it foreshortens it the same either way, so the cant is the one part of the lean that says which way the craft went over.
- `ViewSituation` and `ViewStatus` bind ownship's bank into the two places its mark is drawn: the scope centre and the condition instrument, where it reads like an attitude indicator.

## Notes for review

- `Symbol`'s outline moves from a `rotation` property to a two-element transform list, so the squash lands on the wings *before* the nose turns — otherwise the span would foreshorten along screen x and come out wrong on the north-up minimap. A transform list applies first-to-last, and the item's own `rotation` property would have applied before the list, hence the swap.
- Contacts do not lean: `ViewTracks` plots `Track`s, which carry no bank. Missiles integrate a bank nothing draws.
- The two dials, if the lean wants toning down: `GameRules.maxBank` for how far it goes, `Symbol.bankCant` for how much of that shows as cant rather than foreshortening.

## Verification

Debug build with the steer pinned (probe reverted): bank logged 0 → ±45 → 0, mirror-symmetric left and right, checked on the scope mark and the condition instrument. `ctest --preset windows-msvc-debug` — 121/121 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)