### PR TITLE
Return the tiled scope's track symbols to their pre-retune size

### DIFF
--- a/app/briarthorn/qml/ui/ViewHudTiled.qml
+++ b/app/briarthorn/qml/ui/ViewHudTiled.qml
@@ -120,7 +120,7 @@ Item {
             // list rather than the gutter.
             radiusFraction: 0.62
             verticalShift: 0.2
-            symbolSize: height * 0.06
+            symbolSize: height * 0.04
             trailsRunning: root.running
             armedReach: root.armedReach
             armedValid: root.armedValid


### PR DESCRIPTION
Track symbols on the tiled HUD's attack scope have been drawing 1.5x oversized since the layout became the default. This puts them back.

## What changed

One line in `app/briarthorn/qml/ui/ViewHudTiled.qml`: the attack tile's `symbolSize` goes from `height * 0.06` back to `height * 0.04`.

## Why

`9b20325` ("Make the tiled HUD the default and retune its scope, stores and touch rack") raised the factor from `0.04` to `0.06` in the same hunk that replaced the tile's computed `radiusFraction` with a flat `0.62`. The symbols were scaled up alongside the ring being pushed out past the tile's flanks. Since that commit also made the tiled HUD the layout the duel opens on, the retuned size stopped being something you would only see by switching layouts.

`0.04` is the value the file carried before that commit, and the factor the floating overlay HUD (`ViewHudOverlay.qml:69`) and the menu backdrop (`Main.qml:776`) have always used.

## For the reviewer

- Nothing else moved. The minimap's `0.08`, both stroke weights and `radiusFraction: 0.62` are untouched, so the ring geometry is unchanged.
- The two HUDs measure `height` off different items: the overlay's scope fills the area under the top bar, the tiled one measures the attack tile, which is shorter by the top bar, the gutters and the tile's 8px content margin. So restoring the literal original leaves the tiled symbols ~13% smaller than the overlay's (roughly 25px against 29px at 1280x720), not identical. If matching the overlay exactly is what we want, that is a different binding, not this value.
- Not run. The change is a scalar in a binding restored to its prior value; a desktop debug build loads this QML from the source tree, so a relaunch shows it with no rebuild.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
