### PR TITLE
Player target designation: cycle, tap and cursor on the attack scope

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -41,6 +41,7 @@ awen_add_executable(${PROJECT_NAME}
         ${QML_CUE}
         qml/commands/CommandAbility.qml
         qml/commands/CommandSteer.qml
+        qml/commands/CommandTarget.qml
         qml/commands/CommandThrottle.qml
         qml/database/Ability.qml
         qml/database/AbilityCountermeasure.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -98,6 +98,10 @@ Window {
     readonly property bool armedValid: root.armed !== null && root.armed.valid
     readonly property string lockedContact: root.armed && root.armed.lock ? root.armed.lock.callsign : ""
 
+    // The pilot's designated contact, straight off the flown craft; the
+    // scope's cursor stands on that one mark.
+    readonly property string selectedContact: game.ownship.targetContact
+
     width: 1280
     height: 720
     visible: true
@@ -299,6 +303,16 @@ Window {
             }
         }
 
+        // The designation cycle: each step walks the selectable picture to the
+        // next contact. Frozen off the duel like the flight axes — cycling
+        // changes what a launch does, and a menu's Tab must never re-aim the
+        // craft behind it.
+        Axis {
+            id: axisTarget
+            enabled: root.live
+            onStepped: direction => root.cycleTarget(direction)
+        }
+
         Actions {
             id: actions
 
@@ -334,6 +348,18 @@ Window {
                 control: axisRange
                 positive: root.keymap.range.pad.positive
                 negative: root.keymap.range.pad.negative
+            }
+
+            ActionKey {
+                control: axisTarget
+                positive: root.keymap.target.key.positive
+                negative: root.keymap.target.key.negative
+            }
+
+            ActionButton {
+                control: axisTarget
+                positive: root.keymap.target.pad.positive
+                negative: root.keymap.target.pad.negative
             }
 
             ActionAxis {
@@ -402,6 +428,13 @@ Window {
         // object of its own and posts exactly the record a key press posts.
         CommandAbility {
             id: touched
+            queue: bus
+        }
+
+        // The designation's one path onto the bus: every selection source —
+        // the cycle, a scope tap, a track list's row — posts through this.
+        CommandTarget {
+            id: designate
             queue: bus
         }
 
@@ -592,6 +625,7 @@ Window {
             armedReach: root.armedReach
             armedValid: root.armedValid
             lockedContact: root.lockedContact
+            selectedContact: root.selectedContact
 
             anchors {
                 left: parent.left
@@ -1010,6 +1044,35 @@ Window {
     function judge() {
         if (root.decided && root.live)
             root.mode = Mode.Kind.End;
+    }
+
+    // The contacts the designation cycle walks, ordered clockwise off
+    // ownship's nose so the walk reads as a sweep across the heading-up scope.
+    function selectableTracks(): var {
+        const picked = detection.tracks.filter(t => t.selectable);
+        picked.sort((a, b) => Geo.wrap180(a.azimuth - game.ownship.heading) - Geo.wrap180(b.azimuth - game.ownship.heading));
+        return picked;
+    }
+
+    // One cycle press: the next selectable contact around the scope, wrapping,
+    // or the one nearest the nose where nothing is selected yet. An empty
+    // picture selects nothing and says nothing.
+    function cycleTarget(direction: int) {
+        const picked = root.selectableTracks();
+        if (picked.length === 0)
+            return;
+        const current = picked.findIndex(t => t.contactId === game.ownship.targetContact);
+        let chosen = picked[0];
+        if (current < 0) {
+            for (let i = 1; i < picked.length; ++i) {
+                const off = Math.abs(Geo.wrap180(picked[i].azimuth - game.ownship.heading));
+                if (off < Math.abs(Geo.wrap180(chosen.azimuth - game.ownship.heading)))
+                    chosen = picked[i];
+            }
+        } else {
+            chosen = picked[(current + direction + picked.length) % picked.length];
+        }
+        designate.post({ contact: chosen.contactId });
     }
 
     // New game: rebuild both craft factory-fresh, sweep the whole world —

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -206,8 +206,17 @@ Window {
             event.accepted = actions.keyPressed(event.key);
         }
         Keys.onReleased: event => {
-            if (!event.isAutoRepeat && root.live)
-                event.accepted = actions.keyReleased(event.key);
+            if (event.isAutoRepeat || !root.live)
+                return;
+            event.accepted = actions.keyReleased(event.key);
+            // Tab and Backtab are one physical key wearing the shift state of
+            // the moment, so a press can come down as one and its release
+            // come up as the other — release both, or the cycle key jams a
+            // held contribution it can never clear.
+            if (event.key === Qt.Key_Tab)
+                actions.keyReleased(Qt.Key_Backtab);
+            else if (event.key === Qt.Key_Backtab)
+                actions.keyReleased(Qt.Key_Tab);
         }
 
         // Controller events ignore focus entirely, so handing the page the

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -648,8 +648,11 @@ Window {
             // Live only: a tap on the frozen scope behind an overlay must not
             // queue a designation that lands on resume.
             selectionEnabled: root.live
-            // A tap toggles: tapping the selected contact stands it down.
+            // A tap toggles: tapping the selected contact stands it down. A
+            // thumb on the scope hands the HUD to the touch controls, as one
+            // on the rack does.
             onTrackTapped: contactId => designate.post({ contact: contactId === game.ownship.targetContact ? "" : contactId })
+            onTrackTouched: root.device.kind = ActiveDevice.Touch
 
             anchors {
                 left: parent.left

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -626,6 +626,11 @@ Window {
             armedValid: root.armedValid
             lockedContact: root.lockedContact
             selectedContact: root.selectedContact
+            // Live only: a tap on the frozen scope behind an overlay must not
+            // queue a designation that lands on resume.
+            selectionEnabled: root.live
+            // A tap toggles: tapping the selected contact stands it down.
+            onTrackTapped: contactId => designate.post({ contact: contactId === game.ownship.targetContact ? "" : contactId })
 
             anchors {
                 left: parent.left

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -91,16 +91,26 @@ Window {
 
     // The shot the player is holding armed, if any. Every arming cue reads off
     // this one slot: the scope paints the envelope its round can reach and
-    // brackets the return its seeker is holding, and the readout says what it
-    // is waiting on. Null — the disarmed case — leaves all three off.
+    // the readout says what it is waiting on. Null — the disarmed case —
+    // leaves both off.
     readonly property AbilitySlot armed: game.ownship.armedAbility
     readonly property real armedReach: root.armed ? root.armed.reach : 0
     readonly property bool armedValid: root.armed !== null && root.armed.valid
-    readonly property string lockedContact: root.armed && root.armed.lock ? root.armed.lock.callsign : ""
 
-    // The pilot's designated contact, straight off the flown craft; the
-    // scope's cursor stands on that one mark.
+    // The pilot's designated contact, straight off the flown craft, and —
+    // where the survey validates it — the contact a guided launch would take
+    // right now. The scope's cursor stands on the first and turns its latched
+    // colour on the second; under designation the two can only ever name the
+    // same mark.
     readonly property string selectedContact: game.ownship.targetContact
+    readonly property string shootableContact: {
+        for (let i = 0; i < game.ownship.abilities.length; ++i) {
+            const slot = game.ownship.abilities[i];
+            if (slot.guided && slot.lock !== null)
+                return slot.lock.callsign;
+        }
+        return "";
+    }
 
     width: 1280
     height: 720
@@ -624,7 +634,7 @@ Window {
             trailsRunning: root.running
             armedReach: root.armedReach
             armedValid: root.armedValid
-            lockedContact: root.lockedContact
+            shootableContact: root.shootableContact
             selectedContact: root.selectedContact
             // Live only: a tap on the frozen scope behind an overlay must not
             // queue a designation that lands on resume.
@@ -839,8 +849,8 @@ Window {
             radiusFraction: 0.45
             symbolSize: height * 0.08
             // The envelope mirrors onto the overview with everything else the
-            // minimap keeps; the lock bracket does not, because a mark drawn
-            // this small has no room to stand one off.
+            // minimap keeps; the cursor does not, because a mark drawn this
+            // small has no room to stand one off.
             armedReach: root.armedReach
             armedValid: root.armedValid
             backgroundColor: Style.theme.windowBackground

--- a/app/briarthorn/qml/commands/CommandTarget.qml
+++ b/app/briarthorn/qml/commands/CommandTarget.qml
@@ -1,0 +1,17 @@
+import awen.command
+
+// Designation intent: points the flown craft's guided weapons at one contact
+// by track id; an empty contact stands the designation down. Discrete, so
+// every pick posts one record.
+Command {
+    id: root
+
+    // The contact the record carries.
+    property string contact: ""
+
+    name: Verbs.target
+
+    function payload(): var {
+        return { contact: root.contact };
+    }
+}

--- a/app/briarthorn/qml/commands/Verbs.qml
+++ b/app/briarthorn/qml/commands/Verbs.qml
@@ -9,4 +9,5 @@ QtObject {
     readonly property string steer: "steer"
     readonly property string throttle: "throttle"
     readonly property string ability: "ability"
+    readonly property string target: "target"
 }

--- a/app/briarthorn/qml/input/Keymap.qml
+++ b/app/briarthorn/qml/input/Keymap.qml
@@ -24,20 +24,12 @@ QtObject {
     // says so rather than lying about it.
     readonly property bool available: Qt.application.organization !== "" || Qt.application.domain !== ""
 
-    // Every registered ability's controls, name to { key, button }; -1 is
-    // unbound. Loaded in the initialiser and not at completion: an object held
-    // in a property completes after the file that holds it, so a deferred load
-    // leaves the whole first turn on defaults.
-    property var bindings: root.load()
-
-    // The ability whose binding the last bind() took away, and on which device.
-    // The settings page marks that cap, so a steal is never silent.
-    property string displaced: ""
-    property bool displacedPad: false
-
     // The flight controls, fixed. They are not rebindable, but they are listed
     // so a capture can refuse their codes: the router fans every event to every
-    // action, so an ability sharing W would thrust as well as fire.
+    // action, so an ability sharing W would thrust as well as fire. The fixed
+    // maps and the blocked lists sit above bindings for the same reason the
+    // store does: load() prunes a stale save through reserved(), which reads
+    // them all.
     readonly property var flight: ({
             steer: {
                 key: {
@@ -78,6 +70,20 @@ QtObject {
             }
         })
 
+    // The designation cycle, fixed like the range map: Tab and Shift+Tab walk
+    // the track picture, Y and LB do on the pad, and a capture must refuse
+    // the pad pair the way it refuses a flight control.
+    readonly property var target: ({
+            key: {
+                positive: [Qt.Key_Tab],
+                negative: [Qt.Key_Backtab]
+            },
+            pad: {
+                positive: [Gamepad.Button.North],
+                negative: [Gamepad.Button.LeftShoulder]
+            }
+        })
+
     // Keys a binding may never take: the way in and out of the page, its own
     // traversal keys, and the modifiers — a digital action has no modifier
     // concept and could only fold one as an ordinary key.
@@ -85,6 +91,17 @@ QtObject {
 
     // Buttons a binding may never take: the pad's way in and out of the page.
     readonly property list<int> blockedButtons: [Gamepad.Button.Start, Gamepad.Button.East]
+
+    // Every registered ability's controls, name to { key, button }; -1 is
+    // unbound. Loaded in the initialiser and not at completion: an object held
+    // in a property completes after the file that holds it, so a deferred load
+    // leaves the whole first turn on defaults.
+    property var bindings: root.load()
+
+    // The ability whose binding the last bind() took away, and on which device.
+    // The settings page marks that cap, so a steal is never silent.
+    property string displaced: ""
+    property bool displacedPad: false
 
     // Controller buttons name their position; the faces and shoulders read
     // better as what is printed on the pad in the player's hands.
@@ -125,7 +142,7 @@ QtObject {
         if ((pad ? root.blockedButtons : root.blockedKeys).includes(code))
             return true;
         const channel = pad ? "pad" : "key";
-        const fixed = [root.range];
+        const fixed = [root.range, root.target];
         for (const axis in root.flight)
             fixed.push(root.flight[axis]);
         for (let i = 0; i < fixed.length; ++i) {
@@ -235,12 +252,19 @@ QtObject {
             return table;
         for (const name in saved) {
             const pair = saved[name];
-            if (Array.isArray(pair) && pair.length === 2 && Number.isInteger(pair[0]) && Number.isInteger(pair[1]))
+            if (Array.isArray(pair) && pair.length === 2 && Number.isInteger(pair[0]) && Number.isInteger(pair[1])) {
+                // A code a fixed map has since claimed drops to unbound: the
+                // router fans every event to every action, so a stale save
+                // sharing the cycle pair would fire as well as cycle.
+                const key = root.reserved(false, pair[0]) ? -1 : pair[0];
+                const button = root.reserved(true, pair[1]) ? -1 : pair[1];
+                if (key !== pair[0] || button !== pair[1])
+                    console.warn("Keymap: dropping a saved control the game now reserves from \"" + name + "\"");
                 table[name] = {
-                    key: pair[0],
-                    button: pair[1]
+                    key: key,
+                    button: button
                 };
-            else
+            } else
                 console.warn("Keymap: ignoring a malformed binding for \"" + name + "\"");
         }
         return table;

--- a/app/briarthorn/qml/model/AbilitySlot.qml
+++ b/app/briarthorn/qml/model/AbilitySlot.qml
@@ -18,7 +18,8 @@ QtObject {
         Cooling,
         Empty,
         NoLock,
-        Distant
+        Distant,
+        NoTarget
     }
 
     // The ability definition this slot instantiates.
@@ -65,6 +66,11 @@ QtObject {
     property Entity lock: null
     property bool distant: false
 
+    // Whether the launcher designates its targets and has designated nothing:
+    // the impediment a press meets before any radar question is asked.
+    // SystemWeapon writes it with the lock.
+    property bool undesignated: false
+
     // Whether a launch would happen this instant: everything the consuming
     // system checks, in the one place the rack, the scope and the trigger all
     // read it from.
@@ -75,8 +81,11 @@ QtObject {
             return AbilitySlot.Impediment.Empty;
         if (root.cooldownRemaining > 0)
             return AbilitySlot.Impediment.Cooling;
-        if (root.guided && root.lock === null)
+        if (root.guided && root.lock === null) {
+            if (root.undesignated)
+                return AbilitySlot.Impediment.NoTarget;
             return root.distant ? AbilitySlot.Impediment.Distant : AbilitySlot.Impediment.NoLock;
+        }
         return AbilitySlot.Impediment.None;
     }
 

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -74,6 +74,17 @@ QtObject {
     property real engageTimer: 0
     property bool engageHold: false
 
+    // Whether this entity's guided locks come from its designated track
+    // rather than the radar's automatic pick. The player's craft carries it;
+    // the menu demo's director designates through the same property the
+    // pilot does.
+    property bool selectsTarget: false
+
+    // The designated contact, by track id (the contact's callsign); empty is
+    // none. Player intent lands here off the bus, and SystemDetection stands
+    // down a designation naming no held track.
+    property string targetContact: ""
+
     // SystemThreat pops this entity's flares at inbound guided rounds; the
     // timer spaces the pops so each decoy gets its chance to seduce.
     property bool threatReflex: false

--- a/app/briarthorn/qml/model/StoreGame.qml
+++ b/app/briarthorn/qml/model/StoreGame.qml
@@ -22,6 +22,8 @@ Store {
         classification: Classification.Kind.AircraftFighter
         side: Side.Kind.Ownship
         radarFov: 60
+        // The pilot designates; the guided rack only takes the selected track.
+        selectsTarget: true
         // Spawned already at cruise: the lever at rest commands idle, not a
         // stop, and the first post overwrites this binding.
         commandedThrottle: GameRules.throttleIdle
@@ -51,6 +53,13 @@ Store {
     CommandHandler {
         name: Verbs.ability
         onHandle: payload => root.ownship.invoke(payload.ability)
+    }
+
+    // Designation routes straight onto the craft: the weapon survey is what
+    // judges whether the named contact is anything a seeker can take.
+    CommandHandler {
+        name: Verbs.target
+        onHandle: payload => root.ownship.targetContact = payload.contact
     }
 
     // Replaces the player's craft with a factory-fresh one — QML's

--- a/app/briarthorn/qml/model/Track.qml
+++ b/app/briarthorn/qml/model/Track.qml
@@ -34,4 +34,11 @@ QtObject {
 
     // The hull reading as a fraction of full, 0..1; zero without a reading.
     readonly property real healthFrac: root.maxHealth > 0 ? Math.max(0, Math.min(1, root.health / root.maxHealth)) : 0
+
+    // Whether the pilot can designate this contact: a resolved hostile craft.
+    // Munitions and decoys plot but are passed over — a round aimed at either
+    // re-homes onto the loudest return anyway — and an unresolved contact
+    // reads Unknown, which no seeker opposes. The cycle, the scope's taps and
+    // the track list all read this one answer.
+    readonly property bool selectable: root.side === Side.Kind.Hostile && root.classification !== Classification.Kind.Decoy && Database.weaponDataFor(root.classification) === null
 }

--- a/app/briarthorn/qml/scenarios/ScenarioMenu.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioMenu.qml
@@ -89,6 +89,7 @@ Scenario {
             root.quarry = null;
             root.evade.target = null;
             root.ownship.engageTarget = null;
+            root.ownship.targetContact = "";
             // With no aspect steering it, ownship flies straight and level
             // toward the next engagement.
             root.ownship.commandedSteer = 0;
@@ -105,6 +106,10 @@ Scenario {
             root.quarry = foes[Math.floor(Math.random() * foes.length)];
         root.evade.target = root.quarry;
         root.ownship.engageTarget = root.quarry;
+        // The director designates through the pilot's own property, so the
+        // demo's guided rack fires under the same selection rule the
+        // player's does.
+        root.ownship.targetContact = root.quarry.callsign;
     }
 
     // The demo must never end: the hull stays topped (SystemWeapon must keep
@@ -170,6 +175,7 @@ Scenario {
         root.evade.target = null;
         root.ownship.maneuvers = [];
         root.ownship.engageTarget = null;
+        root.ownship.targetContact = "";
         root.ownship.engageHold = false;
         root.clearTimer = 0;
         root.showTimer = 0;

--- a/app/briarthorn/qml/systems/SystemCue.qml
+++ b/app/briarthorn/qml/systems/SystemCue.qml
@@ -27,10 +27,12 @@ System {
 
     // Last tick's readings, so each cue fires on the edge and not the level.
     // Only a fall sounds: a factory-fresh craft restores the hull and refills
-    // the racks, and a restart must not fire the whole set at once.
+    // the racks, and a restart must not fire the whole set at once. The lock
+    // is tracked by identity rather than as a flag, so re-designating from
+    // one shootable contact straight onto another still re-cues.
     property real lastHealth: 0
     property int lastRounds: 0
-    property bool hadLock: false
+    property string lastLock: ""
     property bool hadThreat: false
 
     function update(dt: real) {
@@ -39,21 +41,21 @@ System {
 
         const health = root.ownship.health;
         const rounds = root.roundsLeft();
-        const holdsLock = root.holdsLock();
+        const lock = root.shootableLock();
         const threatened = root.ownship.threatInbound !== null;
 
         if (health < root.lastHealth)
             Sfx.impact();
         if (rounds < root.lastRounds)
             Sfx.launch();
-        if (holdsLock && !root.hadLock)
+        if (lock !== "" && lock !== root.lastLock)
             Sfx.lock();
         if (threatened && !root.hadThreat)
             Sfx.threat();
 
         root.lastHealth = health;
         root.lastRounds = rounds;
-        root.hadLock = holdsLock;
+        root.lastLock = lock;
         root.hadThreat = threatened;
     }
 
@@ -70,14 +72,15 @@ System {
         return total;
     }
 
-    // Whether any guided rack is holding a return: the moment the shot the
-    // pilot has been waiting on becomes available.
-    function holdsLock(): bool {
+    // The contact some guided rack would take right now, by callsign — the
+    // moment it changes is the moment worth a tone, whether it arrived from
+    // nothing or from a different designation.
+    function shootableLock(): string {
         for (let i = 0; i < root.ownship.abilities.length; ++i) {
             const slot = root.ownship.abilities[i];
             if (slot.guided && slot.lock !== null)
-                return true;
+                return slot.lock.callsign;
         }
-        return false;
+        return "";
     }
 }

--- a/app/briarthorn/qml/systems/SystemDetection.qml
+++ b/app/briarthorn/qml/systems/SystemDetection.qml
@@ -77,6 +77,11 @@ System {
                 changed = true;
             }
         }
+        // A designation naming no held track — its contact died, or a late
+        // record outran the picture — stands down here, where the track
+        // lifecycle already is.
+        if (root.observer.targetContact !== "" && root.held[root.observer.targetContact] === undefined)
+            root.observer.targetContact = "";
         if (changed)
             root.tracks = Object.values(root.held);
     }

--- a/app/briarthorn/qml/systems/SystemWeapon.qml
+++ b/app/briarthorn/qml/systems/SystemWeapon.qml
@@ -70,9 +70,13 @@ System {
                     // pick ranks over, against the one contact the pilot
                     // named — and "too far for the round" keeps its own
                     // answer, judged at the radar's own reach.
-                    if (chosen !== null && root.takeable(launcher, launcher, launcher.side, chosen, slot.reach))
-                        lock = chosen;
-                    distant = lock === null && chosen !== null && root.takeable(launcher, launcher, launcher.side, chosen, launcher.detectionRange);
+                    if (chosen !== null && root.takeable(launcher, launcher, launcher.side, chosen)) {
+                        const d = Geo.distance(launcher, chosen);
+                        if (d <= slot.reach)
+                            lock = chosen;
+                        else
+                            distant = d <= launcher.detectionRange;
+                    }
                 } else {
                     lock = root.bestReturn(launcher, launcher, launcher.side, slot.reach);
                     // Nothing to take inside the envelope, but something out
@@ -278,17 +282,17 @@ System {
         }
     }
 
-    // Whether one return passes every gate a seeker needs — live, opposed,
-    // inside range, illuminated by the radar cone and in line of sight. The
+    // Whether one return passes every gate a seeker needs besides reach —
+    // live, opposed, illuminated by the radar cone and in line of sight. The
     // one definition the automatic pick ranks over and a designation is
     // judged by, so the two policies can never disagree about what is
-    // takeable.
-    function takeable(at: Entity, illuminator: Entity, side: int, contact: Entity, range: real): bool {
+    // takeable; range stays with the caller, which needs the distance anyway.
+    function takeable(at: Entity, illuminator: Entity, side: int, contact: Entity): bool {
         if (contact === at || contact === illuminator || contact.health <= 0)
             return false;
         if (!root.opposed(side, contact.side))
             return false;
-        if (Geo.distance(at, contact) > range || !root.illuminated(illuminator, contact))
+        if (!root.illuminated(illuminator, contact))
             return false;
         // The seeker is a radar receiver too: a return behind a pillar
         // reaches neither it nor the illuminator.
@@ -304,9 +308,9 @@ System {
         let bestDist = 0;
         for (let i = 0; i < root.world.entities.length; ++i) {
             const contact = root.world.entities[i];
-            if (!root.takeable(at, illuminator, side, contact, range))
-                continue;
             const d = Geo.distance(at, contact);
+            if (d > range || !root.takeable(at, illuminator, side, contact))
+                continue;
             if (best === null || contact.stealth < best.stealth || (contact.stealth === best.stealth && d < bestDist)) {
                 best = contact;
                 bestDist = d;

--- a/app/briarthorn/qml/systems/SystemWeapon.qml
+++ b/app/briarthorn/qml/systems/SystemWeapon.qml
@@ -50,31 +50,63 @@ System {
     // The shot picture, published before anything launches: for every guided
     // launch slot in the world, the return it would take right now and —
     // where it has none — whether the radar is holding one anyway, out beyond
-    // what the round could fly to. The rack's readout, the scope's envelope
-    // and the launch below all read this one answer, so what the pilot is
-    // shown is exactly what the trigger does.
+    // what the round could fly to. A launcher that designates (the player,
+    // the demo's director) locks its designated contact or nothing; every
+    // other launcher keeps the automatic pick. The rack's readout, the
+    // scope's envelope and the launch below all read this one answer, so what
+    // the pilot is shown is exactly what the trigger does.
     function survey() {
         for (let i = 0; i < root.world.entities.length; ++i) {
             const launcher = root.world.entities[i];
+            const chosen = launcher.selectsTarget ? root.designated(launcher) : null;
             for (let j = 0; j < launcher.abilities.length; ++j) {
                 const slot = launcher.abilities[j];
                 if (!slot.guided)
                     continue;
-                const lock = root.bestReturn(launcher, launcher, launcher.side, slot.reach);
+                let lock = null;
+                let distant = false;
+                if (launcher.selectsTarget) {
+                    // The designation is judged by the same gates the auto
+                    // pick ranks over, against the one contact the pilot
+                    // named — and "too far for the round" keeps its own
+                    // answer, judged at the radar's own reach.
+                    if (chosen !== null && root.takeable(launcher, launcher, launcher.side, chosen, slot.reach))
+                        lock = chosen;
+                    distant = lock === null && chosen !== null && root.takeable(launcher, launcher, launcher.side, chosen, launcher.detectionRange);
+                } else {
+                    lock = root.bestReturn(launcher, launcher, launcher.side, slot.reach);
+                    // Nothing to take inside the envelope, but something out
+                    // past it: "close the range" and "point at something" are
+                    // different instructions, so the rack gets to tell them
+                    // apart.
+                    distant = lock === null && root.bestReturn(launcher, launcher, launcher.side, launcher.detectionRange) !== null;
+                }
                 // Written only where it changes: a lock repinned in place
                 // every tick flickers every binding on it, and restarts the
                 // animations gated by them — the same care SystemThreat's
                 // mark pass takes.
                 if (slot.lock !== lock)
                     slot.lock = lock;
-                // Nothing to take inside the envelope, but something out
-                // past it: "close the range" and "point at something" are
-                // different instructions, so the rack gets to tell them apart.
-                const distant = lock === null && root.bestReturn(launcher, launcher, launcher.side, launcher.detectionRange) !== null;
                 if (slot.distant !== distant)
                     slot.distant = distant;
+                const undesignated = launcher.selectsTarget && launcher.targetContact === "";
+                if (slot.undesignated !== undesignated)
+                    slot.undesignated = undesignated;
             }
         }
+    }
+
+    // The world entity a launcher's designation names, or null. Selection is
+    // of a track, so the id resolves against the live world each tick and a
+    // spent contact simply stops resolving — no stale lock can publish.
+    function designated(launcher: Entity): Entity {
+        if (launcher.targetContact === "")
+            return null;
+        for (let i = 0; i < root.world.entities.length; ++i) {
+            if (root.world.entities[i].callsign === launcher.targetContact)
+                return root.world.entities[i];
+        }
+        return null;
     }
 
     // One round's tick: seek, trip the fuze on a near non-owning entity (or
@@ -246,6 +278,23 @@ System {
         }
     }
 
+    // Whether one return passes every gate a seeker needs — live, opposed,
+    // inside range, illuminated by the radar cone and in line of sight. The
+    // one definition the automatic pick ranks over and a designation is
+    // judged by, so the two policies can never disagree about what is
+    // takeable.
+    function takeable(at: Entity, illuminator: Entity, side: int, contact: Entity, range: real): bool {
+        if (contact === at || contact === illuminator || contact.health <= 0)
+            return false;
+        if (!root.opposed(side, contact.side))
+            return false;
+        if (Geo.distance(at, contact) > range || !root.illuminated(illuminator, contact))
+            return false;
+        // The seeker is a radar receiver too: a return behind a pillar
+        // reaches neither it nor the illuminator.
+        return Geo.lineOfSight(at, contact, root.world.obstacles);
+    }
+
     // The loudest opposed live return within range of at, gated by the
     // illuminator's radar cone; ties break to the nearest — the tie a craft
     // and its own flare are always in, so range alone decides between them
@@ -255,17 +304,9 @@ System {
         let bestDist = 0;
         for (let i = 0; i < root.world.entities.length; ++i) {
             const contact = root.world.entities[i];
-            if (contact === at || contact === illuminator || contact.health <= 0)
-                continue;
-            if (!root.opposed(side, contact.side))
+            if (!root.takeable(at, illuminator, side, contact, range))
                 continue;
             const d = Geo.distance(at, contact);
-            if (d > range || !root.illuminated(illuminator, contact))
-                continue;
-            // The seeker is a radar receiver too: a return behind a pillar
-            // reaches neither it nor the illuminator.
-            if (!Geo.lineOfSight(at, contact, root.world.obstacles))
-                continue;
             if (best === null || contact.stealth < best.stealth || (contact.stealth === best.stealth && d < bestDist)) {
                 best = contact;
                 bestDist = d;

--- a/app/briarthorn/qml/ui/AbilityButton.qml
+++ b/app/briarthorn/qml/ui/AbilityButton.qml
@@ -229,6 +229,15 @@ Item {
         }
     }
 
+    // The tap-sink (briardart's range-control lesson): the point handler
+    // below takes only a passive grab, and the scope's mark hit areas listen
+    // under the whole display — a control standing over the picture takes the
+    // tap's exclusive grab, or one press fires the button and designates the
+    // mark behind it.
+    TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+    }
+
     // A single point, grabbed on press and held until release — no drag
     // threshold, so the control fires the moment it is touched, and its own
     // point, so a thumb here and one on the stick work at the same time.

--- a/app/briarthorn/qml/ui/AbilityButton.qml
+++ b/app/briarthorn/qml/ui/AbilityButton.qml
@@ -70,6 +70,8 @@ Item {
             return qsTr("NO LOCK");
         case AbilitySlot.Impediment.Distant:
             return qsTr("RANGE");
+        case AbilitySlot.Impediment.NoTarget:
+            return qsTr("NO TARGET");
         default:
             return "";
         }

--- a/app/briarthorn/qml/ui/Joystick.qml
+++ b/app/briarthorn/qml/ui/Joystick.qml
@@ -111,6 +111,14 @@ Item {
     // tracking is also delivered as a synthetic left-button press, which
     // de-activates the handler under the held thumb — and a release is what
     // returns the stick to rest, so the ship would drop to neutral mid-turn.
+
+    // The tap-sink: the point handler takes only a passive grab, and the
+    // scope's mark hit areas listen under the whole display — a thumb landing
+    // here must not also designate a gutter-clamped mark behind the pad.
+    TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+    }
+
     PointHandler {
         id: handler
         acceptedButtons: Qt.NoButton

--- a/app/briarthorn/qml/ui/TouchArrow.qml
+++ b/app/briarthorn/qml/ui/TouchArrow.qml
@@ -68,6 +68,14 @@ Item {
     // which de-activates the handler and re-activates it under the one finger
     // — and this control steps a setting on that rising edge, so a single tap
     // would range twice and run the picture to its stop.
+
+    // The tap-sink: the point handler takes only a passive grab, and the
+    // scope's mark hit areas listen under the whole display — a ranging tap
+    // must not also designate the mark behind the disc.
+    TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+    }
+
     PointHandler {
         id: handler
         acceptedButtons: Qt.NoButton

--- a/app/briarthorn/qml/ui/ViewArming.qml
+++ b/app/briarthorn/qml/ui/ViewArming.qml
@@ -111,4 +111,11 @@ Item {
         NumberAnimation { from: 1; to: 0.4; duration: 300 }
         NumberAnimation { from: 0.4; to: 1; duration: 300 }
     }
+
+    // The tap-sink: the panel stands over the scope's upper sector, and the
+    // mark hit areas listen under the whole display — a press on the readout
+    // must not designate whatever flies behind it.
+    TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+    }
 }

--- a/app/briarthorn/qml/ui/ViewArming.qml
+++ b/app/briarthorn/qml/ui/ViewArming.qml
@@ -36,6 +36,8 @@ Item {
             return qsTr("NO TARGET IN RADAR VOLUME");
         case AbilitySlot.Impediment.Distant:
             return qsTr("TARGET OUT OF MISSILE RANGE");
+        case AbilitySlot.Impediment.NoTarget:
+            return qsTr("NO TARGET SELECTED");
         default:
             return root.slot.lock !== null ? qsTr("LOCK %1").arg(root.slot.lock.callsign) : qsTr("CLEAR TO FIRE");
         }

--- a/app/briarthorn/qml/ui/ViewHints.qml
+++ b/app/briarthorn/qml/ui/ViewHints.qml
@@ -13,7 +13,7 @@ Text {
     // craft on entirely different controls.
     required property ActiveDevice device
 
-    text: root.device.pad ? qsTr("LEFT STICK fly · D-PAD range · START pause") : qsTr("W/S throttle · A/D turn · WHEEL range · ESC pause")
+    text: root.device.pad ? qsTr("LEFT STICK fly · D-PAD range · Y/LB target · START pause") : qsTr("W/S throttle · A/D turn · TAB target · WHEEL range · ESC pause")
     color: Style.theme.textMuted
     elide: Text.ElideRight // the caller caps width where the line would collide
     font { pixelSize: 12; family: Style.monospace }

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -78,6 +78,10 @@ Item {
     // brackets nothing.
     property string lockedContact: ""
 
+    // The pilot's designated contact, by track id; the cursor stands on that
+    // one mark. Empty selects nothing.
+    property string selectedContact: ""
+
     // Heading-up turns the whole picture so ownship's nose is 12 o'clock; false
     // leaves it north-up. The rotation the track picture carries.
     property bool headingUp: true
@@ -308,6 +312,7 @@ Item {
         symbolSize: root.symbolSize
         symbolStrokeWidth: root.symbolStrokeWidth
         lockedContact: root.lockedContact
+        selectedContact: root.selectedContact
         showLabels: root.showTrackLabels
         showHealth: root.showTrackHealth
         showRanges: root.showTrackRanges

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -84,8 +84,10 @@ Item {
     // menu backdrop leave it off and carry no handlers at all.
     property bool selectionEnabled: false
 
-    // A tap on a selectable mark, by track id, forwarded off the track layer.
+    // A tap on a selectable mark, by track id, forwarded off the track layer;
+    // trackTouched rides with it when the tap came from a touchscreen.
     signal trackTapped(string contactId)
+    signal trackTouched
 
     // Heading-up turns the whole picture so ownship's nose is 12 o'clock; false
     // leaves it north-up. The rotation the track picture carries.
@@ -320,6 +322,7 @@ Item {
         shootableContact: root.shootableContact
         selectionEnabled: root.selectionEnabled
         onTrackTapped: contactId => root.trackTapped(contactId)
+        onTrackTouched: root.trackTouched()
         showLabels: root.showTrackLabels
         showHealth: root.showTrackHealth
         showRanges: root.showTrackRanges

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -74,13 +74,11 @@ Item {
     property real armedReach: 0
     property bool armedValid: false
 
-    // The contact the armed weapon's seeker is holding, by track id; empty
-    // brackets nothing.
-    property string lockedContact: ""
-
-    // The pilot's designated contact, by track id; the cursor stands on that
-    // one mark. Empty selects nothing.
+    // The pilot's designated contact, by track id, and the contact a guided
+    // launch would take right now. The cursor stands on the first and turns
+    // its latched colour where the second agrees; both empty mark nothing.
     property string selectedContact: ""
+    property string shootableContact: ""
 
     // Whether a tap on a selectable mark designates it; the minimap and the
     // menu backdrop leave it off and carry no handlers at all.
@@ -318,8 +316,8 @@ Item {
         tracks: root.tracks
         symbolSize: root.symbolSize
         symbolStrokeWidth: root.symbolStrokeWidth
-        lockedContact: root.lockedContact
         selectedContact: root.selectedContact
+        shootableContact: root.shootableContact
         selectionEnabled: root.selectionEnabled
         onTrackTapped: contactId => root.trackTapped(contactId)
         showLabels: root.showTrackLabels

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -82,6 +82,13 @@ Item {
     // one mark. Empty selects nothing.
     property string selectedContact: ""
 
+    // Whether a tap on a selectable mark designates it; the minimap and the
+    // menu backdrop leave it off and carry no handlers at all.
+    property bool selectionEnabled: false
+
+    // A tap on a selectable mark, by track id, forwarded off the track layer.
+    signal trackTapped(string contactId)
+
     // Heading-up turns the whole picture so ownship's nose is 12 o'clock; false
     // leaves it north-up. The rotation the track picture carries.
     property bool headingUp: true
@@ -313,6 +320,8 @@ Item {
         symbolStrokeWidth: root.symbolStrokeWidth
         lockedContact: root.lockedContact
         selectedContact: root.selectedContact
+        selectionEnabled: root.selectionEnabled
+        onTrackTapped: contactId => root.trackTapped(contactId)
         showLabels: root.showTrackLabels
         showHealth: root.showTrackHealth
         showRanges: root.showTrackRanges

--- a/app/briarthorn/qml/ui/ViewTerrain.qml
+++ b/app/briarthorn/qml/ui/ViewTerrain.qml
@@ -88,4 +88,11 @@ Item {
             duration: 240
         }
     }
+
+    // The tap-sink: the warning stands over the scope's upper sector, and the
+    // mark hit areas listen under the whole display — a press on it must not
+    // designate whatever flies behind it.
+    TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+    }
 }

--- a/app/briarthorn/qml/ui/ViewThreat.qml
+++ b/app/briarthorn/qml/ui/ViewThreat.qml
@@ -77,4 +77,11 @@ Item {
             duration: 320
         }
     }
+
+    // The tap-sink: the warning stands over the scope's upper sector, and the
+    // mark hit areas listen under the whole display — a press on it must not
+    // designate whatever flies behind it.
+    TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+    }
 }

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -57,6 +57,14 @@ Item {
     // one mark. Empty selects nothing.
     property string selectedContact: ""
 
+    // Whether a tap on a selectable mark designates it. Off by default, so
+    // the minimap and the menu backdrop carry no handlers at all.
+    property bool selectionEnabled: false
+
+    // A tap on a selectable mark, by track id. The picture stays a display —
+    // the caller posts the designation, this only reports the tap.
+    signal trackTapped(string contactId)
+
     // When positive, off-scale contacts clamp to this pixel radius (the outer
     // ring) instead of plotting beyond it, so ranging in seats a contact that
     // no longer fits at the edge rather than losing it off the display.
@@ -189,6 +197,28 @@ Item {
             rotation: -root.viewRotation
             active: mark.selected
             sourceComponent: root.selectMark
+        }
+
+        // The mark's hit area, floored at a thumb target — the symbols draw
+        // far smaller than a finger. A TapHandler rather than the rack's
+        // PointHandler: its grab makes the topmost mark the only winner where
+        // two overlap, and it takes touch and mouse without the synthetic
+        // double-fire. The track guard covers the teardown window, as the
+        // mark's own bindings do.
+        Loader {
+            anchors.centerIn: parent
+            width: Math.max(44, mark.width * 1.4)
+            height: width
+            active: root.selectionEnabled && mark.track !== null && mark.track.selectable
+            sourceComponent: Item {
+                TapHandler {
+                    gesturePolicy: TapHandler.ReleaseWithinBounds
+                    onTapped: {
+                        if (mark.track !== null)
+                            root.trackTapped(mark.track.contactId);
+                    }
+                }
+            }
         }
     }
 

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -48,14 +48,13 @@ Item {
     // already being read off. Rides showLabels, since it hangs off the label.
     property bool showRanges: true
 
-    // The contact an armed weapon's seeker is holding, by track id; empty
-    // brackets nothing. Exactly one mark ever carries the reticle, so the
-    // scope answers "which one is the shot going to" without a legend.
-    property string lockedContact: ""
-
-    // The pilot's designated contact, by track id; the cursor stands on that
-    // one mark. Empty selects nothing.
+    // The pilot's designated contact and the contact a guided launch would
+    // take right now, both by track id. Exactly one mark ever carries the
+    // cursor — hunting-coloured while the selection cannot yet be taken,
+    // latched where the two ids agree — so the scope answers "which one is
+    // the shot going to" without a legend.
     property string selectedContact: ""
+    property string shootableContact: ""
 
     // Whether a tap on a selectable mark designates it. Off by default, so
     // the minimap and the menu backdrop carry no handlers at all.
@@ -85,29 +84,6 @@ Item {
         angle: root.viewRotation
     }
 
-    // The seeker's lock bracket: a screen-upright reticle standing off the one
-    // mark an armed weapon is holding, in the same colour the scope paints
-    // that weapon's envelope with.
-    readonly property Component lockMark: Component {
-        ShapeReticle {
-            gap: width * 0.3
-            armLength: width * 0.15
-            strokeColor: Style.theme.armValid
-            strokeWidth: Math.max(1.5, root.symbolStrokeWidth)
-        }
-    }
-
-    // The designation cursor: a screen-upright reticle on the contact the
-    // pilot has selected, in the hunting colour — the lock bracket, not this,
-    // says a shot would take it.
-    readonly property Component selectMark: Component {
-        ShapeReticle {
-            gap: width * 0.26
-            armLength: width * 0.18
-            strokeColor: Style.theme.cursorFree
-            strokeWidth: Math.max(1.5, root.symbolStrokeWidth)
-        }
-    }
 
     // One contact's mark: the classification symbol, plus the lock bracket on
     // the one contact carrying it. An Item rather than the bare Loader the
@@ -122,8 +98,8 @@ Item {
 
         readonly property real azimuth: mark.track ? mark.track.azimuth : 0
         readonly property real trueRange: mark.track ? mark.track.range * root.pxPerMeter : 0
-        readonly property bool locked: root.lockedContact !== "" && mark.track !== null && mark.track.contactId === root.lockedContact
         readonly property bool selected: root.selectedContact !== "" && mark.track !== null && mark.track.contactId === root.selectedContact
+        readonly property bool latched: mark.selected && mark.track.contactId === root.shootableContact
 
         // Range under the callsign, on resolved craft only: maxHealth is the
         // one field the sweep leaves at zero for a contact it has not resolved
@@ -175,28 +151,23 @@ Item {
             sourceComponent: mark.track && mark.track.classification === Classification.Kind.Decoy ? mark.flareMark : mark.symbolMark
         }
 
-        // The bracket, counter-rotated so it stands square to the screen the
-        // way the symbol's own label does, and loaded only on the locked mark
-        // — a dogfight plots far more contacts than it locks.
+        // The cursor: a screen-upright reticle counter-rotated the way the
+        // symbol's own label is, loaded only on the selected mark — a
+        // dogfight plots far more contacts than the pilot designates. Its
+        // colour is the designation's whole state: hunting while the rack
+        // cannot yet take the contact, latched the moment a launch would.
         Loader {
             anchors.centerIn: parent
             width: mark.width * 2.1
             height: width
             rotation: -root.viewRotation
-            active: mark.locked
-            sourceComponent: root.lockMark
-        }
-
-        // The cursor, standing a little wider than the bracket so the two
-        // read apart on a mark carrying both, and loaded only on the
-        // selected mark.
-        Loader {
-            anchors.centerIn: parent
-            width: mark.width * 2.6
-            height: width
-            rotation: -root.viewRotation
             active: mark.selected
-            sourceComponent: root.selectMark
+            sourceComponent: ShapeReticle {
+                gap: width * 0.3
+                armLength: width * 0.15
+                strokeColor: mark.latched ? Style.theme.cursorLatched : Style.theme.cursorFree
+                strokeWidth: Math.max(1.5, root.symbolStrokeWidth)
+            }
         }
 
         // The mark's hit area, floored at a thumb target — the symbols draw

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -61,8 +61,11 @@ Item {
     property bool selectionEnabled: false
 
     // A tap on a selectable mark, by track id. The picture stays a display —
-    // the caller posts the designation, this only reports the tap.
+    // the caller posts the designation, this only reports the tap. A tap from
+    // a touchscreen raises trackTouched with it, so the HUD can hand the
+    // interface to the touch controls as the rack does.
     signal trackTapped(string contactId)
+    signal trackTouched
 
     // When positive, off-scale contacts clamp to this pixel radius (the outer
     // ring) instead of plotting beyond it, so ranging in seats a contact that
@@ -175,18 +178,23 @@ Item {
         // PointHandler: its grab makes the topmost mark the only winner where
         // two overlap, and it takes touch and mouse without the synthetic
         // double-fire. The track guard covers the teardown window, as the
-        // mark's own bindings do.
+        // mark's own bindings do. The selected mark stays tappable even
+        // unresolved — the designation survives losing the contact's picture,
+        // so the tap that stands it down must survive with it.
         Loader {
             anchors.centerIn: parent
             width: Math.max(44, mark.width * 1.4)
             height: width
-            active: root.selectionEnabled && mark.track !== null && mark.track.selectable
+            active: root.selectionEnabled && mark.track !== null && (mark.track.selectable || mark.selected)
             sourceComponent: Item {
                 TapHandler {
                     gesturePolicy: TapHandler.ReleaseWithinBounds
-                    onTapped: {
-                        if (mark.track !== null)
-                            root.trackTapped(mark.track.contactId);
+                    onTapped: eventPoint => {
+                        if (mark.track === null)
+                            return;
+                        if (eventPoint.device.type === PointerDevice.TouchScreen)
+                            root.trackTouched();
+                        root.trackTapped(mark.track.contactId);
                     }
                 }
             }

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -53,6 +53,10 @@ Item {
     // scope answers "which one is the shot going to" without a legend.
     property string lockedContact: ""
 
+    // The pilot's designated contact, by track id; the cursor stands on that
+    // one mark. Empty selects nothing.
+    property string selectedContact: ""
+
     // When positive, off-scale contacts clamp to this pixel radius (the outer
     // ring) instead of plotting beyond it, so ranging in seats a contact that
     // no longer fits at the edge rather than losing it off the display.
@@ -85,6 +89,18 @@ Item {
         }
     }
 
+    // The designation cursor: a screen-upright reticle on the contact the
+    // pilot has selected, in the hunting colour — the lock bracket, not this,
+    // says a shot would take it.
+    readonly property Component selectMark: Component {
+        ShapeReticle {
+            gap: width * 0.26
+            armLength: width * 0.18
+            strokeColor: Style.theme.cursorFree
+            strokeWidth: Math.max(1.5, root.symbolStrokeWidth)
+        }
+    }
+
     // One contact's mark: the classification symbol, plus the lock bracket on
     // the one contact carrying it. An Item rather than the bare Loader the
     // symbol loads into, because a Loader's default property is the component
@@ -99,6 +115,7 @@ Item {
         readonly property real azimuth: mark.track ? mark.track.azimuth : 0
         readonly property real trueRange: mark.track ? mark.track.range * root.pxPerMeter : 0
         readonly property bool locked: root.lockedContact !== "" && mark.track !== null && mark.track.contactId === root.lockedContact
+        readonly property bool selected: root.selectedContact !== "" && mark.track !== null && mark.track.contactId === root.selectedContact
 
         // Range under the callsign, on resolved craft only: maxHealth is the
         // one field the sweep leaves at zero for a contact it has not resolved
@@ -160,6 +177,18 @@ Item {
             rotation: -root.viewRotation
             active: mark.locked
             sourceComponent: root.lockMark
+        }
+
+        // The cursor, standing a little wider than the bracket so the two
+        // read apart on a mark carrying both, and loaded only on the
+        // selected mark.
+        Loader {
+            anchors.centerIn: parent
+            width: mark.width * 2.6
+            height: width
+            rotation: -root.viewRotation
+            active: mark.selected
+            sourceComponent: root.selectMark
         }
     }
 


### PR DESCRIPTION
The player now designates the contact their guided weapons take, ported from briardart's cursor with the free-pan reticle deliberately dropped: the selection only ever sits on a track.

## What changed
- `Entity.selectsTarget` / `Entity.targetContact`: designation as an entity aspect. Ownship carries it; the menu demo's director designates through the same property, so one rule covers both.
- `CommandTarget` / `Verbs.target`: selection is player intent and rides the bus as a contactId string; `StoreGame` routes it onto the craft.
- `SystemWeapon.survey()`: a designating launcher locks its designated contact or nothing, judged by the same `takeable()` gates the automatic pick ranks over (extracted from `bestReturn`). AI craft keep automatic locks. `seek()` untouched — designation aims the launch, the seeker hunts on its own, so flares still work against the player's rounds.
- `AbilitySlot.Impediment.NoTarget` + `undesignated`: a press with nothing selected arms and holds, the readout says NO TARGET SELECTED, the rack says NO TARGET.
- Cycle input: Tab/Shift+Tab and pad Y/LB walk the selectable picture clockwise off the nose, wrapping; a fixed `target` keymap joins `reserved()`, and `load()` now drops saved rebinds the fixed maps have since claimed. Tab and Backtab are one physical key wearing the shift state, so releases clear both codes.
- Tap-on-track: per-mark TapHandler hit areas (thumb-floored) on the attack scope; a tap toggles the designation. Controls and readouts standing over the scope take the tap's exclusive grab so one press never fires a button and designates the mark behind it.
- The cursor: one `ShapeReticle` on the selected mark — `cursorFree` while the rack cannot yet take the contact, `cursorLatched` the moment a launch would — replacing the old armValid lock bracket (`lockedContact` chain renamed `shootableContact`). `SystemCue` tones on lock identity change, so re-designating between shootable contacts re-cues.
- `SystemDetection` stands down a designation naming no held track.

## Verification
- Headless qml.exe harness: 19 checks over the selection state machine (NoTarget/Distant/NoLock transitions, armed-hold spends nothing, held shot flies at the designation on validation, track-death stand-down, AI auto-lock untouched) — all pass; a second harness proves the menu demo still fires guided rounds under designation.
- ctest: 126/126.
- Driven in-app (screenshots): NO TARGET SELECTED armed-hold, amber cursor + RANGE beyond reach, TARGET OUT OF MISSILE RANGE hold, cyan latched cursor in reach, valid press firing at the designated bandit, tap-deselect and cycle-reselect.
- Release build clean (qmlcachegen over every new/changed file).
- Four-lens adversarial review; its confirmed findings (tap-through to marks under HUD controls, unreachable deselect on an unresolved contact, missing device-kind report from scope taps, double distance computation) are fixed in the last two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)