### PR TITLE
Number a fresh duel's missiles from one again

### DIFF
--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -920,9 +920,7 @@ Window {
         game.reset();
         scenario.reset();
         mission.reset();
-        const roster = root.world.entities.slice();
-        for (let i = 0; i < roster.length; ++i)
-            root.world.despawn(roster[i]);
+        root.world.clear(null);
         root.world.add(game.ownship);
         for (let i = 0; i < scenario.entities.length; ++i)
             root.world.add(scenario.entities[i]);

--- a/app/briarthorn/qml/model/World.qml
+++ b/app/briarthorn/qml/model/World.qml
@@ -48,4 +48,19 @@ QtObject {
         if (root.spawned.delete(entity))
             entity.destroy();
     }
+
+    // Sweeps the roster back to one survivor — @p keep stays enrolled, every
+    // other entity leaves and the spawned ones are destroyed — and rewinds the
+    // callsign serial, so a new game numbers its missiles from one again rather
+    // than carrying the last game's count. The count only rewinds once nothing
+    // generated is left to collide with, since tracks are keyed by callsign.
+    function clear(keep: Entity) {
+        const roster = root.entities.slice();
+        for (let i = 0; i < roster.length; ++i) {
+            if (roster[i] !== keep)
+                root.despawn(roster[i]);
+        }
+        if (root.spawned.size === 0)
+            root.serial = 0;
+    }
 }

--- a/app/briarthorn/qml/scenarios/ScenarioMenu.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioMenu.qml
@@ -181,11 +181,7 @@ Scenario {
     // the next engagement. In menu mode every other entity is demo-spawned,
     // so the sweep owns exactly what the demo made.
     function restart() {
-        const roster = root.world.entities.slice();
-        for (let i = 0; i < roster.length; ++i) {
-            if (roster[i] !== root.ownship)
-                root.world.despawn(roster[i]);
-        }
+        root.world.clear(root.ownship);
         root.ownship.posX = 0;
         root.ownship.posY = 0;
         root.ownship.heading = 0;


### PR DESCRIPTION
Restarting a duel left the missile numbering where the last game stopped: after a fight that fired a dozen rounds, the next duel's first missile plotted as `MSL 13` on the scope and read back that way in the `LOCK …` caption.

`World.serial` is the counter behind every generated callsign, and both restart paths swept the roster with their own hand-rolled loop without touching it, so the count only ever climbed.

## What changed

The sweep now has one definition, on the world that owns the counter. `World.clear(keep)` despawns everything but the survivor and rewinds the serial; both call sites use it:

- `Main.qml`'s `startDuel()` sweeps everything — `clear(null)`.
- `ScenarioMenu.restart()` keeps ownship — `clear(root.ownship)`.

Putting it on `World` rather than patching the one call site is the point: a third sweep site can no longer forget the counter.

The rewind is guarded on `spawned.size === 0`, so the serial only goes back to zero once no generated entity is left alive to collide with a reissued name. `SystemDetection` keys its tracks by callsign and requires them unique, so an unguarded reset would be a real hazard if a sweep ever kept a spawned entity.

## Verification

- A `qml.exe` harness on `World` directly: `MSL 1, MSL 2, FLR 3` → full clear → `MSL 1, MSL 2` → keep-ownship clear → survivor still enrolled, `MSL 1`.
- The debug app driving the real functions through a temporary probe: `startDuel()` → `MSL 1, MSL 2`; `startMenu()`, `startDuel()` → `MSL 1`. Probe removed; the tree builds clean.

## Note for the reviewer

`startDuel()` re-adds `game.ownship` immediately after the sweep that just removed it. That round-trip is harmless — a declared entity is only unenrolled, never destroyed — and this PR leaves it alone, but it is worth a look if that function is ever revisited.
