### PR TITLE
Fix the duel's opening: a pillar the player cannot dodge, and no way to restart

### DIFF
--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -806,6 +806,7 @@ Window {
         focus: root.paused && !settings.open
         device: root.device
         onResumed: root.resumeDuel()
+        onRestarted: root.startDuel()
         onSettingsRequested: root.openSettings()
         onToMenu: root.startMenu()
         onExitGame: Qt.quit()
@@ -889,8 +890,11 @@ Window {
 
     // New game: rebuild both craft factory-fresh, sweep the whole world —
     // the demo's leavings and the spent craft alike — and enroll the new
-    // pair on the game range step.
+    // pair on the game range step. Clears the pause the way startMenu() does,
+    // so a restart taken from the pause page leaves the fresh duel running
+    // rather than frozen behind the overlay it was ordered from.
     function startDuel() {
+        root.paused = false;
         demo.reset();
         game.reset();
         scenario.reset();

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -19,9 +19,12 @@ Scenario {
     required property Entity ownship
 
     // Where the player opens the duel: due south of the merge, mirroring the
-    // bandit's seat, so the two start the same distance off the origin.
-    readonly property real ownshipPosX: 3000
-    readonly property real ownshipPosY: 75000
+    // bandit's seat, so the two start the same distance off the origin. The
+    // 85 km split seats each craft 13 km beyond the other's 72 km radar, so
+    // the contact opens Unknown and resolves about twenty seconds in rather
+    // than after two minutes of empty sky.
+    readonly property real ownshipPosX: 12000
+    readonly property real ownshipPosY: 42500
     readonly property real ownshipHeading: 0
 
     // The downrated airframe, so the duel is winnable, with its rack's flare
@@ -32,9 +35,13 @@ Scenario {
         callsign: "BANDIT 1"
         classification: Classification.Kind.AircraftFighterLight
         side: Side.Kind.Hostile
-        // Seated a shade east of true north: the closing line to the merge
-        // then passes the north pillar with kilometres to spare, where the
-        // axis itself would fly the pursuit straight into it.
+        // Seated 12 km east of true north, mirroring the player. Both closing
+        // lines then clear every pillar: 12 km abeam the 6 km cardinals and
+        // 9 km abeam the 3 km intercardinals, against the 2 km SystemAvoidance
+        // holds outside a wall. That margin has to come from the seat, because
+        // avoidance skips an entity with no maneuvers — the player's craft —
+        // so a lane the bandit would be steered around is one the player flies
+        // into.
         posX: root.ownshipPosX
         posY: -root.ownshipPosY
         heading: 180
@@ -63,15 +70,14 @@ Scenario {
     entities: [root.bandit]
 
     // The arena: four large pillars boxing the fight at 60 km on the
-    // cardinals, a picket of smaller ones every 45 degrees at 120 km, and
-    // four more on the intercardinals at 30 km — off the cardinal axes, so
-    // the opening lane from the north stays flyable. Static terrain, so
-    // reset() never touches it.
+    // cardinals and four smaller ones on the intercardinals at 30 km, so the
+    // north-south opening lane stays flyable. Static terrain, so reset()
+    // never touches it.
     readonly property Component pillarFactory: Component {
         Obstacle {}
     }
 
-    obstacles: [...root.pillarRing(4, 0, 60000, 6000), ...root.pillarRing(8, 0, 120000, 3000), ...root.pillarRing(4, 45, 30000, 3000)]
+    obstacles: [...root.pillarRing(4, 0, 60000, 6000), ...root.pillarRing(4, 45, 30000, 3000)]
 
     // count pillars of one radius, evenly spaced around the origin at range,
     // the first seated at startBearing.

--- a/app/briarthorn/qml/ui/ViewPause.qml
+++ b/app/briarthorn/qml/ui/ViewPause.qml
@@ -1,12 +1,15 @@
 import QtQuick
 
 // The pause menu (Escape / pad Start mid-duel), over the frozen scope and
-// HUD. Resume leads; the way back to the launch screen and out of the game
-// sit below it. Ports briardart's PauseOverlay.
+// HUD. Resume leads and restart sits with it — a duel flown into a bad
+// opening is abandoned far more often than it is quit — with the way back to
+// the launch screen and out of the game below them. Ports briardart's
+// PauseOverlay.
 MenuPage {
     id: root
 
     signal resumed
+    signal restarted
     signal settingsRequested
     signal toMenu
     signal exitGame
@@ -22,6 +25,11 @@ MenuPage {
                 label: qsTr("RESUME"),
                 primary: true,
                 act: () => root.resumed()
+            },
+            {
+                label: qsTr("RESTART"),
+                primary: false,
+                act: () => root.restarted()
             },
             {
                 label: qsTr("SETTINGS"),


### PR DESCRIPTION
Two fixes to `ScenarioDuel`'s opening, found while auditing the 1v1 for engagement.

## The terrain bug

`ownshipPosX: 3000` put the player's northbound spawn track **inside** the 6,000 m
pillar that `pillarRing(4, 0, 60000, 6000)` seats at `(0, +60000)` — 3,000 m lateral,
entry at 9,804 m. Hands-off that is death at ~40 s; at full throttle ~21 s, before the
bandit even resolves.

It only ever hit the player. `SystemAvoidance` skips entities with an empty `maneuvers`
list, and ownship is the only one — so the bandit, on the mirror-image collision course,
gets steered around the stone the player flies into. The comment claiming the closing
line passed "with kilometres to spare" was wrong about both the pillar and the clearance
(`Geo.offsetY` negates cosine, so +y is south and the hazard is the bearing-180 pillar,
not the north one).

Reseated to `posX 12000`, which clears every pillar by more than `SystemAvoidance`'s
2 km `clearance`:

| Track | Nearest pillar | Lateral | Wall (radius + clearance) |
|---|---|---|---|
| old `x=3000` | `(0, 60000)` r6000 | 3,000 m | **inside the stone** |
| new `x=12000` | `(0, ±60000)` r6000 | 12,000 m | 8,000 m |
| new `x=12000` | `(±21213, ±21213)` r3000 | 9,213 m | 5,000 m |

## The opening was mostly empty sky

150 km of separation against 72 km detection and a 51.2 km guided envelope meant
**141 s before the first legal shot**, of which the first 111 s had nothing on the scope
at all. Cruise fuel also ran the tank dry before the merge — which is why
`SystemMission` declines to lose on fuel.

`ownshipPosY: 75000 → 42500` (85 km split). That leaves each craft 13 km outside the
other's radar, so the header comment's "spawned just past sensor range so it opens as an
Unknown contact" becomes true — it was 78 km past — while cutting time-to-first-shot to
~48 s.

Also dropped `pillarRing(8, 0, 120000, 3000)`: its bearings duplicate the union of the
other two rings, and at 120 km it sits entirely outside a fight this size while costing
per-tick work in five systems.

## RESTART on the pause page

The duel's failure mode is misjudging the opening and flying it out, and the only way
back in was a round trip through the main menu. `startDuel()` already rebuilds
everything in one frame, so this is a signal and one entry — plus `root.paused = false`
in `startDuel()`, the way `startMenu()` already does it. Without that line a restart
taken from the pause page rebuilds the duel and leaves it frozen behind the overlay it
was ordered from.

## Notes for review

- **`projection.step` stays at 2.** `RangeProjection.steps` is
  `[20000, 40000, 80000, 160000]`, so step 1 is a 40 km outer ring and would put the
  51.2 km launch envelope off-scope.
- **85 km rather than a tighter compression.** Anything under 72 km starts the contact
  already resolved and throws away the Unknown opening the scenario is built around.
- `MenuPage` is entirely entry-count-driven (`Selector { count: entries.length }`, a
  `Repeater` over `entries`), so the new row needs no other change.

## Verification

Ran the debug build with the state pinned in `Component.onCompleted` and captured with
`PrintWindow`:

| Check | Result |
|---|---|
| Hands-off flight, 130 s | alive at 32.5 km (old build: dead on a pillar at ~40 s) |
| Contact resolution | BANDIT 1 resolved and on-scope by t=30 s (was 129 km, invisible) |
| Bandit engages | hull 100 → 45 by t=130 s — one 55-damage guided hit |
| Radar cone | drops to `UNK` / `NO LOCK` once the contact passes outside ±30° |
| Fuel | 26% at t=130 s — survives the merge, was dry before first shot |
| RESTART | overlay clears, fuel 87% → 98%, fresh `UNK` at the spawn mark |

All probe code reverted; the diff is the three files above.

## Not addressed

Two larger findings from the same audit, both beyond a tuning pass:

- `PersonalityDuelist` fires once and then runs. `press` is always re-entered below the
  withdraw gate, and withdraw's exit needs a range a slower flee can never open. This is
  **scale-invariant** — no envelope retune fixes it.
- `SystemEngage.ability` is a string on the system, so every AI in the world fires the
  same weapon. No enemy can carry a mixed rack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)