### PR TITLE
Stand anti-air batteries in the duel arena behind one-way screens

### DIFF
--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -67,6 +67,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/database/entities/DataAircraftFighter.qml
         qml/database/entities/DataAircraftFighterLight.qml
         qml/database/entities/DataDecoy.qml
+        qml/database/entities/DataSiteAntiAir.qml
         qml/database/entities/DataUnknown.qml
         qml/database/personalities/PersonalityAggressive.qml
         qml/database/personalities/PersonalityDefensive.qml
@@ -113,6 +114,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/systems/SystemMission.qml
         qml/systems/SystemMovement.qml
         qml/systems/SystemPersonality.qml
+        qml/systems/SystemSentry.qml
         qml/systems/SystemThreat.qml
         qml/systems/SystemWeapon.qml
         qml/themes/Theme.qml
@@ -132,6 +134,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/ui/ViewAlerts.qml
         qml/ui/ViewArming.qml
         qml/ui/ViewEnd.qml
+        qml/ui/ViewEmplacements.qml
         qml/ui/ViewEngagements.qml
         qml/ui/ViewHints.qml
         qml/ui/ViewHudOverlay.qml
@@ -149,6 +152,7 @@ awen_add_executable(${PROJECT_NAME}
         qml/ui/ViewTerrain.qml
         qml/ui/ViewThreat.qml
         qml/ui/ViewTopBar.qml
+        qml/ui/ViewTracked.qml
         qml/ui/ViewTrackList.qml
         qml/ui/ViewTracks.qml
         qml/ui/ViewTrails.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -546,6 +546,11 @@ Window {
                 obstacles: root.world.obstacles
             }
 
+            SystemSentry {
+                entities: root.entities
+                obstacles: root.world.obstacles
+            }
+
             SystemEngage {
                 entities: root.entities
                 obstacles: root.world.obstacles

--- a/app/briarthorn/qml/database/Classification.qml
+++ b/app/briarthorn/qml/database/Classification.qml
@@ -14,6 +14,7 @@ QtObject {
         MissileKinetic,
         Decoy,
         AircraftFighterLight,
+        SiteAntiAir,
         Count
     }
 }

--- a/app/briarthorn/qml/database/Database.qml
+++ b/app/briarthorn/qml/database/Database.qml
@@ -20,6 +20,7 @@ QtObject {
         DataAircraftFighter {},
         DataAircraftFighterLight {},
         DataDecoy {},
+        DataSiteAntiAir {},
         // Munitions.
         DataMissileGuided {},
         DataMissileKinetic {}

--- a/app/briarthorn/qml/database/GameRules.qml
+++ b/app/briarthorn/qml/database/GameRules.qml
@@ -51,6 +51,14 @@ QtObject {
     // compute buys a guided seeker's acquisition range (m).
     readonly property real maxGuidedRange: 150000
 
+    // How much of its radar volume a battery will shoot into. A search set
+    // reaches far past what the round on the rail can catch — pure pursuit
+    // takes reach * speed / (speed^2 - target^2) seconds, so a 64 s round
+    // making 800 m/s runs out at 31 km against a craft fleeing at 500 —
+    // and a rack emptied at the rim is a battery that has disarmed itself.
+    // The rest of the volume is where a track is followed but not fired on.
+    readonly property real sentryFireFraction: 0.65
+
     // How far up its range a rating sits, clamped to [0, 1] — every rule
     // below is this fraction of the matching span.
     function fraction(stat: real): real {
@@ -90,6 +98,13 @@ QtObject {
 
     function detectionRangeFor(sensor: real): real {
         return root.maxDetectionRange * root.fraction(sensor);
+    }
+
+    // The range inside which a battery of a given radar volume opens fire —
+    // the ring the scope draws and the one SystemSentry gates the trigger on,
+    // so the picture and the rule can never disagree.
+    function sentryFireRangeFor(detectionRange: real): real {
+        return detectionRange * root.sentryFireFraction;
     }
 
     function guidedRangeFor(compute: real): real {

--- a/app/briarthorn/qml/database/entities/DataSiteAntiAir.qml
+++ b/app/briarthorn/qml/database/entities/DataSiteAntiAir.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import ".."
+
+// The anti-air site: a dug-in missile battery whose radar dish is the
+// entity's own heading — SystemSentry sweeps it and locks what the volume
+// catches, and the guided rack fires through the same engage machinery a
+// fighter's does. kinetic 0 pins it in place and zeroes its fuel burn while
+// the maneuver rating still prices the dish's turn.
+DataEntity {
+    id: root
+
+    classification: Classification.Kind.SiteAntiAir
+    // A squat ground pentagon with a nose: asymmetric on purpose, so the
+    // mark's rotation reads as the sweep on the scope.
+    outline: [Qt.point(0, -0.5), Qt.point(0.38, -0.05), Qt.point(0.24, 0.45), Qt.point(-0.24, 0.45), Qt.point(-0.38, -0.05)]
+    label: qsTr("SAM")
+    symbolScale: 0.9
+    hullGauge: true
+
+    // The wedge the dish paints. Narrow, or the sweep stops meaning anything:
+    // the volume is a searchlight, not a floodlight.
+    radarFov: 40
+
+    stats: Stats {
+        kinetic: 0
+        maneuver: 6
+        durable: 5
+        compute: 6
+        // The search volume: 42 km, and the engagement lobe GameRules prices
+        // off it, 27 km. This is the one knob that sizes a battery, and what
+        // caps it is how thickly they are seeded rather than what one set
+        // could do: a lobe wider than half the spacing between neighbours
+        // meets the next one and leaves no flyable ground between them. The
+        // duel stands four of them 70 km apart, which puts that ceiling at a
+        // rating of 4.5 — reach here is bought by standing further out, and
+        // moving them back in again costs it straight back.
+        sensor: 3.5
+        // Exactly a fighter's loudness, so a player round with both the site
+        // and the bandit illuminated takes whichever is nearer rather than
+        // systematically deserting one shot for the other.
+        stealth: 5
+    }
+
+    abilities: ["guided"]
+}

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -85,6 +85,14 @@ QtObject {
     // down a designation naming no held track.
     property string targetContact: ""
 
+    // SystemSentry sweeps this entity's radar and locks what the volume
+    // catches: engageTarget becomes radar state, held while the volume holds
+    // and null while the antenna searches. A sentry must never also carry a
+    // director — it owns engageTarget too — nor a personality, whose
+    // maneuvers would fight the slew for commandedSteer and whose stances
+    // rewrite the engageHoldoff pacing.
+    property bool sentry: false
+
     // SystemThreat pops this entity's flares at inbound guided rounds; the
     // timer spaces the pops so each decoy gets its chance to seduce.
     property bool threatReflex: false

--- a/app/briarthorn/qml/model/Geo.qml
+++ b/app/briarthorn/qml/model/Geo.qml
@@ -64,9 +64,16 @@ QtObject {
     // pillar — the one radar line-of-sight test the sensor, seeker and
     // trigger gates all share. A pillar cuts the line when the segment's
     // closest point to its centre falls inside its radius.
+    //
+    // Judged from @p a, always: every caller passes the sensing party first —
+    // the observer, the illuminator, the seeker head, the craft being shot at
+    // — so a piece transparent to that side simply is not there, and the same
+    // ground can block one side's radar while the other shoots through it.
     function lineOfSight(a: Entity, b: Entity, obstacles: list<Obstacle>): bool {
         for (let i = 0; i < obstacles.length; ++i) {
             const o = obstacles[i];
+            if (!o.opaqueTo(a))
+                continue;
             const dx = b.posX - a.posX;
             const dy = b.posY - a.posY;
             const len2 = dx * dx + dy * dy;

--- a/app/briarthorn/qml/model/Obstacle.qml
+++ b/app/briarthorn/qml/model/Obstacle.qml
@@ -12,4 +12,24 @@ QtObject {
 
     // The disc's radius, metres.
     property real radius: 1000
+
+    // The side whose air defences this piece is keyed to; Unknown — the
+    // default — is plain rock, in everyone's way. A battery's screens name
+    // its own side, so the set behind them shoots out through ground the
+    // attacker can neither see nor shoot through, which is the whole point
+    // of a screen.
+    property int transparentTo: Side.Kind.Unknown
+
+    // Whether this piece stands in a given entity's way, for sight and for
+    // passage both — a barrier that stopped a round it could not see would be
+    // two rules wearing one name. Only the network that keeps a screen sees
+    // through it: the batteries of its side and the rounds they launch. That
+    // side's own aircraft are blocked like anyone else, because a fighter
+    // that could vanish behind one while still shooting out of it would be
+    // unkillable rather than defended.
+    function opaqueTo(entity: Entity): bool {
+        if (entity.side !== root.transparentTo)
+            return true;
+        return !(entity.sentry || (entity.owner !== null && entity.owner.sentry));
+    }
 }

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -23,7 +23,11 @@ Scenario {
     // 85 km split seats each craft 13 km beyond the other's 72 km radar, so
     // the contact opens Unknown and resolves about twenty seconds in rather
     // than after two minutes of empty sky.
-    readonly property real ownshipPosX: 12000
+    //
+    // On the meridian, not offset off it: with batteries on the diagonals the
+    // safe ground is the cardinal lanes between them, and opening in one is
+    // what makes the arena's shape teachable from the first second.
+    readonly property real ownshipPosX: 0
     readonly property real ownshipPosY: 42500
     readonly property real ownshipHeading: 0
 
@@ -35,13 +39,13 @@ Scenario {
         callsign: "BANDIT 1"
         classification: Classification.Kind.AircraftFighterLight
         side: Side.Kind.Hostile
-        // Seated 12 km east of true north, mirroring the player. Both closing
-        // lines then clear every pillar: 12 km abeam the 6 km cardinals and
-        // 9 km abeam the 3 km intercardinals, against the 2 km SystemAvoidance
-        // holds outside a wall. That margin has to come from the seat, because
-        // avoidance skips an entity with no maneuvers — the player's craft —
-        // so a lane the bandit would be steered around is one the player flies
-        // into.
+        // Seated on the meridian, mirroring the player. The walls sit on it
+        // too, 17.5 km past each opening mark, so the closing lines run clear
+        // of everything and only a craft that keeps running meets one — the
+        // bandit gets turned by SystemAvoidance, the player gets TERRAIN,
+        // since avoidance skips an entity with no maneuvers. The batteries
+        // are the bandit's own, so it flies this lane untroubled by the lobes
+        // the player has to stay between.
         posX: root.ownshipPosX
         posY: -root.ownshipPosY
         heading: 180
@@ -60,24 +64,115 @@ Scenario {
         ]
     }
 
-    // The live bandit. reset() owns the swap.
+    // An anti-air battery standing where a pillar stood: a sentry the shared
+    // systems run whole — SystemSentry sweeps and locks, SystemEngage fires,
+    // and its rounds ride its own illumination, so masking the dish blinds
+    // them. Four rounds paced well apart, so a full transit of a lobe eats
+    // the whole rack rather than one salvo.
+    component DuelSite: Entity {
+        classification: Classification.Kind.SiteAntiAir
+        side: Side.Kind.Hostile
+        sentry: true
+        engageHoldoff: 14
+
+        abilities: [
+            AbilitySlot {
+                def: Abilities.defFor("guided")
+                charges: 4
+            }
+        ]
+    }
+
+    // The live bandit and batteries. reset() owns the swaps.
     property Entity bandit: DuelBandit {}
+    property list<Entity> sites: root.makeSites()
 
     readonly property Component banditFactory: Component {
         DuelBandit {}
     }
 
-    entities: [root.bandit]
+    readonly property Component siteFactory: Component {
+        DuelSite {}
+    }
 
-    // The arena: four large pillars boxing the fight at 60 km on the
-    // cardinals and four smaller ones on the intercardinals at 30 km, so the
-    // north-south opening lane stays flyable. Static terrain, so reset()
-    // never touches it.
+    entities: [root.bandit, ...root.sites]
+
+    // Where the batteries sit: on the four intercardinals, 50 km out. Standing
+    // them that far apart — 70 km between neighbours — is what buys the reach,
+    // since a lobe may not exceed half the spacing without meeting the next
+    // one and leaving the arena with no flyable ground (see DataSiteAntiAir).
+    //
+    // The shape that falls out is the whole level design. A 22.7 km bubble at
+    // the centre where the two craft merge, unwatched by anything; four lobes
+    // out on the diagonals; and four lanes on the cardinals between them,
+    // 16 km wide, each gated at its far end by one of the 6 km walls. The
+    // lanes run inside the searches and outside the engagements, so a dish
+    // swings onto a craft flying one and holds it the whole way without a
+    // shot — every approach is watched, and only leaving the lane is paid for.
+    readonly property list<real> siteBearings: [45, 135, 225, 315]
+    readonly property real siteRange: 50000
+
+    // Each battery's screens: three discs ringing it, transparent to its own
+    // side and solid to everyone else. They are what makes a battery hard to
+    // kill rather than hard to survive — it shoots out through them freely
+    // while an attacker can neither see nor shoot through, so a strike has to
+    // be flown into one of the three gaps between them. Nine km out and four
+    // across leaves each gap about 67 degrees wide: enough to find, not
+    // enough to stumble into.
+    readonly property int screenCount: 3
+    readonly property real screenRange: 9000
+    readonly property real screenRadius: 4000
+
+    // The batteries, seated on those bearings and opened each pointed a
+    // quarter turn from the last, so the four sweeps never march together.
+    function makeSites(): list<Entity> {
+        const built = [];
+        for (let i = 0; i < root.siteBearings.length; ++i) {
+            const bearing = root.siteBearings[i];
+            built.push(root.siteFactory.createObject(root, {
+                callsign: "SAM " + (i + 1),
+                posX: Geo.offsetX(bearing, root.siteRange),
+                posY: Geo.offsetY(bearing, root.siteRange),
+                heading: i * 90
+            }) as Entity);
+        }
+        return built;
+    }
+
+    // The arena's terrain: the four big walls on the cardinals at 60 km, one
+    // gating the far end of each lane, plus the screens ringing each battery.
+    // Nothing else — the middle of the arena is defended rather than solid,
+    // so a lock is broken by leaving the lobe rather than by hiding in it,
+    // and the only cover that exists is cover the enemy shoots through.
+    // Static, so reset() never touches it.
     readonly property Component pillarFactory: Component {
         Obstacle {}
     }
 
-    obstacles: [...root.pillarRing(4, 0, 60000, 6000), ...root.pillarRing(4, 45, 30000, 3000)]
+    obstacles: [...root.pillarRing(4, 0, 60000, 6000), ...root.makeScreens()]
+
+    // The screens, three to a battery. The first faces the arena centre —
+    // where an attacker comes from — and the others space out from it, so the
+    // gaps a shot has to be lined up through are never on the obvious
+    // approach. They are the battery's own, so it neither sees nor flies into
+    // them; everything else does.
+    function makeScreens(): list<Obstacle> {
+        const built = [];
+        for (let i = 0; i < root.siteBearings.length; ++i) {
+            const seatX = Geo.offsetX(root.siteBearings[i], root.siteRange);
+            const seatY = Geo.offsetY(root.siteBearings[i], root.siteRange);
+            for (let j = 0; j < root.screenCount; ++j) {
+                const around = root.siteBearings[i] + 180 + j * 360 / root.screenCount;
+                built.push(root.pillarFactory.createObject(root, {
+                    posX: seatX + Geo.offsetX(around, root.screenRange),
+                    posY: seatY + Geo.offsetY(around, root.screenRange),
+                    radius: root.screenRadius,
+                    transparentTo: Side.Kind.Hostile
+                }) as Obstacle);
+            }
+        }
+        return built;
+    }
 
     // count pillars of one radius, evenly spaced around the origin at range,
     // the first seated at startBearing.
@@ -94,16 +189,18 @@ Scenario {
         return ring;
     }
 
-    // Replaces the bandit with a factory-fresh one — QML's constructor — so a
-    // duel entered from the menu always opens the same fight, with nothing to
-    // restore field by field, and seats the player's craft at its opening
-    // mark. Ownship is the store's, rebuilt just before this runs, so its
-    // initial conditions are set here rather than declared on a spawn site.
-    // The caller re-enrolls the scenario's entities.
+    // Replaces the bandit and the batteries with factory-fresh ones — QML's
+    // constructor — so a duel entered from the menu always opens the same
+    // fight, with nothing to restore field by field, and seats the player's
+    // craft at its opening mark. Ownship is the store's, rebuilt just before
+    // this runs, so its initial conditions are set here rather than declared
+    // on a spawn site. The caller re-enrolls the scenario's entities.
     function reset() {
-        const spent = root.bandit;
+        const spent = [root.bandit, ...root.sites];
         root.bandit = root.banditFactory.createObject(root) as Entity;
-        spent.destroy();
+        root.sites = root.makeSites();
+        for (let i = 0; i < spent.length; ++i)
+            spent[i].destroy();
 
         root.ownship.posX = root.ownshipPosX;
         root.ownship.posY = root.ownshipPosY;

--- a/app/briarthorn/qml/systems/SystemAvoidance.qml
+++ b/app/briarthorn/qml/systems/SystemAvoidance.qml
@@ -58,6 +58,10 @@ System {
         let nearestEntry = Infinity;
         for (let i = 0; i < root.obstacles.length; ++i) {
             const pillar = root.obstacles[i];
+            // Ground this craft passes through is nothing to turn for, and
+            // nothing to warn about either.
+            if (!pillar.opaqueTo(entity))
+                continue;
             const dx = pillar.posX - entity.posX;
             const dy = pillar.posY - entity.posY;
             const along = dx * ux + dy * uy;

--- a/app/briarthorn/qml/systems/SystemCollision.qml
+++ b/app/briarthorn/qml/systems/SystemCollision.qml
@@ -16,6 +16,10 @@ System {
             const pillar = root.world.obstacles[i];
             for (let j = 0; j < root.world.entities.length; ++j) {
                 const entity = root.world.entities[j];
+                // A piece a craft sees through is no wall to it either — a
+                // battery's own rounds leave the rail through its screens.
+                if (!pillar.opaqueTo(entity))
+                    continue;
                 if (entity.health > 0 && Geo.distanceFrom(entity.posX, entity.posY, pillar.posX, pillar.posY) <= pillar.radius)
                     entity.health = 0;
             }

--- a/app/briarthorn/qml/systems/SystemEngage.qml
+++ b/app/briarthorn/qml/systems/SystemEngage.qml
@@ -29,10 +29,14 @@ System {
     function update(dt: real) {
         for (let i = 0; i < root.entities.length; ++i) {
             const entity = root.entities[i];
-            if (entity.engageTarget === null || entity.engageHold)
+            if (entity.engageHold)
                 continue;
+            // The pacing runs in wall time, target or none — a sentry that
+            // fired just before losing its lock must telegraph a later
+            // re-engagement exactly like a first, not fire off the frozen
+            // remainder of the old holdoff.
             entity.engageTimer = Math.max(0, entity.engageTimer - dt);
-            if (entity.engageTimer > 0 || entity.engageTarget.health <= 0)
+            if (entity.engageTarget === null || entity.engageTimer > 0 || entity.engageTarget.health <= 0)
                 continue;
             if (Geo.distance(entity, entity.engageTarget) > root.engageRange)
                 continue;

--- a/app/briarthorn/qml/systems/SystemSentry.qml
+++ b/app/briarthorn/qml/systems/SystemSentry.qml
@@ -1,0 +1,153 @@
+import awen.entity
+import "../database"
+import "../model"
+
+// The sentry radar: every entity carrying the sentry aspect either sweeps —
+// full deflection, so the maneuver rating alone prices the revolution — or
+// slews onto the target its volume caught. The radar state is engageTarget
+// itself: null is the search, a target is the track, and every consequence
+// follows from machinery that already exists — SystemEngage fires at it,
+// SystemWeapon illuminates rounds down the same nose, and dropping it back
+// to null is what "resumes the sweep" means, from wherever the slew left
+// the antenna pointed.
+//
+// A track is not yet a shot: the search volume reaches far past what the
+// round on the rail can catch, so the trigger is held on engageHold until
+// the track is inside the engagement ring GameRules prices. A craft is
+// followed across the whole volume and fired on only in its heart.
+//
+// Runs before SystemEngage so the trigger sees this tick's track — the fresh
+// engageTarget and its grace-floored pacing; the wedge itself is judged
+// against last tick's heading, since SystemMovement integrates the slew
+// after the trigger runs.
+System {
+    id: root
+
+    // The world's roster; entities without the aspect are passed over.
+    property list<Entity> entities
+
+    // The arena geometry radar cannot see through.
+    property list<Obstacle> obstacles
+
+    // Degrees off the nose at which the tracking slew saturates — a seeker's
+    // cut, tighter than a flown maneuver's.
+    readonly property real cutAngle: 20
+
+    // Seconds every fresh lock telegraphs before the first launch: the pacing
+    // timer is floored to this on the acquire edge, so a re-lock can never
+    // fire the tick it lands however long the last track ran the timer down.
+    property real grace: 3
+
+    // The hold volume stretches this far past the acquisition volume in
+    // range and wedge both, so a target riding a rim crosses one edge going
+    // out and another coming back in rather than flickering the lock on one.
+    property real holdMargin: 1.08
+
+    function update(dt: real) {
+        for (let i = 0; i < root.entities.length; ++i) {
+            const entity = root.entities[i];
+            if (!entity.sentry)
+                continue;
+            if (entity.health <= 0) {
+                // Backstop for a scripted health write: an in-game kill
+                // despawns the site inside SystemWeapon the same tick, so
+                // this branch never sees one — but a corpse left enrolled
+                // must still hold nothing and intend nothing.
+                if (entity.engageTarget !== null)
+                    entity.engageTarget = null;
+                root.standDown(entity);
+                continue;
+            }
+            const next = root.tracked(entity);
+            if (entity.engageTarget !== next) {
+                // Every change of track stands the rack down first — a track
+                // handed straight from one target to another never passes
+                // null, and intent armed against the old target must not
+                // fire itself at the new one unpaced.
+                root.standDown(entity);
+                entity.engageTarget = next;
+                if (next !== null)
+                    entity.engageTimer = Math.max(entity.engageTimer, root.grace);
+            }
+            if (next !== null) {
+                const error = Geo.wrap180(Geo.bearing(entity, next) - entity.heading);
+                entity.commandedSteer = Math.max(-1, Math.min(1, error / root.cutAngle));
+                // Held out of the engagement ring, released inside it, with
+                // the same margin the track carries so the trigger does not
+                // chatter on the boundary. The hold freezes the pacing, so a
+                // lock's grace is spent where it matters: on the way in.
+                const fire = GameRules.sentryFireRangeFor(entity.detectionRange);
+                entity.engageHold = Geo.distance(entity, next) > (entity.engageHold ? fire : fire * root.holdMargin);
+            } else {
+                entity.commandedSteer = 1;
+                // Nothing to hold: the pacing runs down through the search so
+                // a battery that has been quiet opens on its own telegraph.
+                entity.engageHold = false;
+            }
+        }
+    }
+
+    // The contact the radar holds this tick: the held target while it stays
+    // inside the stretched volume, else whatever the acquisition volume
+    // catches, else null. Losing and catching in the same tick hands the
+    // track over without a sweep between — the dish is already pointing
+    // wherever that could be true.
+    function tracked(entity: Entity): Entity {
+        const held = entity.engageTarget;
+        if (held !== null && held.health > 0 && root.inVolume(entity, held, entity.detectionRange * root.holdMargin, root.holdMargin))
+            return held;
+        return root.acquire(entity);
+    }
+
+    // The nearest live opposed craft inside the acquisition volume — craft,
+    // not rounds or decoys: a search radar tracks intruders, and what a
+    // seeker prefers stays the seeker's business.
+    function acquire(entity: Entity): Entity {
+        let best = null;
+        let bestRange = Infinity;
+        for (let i = 0; i < root.entities.length; ++i) {
+            const contact = root.entities[i];
+            if (contact === entity || contact.health <= 0 || contact.weapon !== null || contact.decoy)
+                continue;
+            if (!root.opposed(entity.side, contact.side))
+                continue;
+            const range = Geo.distance(entity, contact);
+            if (range < bestRange && root.inVolume(entity, contact, entity.detectionRange, 1)) {
+                best = contact;
+                bestRange = range;
+            }
+        }
+        return best;
+    }
+
+    // The radar volume at a given reach: inside the wedge off the nose and in
+    // line of sight — the same three gates the sensor and trigger systems
+    // spell for themselves. The hold path passes its margin so the wedge
+    // stretches with the range and a target riding either edge crosses two
+    // thresholds rather than flickering the lock on one; sight has no soft
+    // edge — a shadow is entered, not drifted over.
+    function inVolume(entity: Entity, contact: Entity, reach: real, wedgeMargin: real): bool {
+        if (Geo.distance(entity, contact) > reach)
+            return false;
+        const off = Geo.wrap180(Geo.bearing(entity, contact) - entity.heading);
+        return Math.abs(off) <= wedgeMargin * entity.radarFov / 2 && Geo.lineOfSight(entity, contact, root.obstacles);
+    }
+
+    // Whether two sides shoot at each other: ownship and friendly versus
+    // hostile; unknowns and neutrals engage no one.
+    function opposed(a: int, b: int): bool {
+        const friend = s => s === Side.Kind.Ownship || s === Side.Kind.Friendly;
+        return (friend(a) && b === Side.Kind.Hostile) || (a === Side.Kind.Hostile && friend(b));
+    }
+
+    // No launch intent survives a change of track: a slot the trigger armed
+    // against a stale survey would otherwise fire itself at the next return
+    // the radar happens across — unpaced, and at the survey's own reach
+    // rather than the volume's.
+    function standDown(entity: Entity) {
+        for (let i = 0; i < entity.abilities.length; ++i) {
+            if (entity.abilities[i].armed)
+                entity.abilities[i].armed = false;
+        }
+    }
+}

--- a/app/briarthorn/qml/systems/SystemWeapon.qml
+++ b/app/briarthorn/qml/systems/SystemWeapon.qml
@@ -154,10 +154,17 @@ System {
     // seekerRange, and on the nearest of the returns that are equally loud —
     // which is what a flare exploits, wearing its deployer's signature so the
     // round takes whichever of the two it is closer to. No return leaves the
-    // round flying straight; a destroyed owner drops the illumination gate
-    // (plain homing).
+    // round flying straight; a destroyed owner blinds the round the same way
+    // a killed one does — every briarthorn round launches with an owner, so
+    // a null here can only mean the launcher is gone, and the illumination
+    // must go with it whether the corpse object survives or not.
     function seek(missile: Entity) {
         const w = missile.weapon;
+        if (missile.owner === null) {
+            w.target = null;
+            missile.commandedSteer = 0;
+            return;
+        }
         const best = root.bestReturn(missile, missile.owner, missile.side, w.def.seekerRange);
         w.target = best;
         if (best === null) {
@@ -302,6 +309,11 @@ System {
     function takeable(at: Entity, illuminator: Entity, side: int, contact: Entity): bool {
         if (contact === at || contact === illuminator || contact.health <= 0)
             return false;
+        // A round in flight is a receiver's problem, never a return worth a
+        // rail — a rack must not spend a charge intercepting a missile.
+        // Decoys stay takeable, which is the whole seduction mechanic.
+        if (contact.weapon !== null)
+            return false;
         if (!root.opposed(side, contact.side))
             return false;
         if (!root.illuminated(illuminator, contact))
@@ -353,10 +365,14 @@ System {
 
     // Whether the illuminator's radar cone paints the contact — inside the
     // cone with a clear line past the arena's pillars; a missing illuminator
-    // is lenient, per briardart.
+    // is lenient, per briardart. A killed one is not: its dish froze pointed
+    // wherever it died, and rounds riding a corpse's wedge would otherwise
+    // keep full guidance — killing the shooter must actually blind its shots.
     function illuminated(illuminator: Entity, contact: Entity): bool {
         if (illuminator === null)
             return true;
+        if (illuminator.maxHealth > 0 && illuminator.health <= 0)
+            return false;
         const off = Geo.wrap180(Geo.bearing(illuminator, contact) - illuminator.heading);
         return Math.abs(off) <= illuminator.radarFov / 2 && Geo.lineOfSight(illuminator, contact, root.world.obstacles);
     }

--- a/app/briarthorn/qml/ui/ViewAlerts.qml
+++ b/app/briarthorn/qml/ui/ViewAlerts.qml
@@ -1,19 +1,22 @@
 import QtQuick
 import "../model"
 
-// The alert channel: three readouts stacked in the order the pilot has to
+// The alert channel: four readouts stacked in the order the pilot has to
 // act — terrain first, because a missile can be beaten and a wall cannot;
-// the missile warning next; the arming readout last, since it answers a
-// press the other two interrupt. A Column rather than a chain of anchors, so
+// the missile warning next; the radar-lock warning under it, since a lock is
+// only the promise of a missile; the arming readout last, since it answers a
+// press the others interrupt. A Column rather than a chain of anchors, so
 // an alert that is not up takes no room and the ones below close over it.
 // Shared by both HUD compositions; the caller anchors it where its players
 // are already looking.
 Column {
     id: root
 
-    // The craft the readouts speak for, and the widest the arming panel may
-    // draw before its reason elides.
+    // The craft the readouts speak for, the roster the lock warning scans
+    // for sentries, and the widest the arming panel may draw before its
+    // reason elides.
     required property Entity ownship
+    property list<Entity> entities
     property real maximumWidth: -1
 
     spacing: 12
@@ -32,6 +35,15 @@ Column {
         anchors.horizontalCenter: parent.horizontalCenter
         visible: threatAlert.active
         ownship: root.ownship
+    }
+
+    ViewTracked {
+        id: trackedAlert
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        visible: trackedAlert.active
+        ownship: root.ownship
+        entities: root.entities
     }
 
     ViewArming {

--- a/app/briarthorn/qml/ui/ViewEmplacements.qml
+++ b/app/briarthorn/qml/ui/ViewEmplacements.qml
@@ -1,0 +1,148 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import awen.shapes
+import "../database"
+import "../model"
+import "../themes"
+
+// The known emplacements: every sentry radar drawn as the beam it is actually
+// sweeping — a wedge off the dish's own heading, shadow-cast behind the
+// pillars exactly as ownship's cone is, so the volume turns on the scope as
+// the antenna turns in the world. Two reaches nested in one beam: the faint
+// span is what the set can see, the bright core what it can shoot into, and
+// the fills stack so the dangerous half of a beam reads brighter without a
+// second outline anywhere.
+//
+// Drawn from ground truth rather than the track picture, on the same argument
+// the terrain layer draws pillars resolved at any range: these are fixed
+// installations on a mapped arena, and a sweep a pilot cannot see is a sweep
+// they cannot time. Where the dish is pointing is the whole tactical
+// question, so it is the one thing this layer exists to answer.
+Item {
+    id: root
+
+    // The observer at the scope centre, and the roster scanned for sentries.
+    property Entity observer
+    property list<Entity> entities
+
+    // The pillars the beams are cut by, as awen.shapes' {x, y, r} rows — the
+    // same set the terrain layer draws, so a bite always has its disc under it.
+    property var occluders: []
+
+    // Scope centre in item coordinates and the world-to-screen scale.
+    property real centerX: width / 2
+    property real centerY: height / 2
+    property real pxPerMeter: 0
+
+    // Screen rotation of the picture about the scope centre.
+    property real viewRotation: 0
+
+    // How much of the faction colour each reach is filled with. Low, and
+    // lower still for the search span: a beam is a volume to route around,
+    // never an alert competing with the marks that fly through it.
+    property real searchAlpha: 0.07
+    property real engagementAlpha: 0.11
+
+    // When positive, a beam draws only while it fits wholly inside this pixel
+    // radius — the minimap's backing disc, exactly as terrain culls.
+    property real cullRadius: 0
+
+    // The emplacements to draw. This rebuilds when the roster does — a spawn,
+    // a despawn — and never per tick; a killed battery leaves the roster, so
+    // its beam goes off the picture with it.
+    readonly property var sites: root.entities.filter(entity => entity.sentry)
+
+    // Whether a beam of this pixel reach fits wholly inside the mask — the
+    // terrain layer's own cull rule, applied to the disc the wedge sits in.
+    function fits(site: Entity, reach: real): bool {
+        if (root.cullRadius <= 0)
+            return true;
+        if (!root.observer)
+            return false;
+        return Math.hypot(site.posX - root.observer.posX, site.posY - root.observer.posY) * root.pxPerMeter + reach <= root.cullRadius;
+    }
+
+    transform: Rotation {
+        origin.x: root.centerX
+        origin.y: root.centerY
+        angle: root.viewRotation
+    }
+
+    Repeater {
+        model: root.sites
+
+        Item {
+            id: emplacement
+
+            required property Entity modelData
+
+            // Both reaches off the entity's own priced range rather than a
+            // database lookup, so a scenario that rates one battery
+            // differently draws it differently.
+            readonly property real searchReach: emplacement.modelData.detectionRange * root.pxPerMeter
+            readonly property real engagementReach: GameRules.sentryFireRangeFor(emplacement.modelData.detectionRange) * root.pxPerMeter
+            readonly property real screenX: root.observer ? root.centerX + (emplacement.modelData.posX - root.observer.posX) * root.pxPerMeter : 0
+            readonly property real screenY: root.observer ? root.centerY + (emplacement.modelData.posY - root.observer.posY) * root.pxPerMeter : 0
+
+            readonly property color beamColor: {
+                switch (emplacement.modelData.side) {
+                case Side.Kind.Hostile:
+                    return Style.theme.factionHostile;
+                case Side.Kind.Friendly:
+                case Side.Kind.Ownship:
+                    return Style.theme.factionFriendly;
+                default:
+                    return Style.theme.factionUnknown;
+                }
+            }
+
+            // What cuts THIS battery's beam: the pieces its own side does not
+            // see through. Its screens drop out, so the beam sweeps visibly
+            // straight through ground that bites the player's own cone — the
+            // asymmetry is on the scope rather than in a rule nobody sees.
+            readonly property var beamOccluders: root.occluders.filter(row => row.transparentTo !== emplacement.modelData.side)
+
+            visible: root.observer !== null
+
+            // The span it searches: where a craft is found and followed.
+            Loader {
+                anchors.fill: parent
+                active: emplacement.searchReach > 0 && root.fits(emplacement.modelData, emplacement.searchReach)
+
+                sourceComponent: ShapeSectorOccluded {
+                    centerX: emplacement.screenX
+                    centerY: emplacement.screenY
+                    angleAt: emplacement.modelData.heading
+                    angleSpan: emplacement.modelData.radarFov
+                    radius: emplacement.searchReach
+                    sourceX: emplacement.modelData.posX
+                    sourceY: emplacement.modelData.posY
+                    positionScale: root.pxPerMeter
+                    occluders: emplacement.beamOccluders
+                    fillColor: Qt.alpha(emplacement.beamColor, root.searchAlpha)
+                }
+            }
+
+            // The core it shoots into, laid over the span so the two fills
+            // stack: the brighter half of the beam is the half that kills.
+            Loader {
+                anchors.fill: parent
+                active: emplacement.engagementReach > 0 && root.fits(emplacement.modelData, emplacement.engagementReach)
+
+                sourceComponent: ShapeSectorOccluded {
+                    centerX: emplacement.screenX
+                    centerY: emplacement.screenY
+                    angleAt: emplacement.modelData.heading
+                    angleSpan: emplacement.modelData.radarFov
+                    radius: emplacement.engagementReach
+                    sourceX: emplacement.modelData.posX
+                    sourceY: emplacement.modelData.posY
+                    positionScale: root.pxPerMeter
+                    occluders: emplacement.beamOccluders
+                    fillColor: Qt.alpha(emplacement.beamColor, root.engagementAlpha)
+                }
+            }
+        }
+    }
+}

--- a/app/briarthorn/qml/ui/ViewHudOverlay.qml
+++ b/app/briarthorn/qml/ui/ViewHudOverlay.qml
@@ -107,6 +107,7 @@ Item {
     // touch player and a desktop player are already looking.
     ViewAlerts {
         ownship: root.ownship
+        entities: root.entities
         // Never off the edge of a phone: the reason elides instead.
         maximumWidth: root.width - 32
 

--- a/app/briarthorn/qml/ui/ViewHudTiled.qml
+++ b/app/briarthorn/qml/ui/ViewHudTiled.qml
@@ -136,6 +136,7 @@ Item {
         ViewAlerts {
             z: 1
             ownship: root.ownship
+            entities: root.entities
             maximumWidth: attack.width - 32
 
             anchors {

--- a/app/briarthorn/qml/ui/ViewObstacles.qml
+++ b/app/briarthorn/qml/ui/ViewObstacles.qml
@@ -61,6 +61,21 @@ Item {
             readonly property real screenX: root.observer ? root.centerX + (pillar.modelData.posX - root.observer.posX) * root.pxPerMeter : 0
             readonly property real screenY: root.observer ? root.centerY + (pillar.modelData.posY - root.observer.posY) * root.pxPerMeter : 0
 
+            // A screen wears the colour of the side it belongs to, plain rock
+            // the terrain colour: ground that only stands in some of the
+            // sky's way should not look like ground that stands in all of it.
+            readonly property color rim: {
+                switch (pillar.modelData.transparentTo) {
+                case Side.Kind.Hostile:
+                    return Style.theme.factionHostile;
+                case Side.Kind.Friendly:
+                case Side.Kind.Ownship:
+                    return Style.theme.factionFriendly;
+                default:
+                    return Style.theme.terrain;
+                }
+            }
+
             visible: root.draws(pillar.modelData.posX, pillar.modelData.posY, pillar.modelData.radius)
             x: pillar.screenX - pillar.edge
             y: pillar.screenY - pillar.edge
@@ -68,7 +83,7 @@ Item {
             height: width
             radius: width / 2
             color: Style.theme.terrainFill
-            border.color: Style.theme.terrain
+            border.color: pillar.rim
             border.width: root.strokeWidth
         }
     }

--- a/app/briarthorn/qml/ui/ViewSituation.qml
+++ b/app/briarthorn/qml/ui/ViewSituation.qml
@@ -46,7 +46,10 @@ Item {
                 rows.push({
                     x: pillar.posX,
                     y: pillar.posY,
-                    r: pillar.radius
+                    r: pillar.radius,
+                    // Carried so a layer casting for someone else's sensor can
+                    // drop the pieces that sensor sees through.
+                    transparentTo: pillar.transparentTo
                 });
         }
         return rows;
@@ -114,6 +117,10 @@ Item {
     property bool showTrackLabels: true
     property bool showTrackHealth: true
     property bool showTrackRanges: true
+
+    // Whether the known emplacements draw their sweeping beams. Needs
+    // entities, so a display given none draws nothing either way.
+    property bool showEmplacements: true
     property bool showNorth: false
     property bool closedRings: false
 
@@ -287,6 +294,21 @@ Item {
         pxPerMeter: root.pxPerMeter
         viewRotation: root.viewRotation
         strokeWidth: root.ringStrokeWidth
+        cullRadius: root.backgroundColor.a > 0 ? root.discRadius : 0
+    }
+
+    // The sweeping beams of the arena's batteries, over the terrain they are
+    // dug into and under everything that flies.
+    ViewEmplacements {
+        anchors.fill: parent
+        visible: root.showEmplacements
+        observer: root.observer
+        entities: root.entities
+        occluders: root.occluderRows
+        centerX: root.centerX
+        centerY: root.centerY
+        pxPerMeter: root.pxPerMeter
+        viewRotation: root.viewRotation
         cullRadius: root.backgroundColor.a > 0 ? root.discRadius : 0
     }
 

--- a/app/briarthorn/qml/ui/ViewTracked.qml
+++ b/app/briarthorn/qml/ui/ViewTracked.qml
@@ -1,0 +1,116 @@
+import QtQuick
+import awen.shapes
+import "../model"
+import "../themes"
+
+// Radar-lock warning: flashes while a sentry radar holds the ownship inside
+// its engagement ring — the sweep that stopped on you, close enough to shoot
+// — with an arrow swinging to the site's bearing in the scope's heading-up
+// frame and its range beside it. It reads the sentry's own lock rather than
+// any sensor product, which is what a warning receiver is: being painted is
+// not something a target can miss. A battery that is merely following a
+// track it cannot reach raises nothing, or the panel would be lit for most
+// of a duel and mean nothing when it mattered. Warn-coloured, not hostile —
+// a lock is the seconds before the MISSILE alert, not the missile.
+Item {
+    id: root
+
+    // The craft the warning speaks for, and the roster scanned for sentries.
+    property Entity ownship
+    property list<Entity> entities
+
+    // The nearest live sentry holding the ownship, or null for a quiet sky.
+    // A dropped lock nulls the sentry's engageTarget the tick it drops, so
+    // this needs no timeout of its own.
+    readonly property Entity tracker: {
+        if (!root.ownship)
+            return null;
+        let best = null;
+        let bestRange = Infinity;
+        for (let i = 0; i < root.entities.length; ++i) {
+            const site = root.entities[i];
+            if (!site.sentry || site.health <= 0 || site.engageTarget !== root.ownship || site.engageHold)
+                continue;
+            const range = Geo.distance(site, root.ownship);
+            if (range < bestRange) {
+                best = site;
+                bestRange = range;
+            }
+        }
+        return best;
+    }
+
+    readonly property bool active: root.tracker !== null
+
+    // Degrees the tracking site sits off the nose — the arrow's swing.
+    readonly property real trackerBearing: root.active ? Geo.wrap180(Geo.bearing(root.ownship, root.tracker) - root.ownship.heading) : 0
+    readonly property real trackerRange: root.active ? Geo.distance(root.ownship, root.tracker) : 0
+
+    implicitWidth: content.implicitWidth + 32
+    implicitHeight: content.implicitHeight + 14
+    visible: root.active
+
+    Rectangle {
+        anchors.fill: parent
+        radius: Style.theme.panelRadius
+        color: Style.theme.panelBackground
+        border.color: Style.theme.warn
+        border.width: 2
+    }
+
+    Row {
+        id: content
+
+        anchors.centerIn: parent
+        spacing: 12
+
+        ShapePolygon {
+            anchors.verticalCenter: parent.verticalCenter
+            width: 22
+            height: width
+            rotation: root.trackerBearing
+            points: [Qt.point(0, -0.5), Qt.point(0.38, 0.34), Qt.point(0, 0.14), Qt.point(-0.38, 0.34)]
+            fillColor: Style.theme.warn
+        }
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("TRACKED")
+            color: Style.theme.warn
+            font { pixelSize: 16; family: Style.monospace; bold: true; letterSpacing: Style.theme.capsTracking }
+        }
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("%1 KM").arg((root.trackerRange / 1000).toFixed(1))
+            color: Style.theme.textBright
+            font { pixelSize: 13; family: Style.monospace }
+        }
+    }
+
+    // A slower breath than the missile warning's flash: the lock asks for a
+    // decision, the missile for a reaction, and the eye should be able to
+    // tell which from the corner it watches this in.
+    SequentialAnimation on opacity {
+        running: root.visible
+        loops: Animation.Infinite
+
+        NumberAnimation {
+            from: 1
+            to: 0.45
+            duration: 500
+        }
+
+        NumberAnimation {
+            from: 0.45
+            to: 1
+            duration: 500
+        }
+    }
+
+    // The tap-sink the other alerts carry: a press on the warning must not
+    // designate whatever flies behind it.
+    TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+    }
+}

--- a/src/awen/entity/Systems.qml
+++ b/src/awen/entity/Systems.qml
@@ -12,10 +12,16 @@ QtObject {
     // Whether the per-frame loop is active.
     property bool running: true
 
+    // The longest step one frame may integrate, in seconds. A stalled frame —
+    // a dragged window, a suspended tab — resumes as one bounded tick rather
+    // than integrating the whole gap: entities must not teleport through
+    // walls, and no timer a system floored this tick may run out in it.
+    property real maxFrameTime: 0.1
+
     // The frame clock driving the loop, in sync with scene rendering.
     readonly property FrameAnimation clock: FrameAnimation {
         running: root.running
-        onTriggered: root.tick(frameTime)
+        onTriggered: root.tick(Math.min(frameTime, root.maxFrameTime))
     }
 
     // One update pass: forwards dt (seconds) to every enabled system.


### PR DESCRIPTION
Adds anti-air batteries to the duel arena. A battery sweeps a radar, locks
what its volume catches, follows it, and shoots — and sits behind screens that
its own network sees and shoots through while an attacker can do neither.

## The radar seam

`SystemSentry` gives any entity carrying the new `sentry` aspect two states,
and **the radar state is `engageTarget` itself**: null is the search (full
deflection, so the maneuver rating alone prices the revolution — 14.4 deg/s,
25 s a lap), a target is the track (proportional slew). Dropping it back to
null is what "resume the sweep" means, from wherever the slew left the dish.

Everything downstream is machinery that already existed: `SystemEngage` fires
at the lock, `SystemWeapon` illuminates the rounds down the battery's own
nose, `SystemThreat` raises MISSILE, flares seduce. A design panel scored a
personality-registry integration higher on conventions, but its `SystemEngage`
rewrite read as shared-seam regression risk, so the seam here is additive.

## Two tiers, because the round has an opinion

Sizing the trigger to the radar produced four launches and zero hits. Pure
pursuit takes `R*vp/(vp^2 - vt^2)` seconds, so the 800 m/s guided round dies
at **31 km against a 500 m/s runner**; a battery firing at its 42 km rim
empties the rack into empty sky and disarms itself. So `GameRules`
(`sentryFireFraction`) gates the trigger through `engageHold`:

- **search 42 km** — the dish finds and follows you, no alert, no shots
- **engagement 27 km** — TRACKED lights and missiles fly

TRACKED deliberately lights only on engagement; at a 42 km search it would
otherwise be lit for most of a duel and mean nothing.

## One-way screens

`Obstacle.transparentTo` names a side, and `opaqueTo(entity)` decides sight
**and** passage together — a barrier that stopped a round it could not see
would be two rules wearing one name. Only the air-defence network sees
through (`entity.sentry || entity.owner.sentry`), deliberately not the whole
side: letting the bandit through would let a damaged one flee behind a screen
and be invisible, unkillable and still shooting.

`Geo.lineOfSight` judges from its first argument, which works because every
caller already passes the sensing party first — worth checking before adding
a call site. Without the collision half of the rule, about a third of each
battery's own shots died on its own screens on the way out.

## Arena

Four batteries on the intercardinals at 50 km, each ringed by three screens;
the four 6 km walls stay on the cardinals. Spacing is what caps the kind: a
lobe wider than half the distance to its neighbour meets it and leaves no
flyable ground, which puts the ceiling at a rating of 4.5 here. The shape:
a 22.7 km merge bubble nothing watches, four lobes on the diagonals, and four
16 km lanes on the cardinals, each gated by a wall. The opening moved onto
the meridian so both craft start in a lane.

## Also in here

Three fixes the feature surfaced in shared combat code, split into their own
commits:

- a killed or destroyed launcher now blinds its rounds in flight (only
  scenario-declared shooters did before, since `World.despawn` destroys
  spawned ones and QML nulls the reference)
- `takeable()` excludes rounds, so racks stop spending charges intercepting
  missiles; decoys stay takeable, so flare seduction is untouched
- `engageTimer` runs down in wall time, so a re-engagement telegraphs like a
  first
- `Systems.qml` clamps the frame step: one dragged-window stall used to
  integrate the whole gap, running a just-floored grace timer to zero and
  tunnelling movers through walls

## Verification

Headless harness stepping the real systems (`Systems { running: false }` plus
manual ticks), then the running app.

| Check | Result |
| --- | --- |
| battery -> player through its own screen | sees, and kills: swept on at 11 s, 3 launches, 2 hits |
| player -> battery through the same screen | blocked, and the track stays unresolved |
| bandit -> battery | blocked; an aircraft is not the network |
| player flying into a screen | TERRAIN at 23 s, wrecked at 34 s |
| opening | 8.8 km clear of the nearest lobe |
| sweep rate / side filter | 14.4 deg/s; a bandit parked on the boresight never locks |

An earlier adversarial review over this diff raised 26 findings and confirmed
18; the armed-slot leak, the dead-radar hole and the unclamped `dt` above all
came from it. qmllint clean, release build clean, 126/126 ctest.

## Reviewer notes

- Beams draw from ground truth, not the track picture: a sweep you cannot see
  is a sweep you cannot time. That reveals dish direction without detection.
- Batteries are Hostile, so they threaten only the player. Making them
  threaten both combatants needs a side that opposes everyone — a change to
  the shared `opposed()` rule, not attempted here.
- Nothing solid stands inside a lobe, so a lock is broken by leaving it
  rather than by hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
