### PR TITLE
Put the last duel's blasts out, and re-read a stick the mode change dropped

### DIFF
--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -212,6 +212,13 @@ Window {
             if (!root.active)
                 return;
             root.device.moved(value);
+            // The flight axes hear the stick in every mode, not just the duel's.
+            // A stick states a level and states it only when it moves, so the
+            // one way to know where it is on the way back into the fight is to
+            // have gone on listening while the overlay had the input. Their
+            // fold is frozen off the duel (see axisSteer below), so listening
+            // drives nothing — it only keeps the record honest.
+            actions.axisMoved(axis, value);
             switch (root.mode) {
             case Mode.Kind.Settings:
                 settings.axisMoved(axis, value);
@@ -224,9 +231,6 @@ Window {
                 break;
             case Mode.Kind.Pause:
                 pausePage.axisMoved(axis, value);
-                break;
-            case Mode.Kind.Duel:
-                actions.axisMoved(axis, value);
                 break;
             }
         }
@@ -262,12 +266,22 @@ Window {
 
         // The input layer: keys, controller and (later) touch all fold into
         // these axes through the action bindings below.
+        //
+        // Both are frozen off the duel rather than silenced: their sources go
+        // on recording while an overlay holds the input — which is what lets a
+        // stick be re-read on the way back — and the fold catches up with the
+        // controls in one step on re-enable. Frozen rather than merely
+        // ignored because the launch screen's demo is a running simulation
+        // driving the very craft these command, and a stick nudged while
+        // reading a menu must not fly it.
         Axis {
             id: axisSteer
+            enabled: root.live
         }
 
         Axis {
             id: axisThrottle
+            enabled: root.live
         }
 
         // The scope's range control, the one object every ranging source —
@@ -433,7 +447,7 @@ Window {
         // load systems of their own.
         Systems {
             // Only the two modes with nothing over the world integrate — see
-            // root.running. dropInput() posts the zeroed axes before this
+            // root.running. resyncInput() posts the settled axes before this
             // flips, and nothing clears the queue, so they publish on resume.
             running: root.running
 
@@ -934,11 +948,25 @@ Window {
 
     // Returns every input source to rest: the action bindings, and the stick's
     // own axis slots, which it contributes under the axis itself and so the
-    // router cannot reach.
+    // router cannot reach. For leaving — the window going inactive, where the
+    // pad route shuts down with it and nothing is heard again until it comes
+    // back, so rest is the only honest reading of controls nobody is watching.
     function dropInput() {
         actions.reset();
         axisSteer.invoke(0);
         axisThrottle.invoke(0);
+    }
+
+    // For a handover between screens, where the router goes on listening.
+    // The same drop, because a key or a pad button released behind an overlay
+    // never reports its release and would otherwise stay held for good — and
+    // then the analogue controls re-state themselves, because a stick says
+    // nothing while it is held still, and dropping it leaves the player
+    // holding a lever the game has stopped reading. One is honest about a lost
+    // edge; the other would be inventing a centred stick.
+    function resyncInput() {
+        root.dropInput();
+        actions.resync();
     }
 
     // The launch screen: the demo scenario populates the world itself, one
@@ -952,8 +980,11 @@ Window {
     // startDuel() that rearms it, and it does so before entering the duel, so
     // no decided latch can outlive the screen it belongs to.
     function startMenu() {
-        root.dropInput();
+        root.resyncInput();
         demo.restart();
+        // The blasts go out with the fight that lit them; the demo's own
+        // rounds light their own.
+        weapons.reset();
         // The demo plays an open sky: the duel's arena leaves with the duel.
         root.world.obstacles = [];
         projection.step = 1;
@@ -963,13 +994,13 @@ Window {
     // Escape or Start mid-duel: freeze the sim behind the pause menu. Held
     // input is dropped while the bus still runs, exactly as the page does.
     function openPause() {
-        root.dropInput();
+        root.resyncInput();
         root.mode = Mode.Kind.Pause;
     }
 
     function resumeDuel() {
         root.mode = Mode.Kind.Duel;
-        root.dropInput();
+        root.resyncInput();
     }
 
     // The duel's decision. The judge latches from live model state inside the
@@ -993,6 +1024,9 @@ Window {
         game.reset();
         scenario.reset();
         mission.reset();
+        // The blasts burn on simulation time, so the one that decided the last
+        // duel is still lit when this one opens.
+        weapons.reset();
         root.world.clear(null);
         root.world.add(game.ownship);
         for (let i = 0; i < scenario.entities.length; ++i)
@@ -1000,7 +1034,7 @@ Window {
         root.world.obstacles = scenario.obstacles;
         projection.step = 2;
         root.mode = Mode.Kind.Duel;
-        root.dropInput();
+        root.resyncInput();
     }
 
     // The page stops the sim whatever it is opened over, so a duel it is
@@ -1010,19 +1044,19 @@ Window {
     // was opened from is what DONE returns to, and this is that field's only
     // writer, so the page always has somewhere to go back to.
     //
-    // Held input is released while the bus is still running, so the zeroed
+    // Held input is released while the bus is still running, so the settled
     // steer and throttle post before the simulation stops. Both verbs
-    // coalesce, so they publish on resume and the ship never carries its
-    // pre-pause command out of the page — which is also why nothing clears
-    // the queue.
+    // coalesce, so they publish on resume and the ship never carries a command
+    // out of the page that its controls have stopped giving — which is also
+    // why nothing clears the queue.
     function openSettings() {
-        root.dropInput();
+        root.resyncInput();
         root.settingsFrom = root.live ? Mode.Kind.Pause : root.mode;
         root.mode = Mode.Kind.Settings;
     }
 
     function closeSettings() {
         root.mode = root.settingsFrom;
-        root.dropInput();
+        root.resyncInput();
     }
 }

--- a/app/briarthorn/qml/systems/SystemWeapon.qml
+++ b/app/briarthorn/qml/systems/SystemWeapon.qml
@@ -221,6 +221,17 @@ System {
         }
     }
 
+    // Puts every blast out. They burn down on simulation time, so the one lit
+    // on the frame a duel is decided never runs down at all — the sim stops
+    // with it — and would otherwise be handed to the next game to finish
+    // burning at a world position nothing is standing at any more.
+    function reset() {
+        const lit = root.detonations.slice();
+        root.detonations = [];
+        for (let i = 0; i < lit.length; ++i)
+            lit[i].destroy();
+    }
+
     function ageDetonations(dt: real) {
         let expired = false;
         for (let i = 0; i < root.detonations.length; ++i) {

--- a/src/awen/input/Action.qml
+++ b/src/awen/input/Action.qml
@@ -22,6 +22,14 @@ QtObject {
         root.value = 0;
     }
 
+    // Re-states what the source is saying right now, with no event to prompt
+    // it — for a handover where the router goes on listening and rest would be
+    // a lie about a control the player is still holding. Nothing by default:
+    // a digital source speaks in edges, and an edge that has already been and
+    // gone cannot be read back off the device, which is exactly why reset() is
+    // the honest answer for one. An absolute source overrides this.
+    function resync() {}
+
     function keyPressed(key: int): bool {
         return false;
     }

--- a/src/awen/input/ActionAxis.qml
+++ b/src/awen/input/ActionAxis.qml
@@ -14,10 +14,24 @@ Action {
     // Positions closer to rest than this fold to zero, absorbing stick jitter.
     property real deadzone: 0.15
 
-    function axisMoved(moved: int, position: real): bool {
+    // Where the source last reported itself. A stick states a level rather
+    // than an edge, and states it only when it moves — a stick pushed to its
+    // stop and held there emits nothing at all — so this is the whole record
+    // of where the control is, and the only thing resync() can read it back
+    // from.
+    property real position: 0
+
+    function axisMoved(moved: int, reading: real): bool {
         if (moved !== root.axis)
             return false;
-        root.value = (Math.abs(position) < root.deadzone ? 0 : position) * root.scale;
+        root.position = reading;
+        root.resync();
         return true;
+    }
+
+    // The one place the raw position becomes a contribution, so re-stating the
+    // stick and hearing it move cannot map it two different ways.
+    function resync() {
+        root.value = (Math.abs(root.position) < root.deadzone ? 0 : root.position) * root.scale;
     }
 }

--- a/src/awen/input/Actions.qml
+++ b/src/awen/input/Actions.qml
@@ -36,6 +36,20 @@ QtObject {
         }
     }
 
+    // Has every action re-state what its source is saying now — call after a
+    // reset() that was a handover rather than a departure, where the router
+    // goes on listening. The digital bindings stay at rest, since a release
+    // that never arrived cannot be read back; the analogue ones re-report
+    // themselves, since a control the player is still holding is not at rest
+    // however long it has been silent.
+    function resync() {
+        for (let i = 0; i < root.actions.length; ++i) {
+            const action = root.actions[i];
+            if (action !== null)
+                action.resync();
+        }
+    }
+
     // Delivers one event to every action without short-circuiting, so shared
     // inputs reach every binding. A destroyed action leaves a null slot behind,
     // and skipping it keeps one dead binding from taking the router down.

--- a/src/awen/input/test/Actions.test.cpp
+++ b/src/awen/input/test/Actions.test.cpp
@@ -237,6 +237,85 @@ TEST(Actions, ResetDropsAllHeldState)
     EXPECT_DOUBLE_EQ(steer(*map), 0.0);
 }
 
+TEST(Actions, ResyncRestatesAStickThatNeverMoved)
+{
+    auto engine = QQmlEngine{};
+    const auto map = load(engine, Harness);
+    ASSERT_NE(map, nullptr);
+
+    // A stick pushed to its stop reports once and then says nothing at all for
+    // as long as it is held there, so a reset is the last word the axis has —
+    // and rest is not where the control is.
+    EXPECT_TRUE(move(*map, 0, 0.7));
+    EXPECT_DOUBLE_EQ(steer(*map), 0.7);
+
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "reset"));
+    EXPECT_DOUBLE_EQ(steer(*map), 0.0);
+
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "resync"));
+    EXPECT_DOUBLE_EQ(steer(*map), 0.7);
+}
+
+TEST(Actions, ResyncLeavesDroppedKeysAtRest)
+{
+    auto engine = QQmlEngine{};
+    const auto map = load(engine, Harness);
+    ASSERT_NE(map, nullptr);
+
+    // The release of a held key behind an overlay never arrives, so the drop
+    // has to stand: a digital source cannot be read back off the device the
+    // way a stick's position can.
+    EXPECT_TRUE(route(*map, "keyPressed", Qt::Key_D));
+    EXPECT_DOUBLE_EQ(steer(*map), 1.0);
+
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "reset"));
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "resync"));
+    EXPECT_DOUBLE_EQ(steer(*map), 0.0);
+}
+
+TEST(Actions, ResyncKeepsTheStickAndDropsTheKeyTogether)
+{
+    auto engine = QQmlEngine{};
+    const auto map = load(engine, Harness);
+    ASSERT_NE(map, nullptr);
+
+    // Both sources on one axis: only the half that can be re-read comes back.
+    EXPECT_TRUE(route(*map, "keyPressed", Qt::Key_W));
+    EXPECT_TRUE(move(*map, 1, -0.4));
+    EXPECT_DOUBLE_EQ(throttle(*map), 1.0);
+
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "reset"));
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "resync"));
+    EXPECT_DOUBLE_EQ(throttle(*map), 0.4);
+}
+
+TEST(Actions, ResyncHonoursTheDeadzone)
+{
+    auto engine = QQmlEngine{};
+    const auto map = load(engine, Harness);
+    ASSERT_NE(map, nullptr);
+
+    // A stick resting off centre must not be re-stated as a real deflection —
+    // resync goes through the same mapping the move did.
+    EXPECT_TRUE(move(*map, 0, 0.1));
+    EXPECT_DOUBLE_EQ(steer(*map), 0.0);
+
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "reset"));
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "resync"));
+    EXPECT_DOUBLE_EQ(steer(*map), 0.0);
+}
+
+TEST(Actions, ResyncOnAnUntouchedMapChangesNothing)
+{
+    auto engine = QQmlEngine{};
+    const auto map = load(engine, Harness);
+    ASSERT_NE(map, nullptr);
+
+    EXPECT_TRUE(QMetaObject::invokeMethod(map.get(), "resync"));
+    EXPECT_DOUBLE_EQ(steer(*map), 0.0);
+    EXPECT_DOUBLE_EQ(throttle(*map), 0.0);
+}
+
 TEST(Actions, SharedInputReachesEveryBinding)
 {
     auto engine = QQmlEngine{};


### PR DESCRIPTION
Stacked on #113 — base is `app-state-mode`, because both changes touch the `Gamepad.onAxisChanged` handler that PR rewrites. GitHub will retarget this to `main` when #113 merges. The two fixes are independent of each other; they are together because they are the remaining confirmed findings from the same review.

---

## 1. The last duel's blasts burn into the next one

`SystemWeapon.detonations` burn down on **simulation** time, and the sim stops the moment a duel is decided. So the blast that killed you is lit, frozen, and still lit when FLY AGAIN opens the next duel — where it finishes burning at a world position nothing is standing at any more. Same on the way to the launch screen, whose backdrop draws engagements too.

`SystemWeapon.reset()` puts them out, called from `startDuel()` and `startMenu()` alongside the store, scenario and mission resets. The list is cleared before the objects are destroyed, the same order `ageDetonations()` already uses, so nothing is destroyed while the `Repeater` still models it.

**Verified on the real path.** With the blast lifetime temporarily stretched so one could be caught, a duel was played to a genuine missile kill and the sweep reported putting out exactly one blast on FLY AGAIN. Instrumentation removed before commit.

## 2. A stick held at its stop is dead after a mode change

`dropInput()` zeroes the fold on every mode change. For a key that is right — a release that arrives behind an overlay is never delivered, so held state has to be dropped or it sticks forever. For an analogue stick it is wrong: SDL emits `AXISMOTION` only when the position *changes*, so a stick pushed to its stop and held there says nothing at all. Zeroing it invents a centred stick the player is not holding, and nothing re-reads it until they physically move it. Pause and resume with the stick at the firewall and the craft comes back at cruise with a lost turn.

The rule this settles on: **zero what we stop listening to, re-state what we keep listening to.**

- `Action.resync()` — new, a no-op by default. A digital source speaks in edges, and an edge that has been and gone cannot be read back off the device, which is exactly why `reset()` is the honest answer for one.
- `ActionAxis` records the last reported `position` and overrides `resync()` to re-apply it, through the same deadzone-and-scale mapping `axisMoved` uses, so hearing the stick move and re-stating it cannot map it two different ways.
- `Actions.resync()` fans it out.
- `Main.qml` gains `resyncInput()` (`dropInput()` then `actions.resync()`) at the six mode transitions. `dropInput()` alone stays on window deactivation — there the pad route shuts down with the window, so we genuinely stop listening and rest is the honest reading.
- The flight axes now hear the stick in **every** mode, which is what keeps the record current while an overlay has the input. Their fold is frozen with `enabled: root.live` so listening drives nothing — necessary because the launch screen's demo is a running simulation driving the very craft these command, and a stick nudged while reading a menu must not fly it.

**`reset()` semantics are unchanged.** The existing `Actions.ResetDropsAllHeldState` still passes as written; this only adds an operation.

### Why not the obvious fix

Freezing the axes and dropping `actions.reset()` outright looks simpler and is wrong twice over: digital `held` state keeps stale `true` for anything released behind the overlay, and `Axis.test.cpp:DisabledSwallowsStepsUntilReEnabled` pins that re-enabling a recorded engagement fires `stepped` once — so the ability axes would launch a weapon on resume. Ability axes are untouched here, and only the two flight axes freeze.

---

## Verification

Debug and release build clean, `qmllint-check` clean, **126/126 tests pass** — five of them new, covering resync restating a stick that never moved, leaving dropped keys at rest, doing both on one axis at once, honouring the deadzone, and being a no-op on an untouched map.

In-app: all five modes walked with zero QML warnings; keyboard steering confirmed working before *and* after a pause round-trip (the frozen-fold path), with the sim provably frozen in between (identical frames).

**Not verified:** the analogue behaviour itself, for want of a controller on this machine. The `resync()` semantics are covered by unit tests; the routing and freezing are verified by inspection and by the digital paths still working.

## Still open from the review

The end screen declines Escape while pad Start activates FLY AGAIN, and `SystemDetection.held` is keyed by callsign and never swept, so the second duel's opening Unknown contact carries the previous bandit's dying heading. Neither is fixed here.
