### PR TITLE
Gatling gun ability with hold-to-fire and a duelist knife-fight stance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,8 @@ the database imports nothing back.
   registry, and its `Switch` rows express every distance as a fraction of a
   priced envelope (own weapon reach, the target's, detection range) — never
   metres. `SystemPersonality` attaches the live `PersonalityState` and owns
-  `maneuvers`, `engageHold` and `engageHoldoff` on its entities; scenarios
+  `maneuvers`, `engageHold`, `engageHoldoff` and `engageAbility` on its
+  entities; scenarios
   point `engageTarget` and the personality decides how to fight it, so a
   director-run entity (the menu demo's ownship) stays personality-free.
 - **Ability input is generated, never written.** Adding an ability is four
@@ -145,4 +146,8 @@ the database imports nothing back.
   scope's envelope and the trigger can never disagree. `Entity.invoke()` is
   the press path (one armed slot at a time, second press stands it down);
   `AbilitySlot.activate()` is the raised-intent primitive behaviour systems
-  use and is idempotent.
+  use and is idempotent. An `automatic` ability (the gatling gun) holds
+  instead of arming: `invoke()` puts the slot's `held` trigger down,
+  `Entity.release()` lifts it, and it fires every time its cooldown allows
+  while down — `SystemEngage` grips and releases AI triggers the same way,
+  never touching a target-less entity's slots.

--- a/app/briarthorn/CMakeLists.txt
+++ b/app/briarthorn/CMakeLists.txt
@@ -63,17 +63,20 @@ awen_add_executable(${PROJECT_NAME}
         qml/database/SwitchThreat.qml
         qml/database/abilities/AbilityFlare.qml
         qml/database/abilities/AbilityLaunchGuided.qml
+        qml/database/abilities/AbilityLaunchGun.qml
         qml/database/abilities/AbilityLaunchKinetic.qml
         qml/database/entities/DataAircraftFighter.qml
         qml/database/entities/DataAircraftFighterLight.qml
         qml/database/entities/DataDecoy.qml
         qml/database/entities/DataSiteAntiAir.qml
+        qml/database/entities/DataTurret.qml
         qml/database/entities/DataUnknown.qml
         qml/database/personalities/PersonalityAggressive.qml
         qml/database/personalities/PersonalityDefensive.qml
         qml/database/personalities/PersonalityDuelist.qml
         qml/database/personalities/PersonalityFearful.qml
         qml/database/personalities/PersonalityTactical.qml
+        qml/database/weapons/DataBullet.qml
         qml/database/weapons/DataMissileGuided.qml
         qml/database/weapons/DataMissileKinetic.qml
         qml/input/AbilityInput.qml

--- a/app/briarthorn/qml/Main.qml
+++ b/app/briarthorn/qml/Main.qml
@@ -655,6 +655,7 @@ Window {
                 selectedContact: root.selectedContact
                 shootableContact: root.shootableContact
                 onInvoked: ability => touched.post({ ability: ability })
+                onReleased: ability => touched.post({ ability: ability, active: false })
                 onTouched: root.device.kind = ActiveDevice.Touch
                 // A tap toggles: tapping the selected contact stands it down.
                 onContactChosen: contactId => designate.post({ contact: contactId === game.ownship.targetContact ? "" : contactId })
@@ -686,6 +687,7 @@ Window {
                 selectedContact: root.selectedContact
                 shootableContact: root.shootableContact
                 onInvoked: ability => touched.post({ ability: ability })
+                onReleased: ability => touched.post({ ability: ability, active: false })
                 onTouched: root.device.kind = ActiveDevice.Touch
                 onContactChosen: contactId => designate.post({ contact: contactId === game.ownship.targetContact ? "" : contactId })
                 onContactTouched: root.device.kind = ActiveDevice.Touch

--- a/app/briarthorn/qml/commands/CommandAbility.qml
+++ b/app/briarthorn/qml/commands/CommandAbility.qml
@@ -1,7 +1,9 @@
 import awen.command
 
 // Ability intent: invokes one of the flown entity's abilities by name —
-// launch a weapon, pop a flare. Discrete, so every press posts one record.
+// launch a weapon, pop a flare. Discrete presses post one record each;
+// automatic abilities post the falling edge too, as active false, so the
+// store can stand a held trigger back down.
 Command {
     id: root
 
@@ -11,6 +13,6 @@ Command {
     name: Verbs.ability
 
     function payload(): var {
-        return { ability: root.ability };
+        return { ability: root.ability, active: true };
     }
 }

--- a/app/briarthorn/qml/database/Abilities.qml
+++ b/app/briarthorn/qml/database/Abilities.qml
@@ -13,6 +13,7 @@ QtObject {
     readonly property list<Ability> registry: [
         AbilityFlare {},
         AbilityLaunchGuided {},
+        AbilityLaunchGun {},
         AbilityLaunchKinetic {}
     ]
 

--- a/app/briarthorn/qml/database/Ability.qml
+++ b/app/briarthorn/qml/database/Ability.qml
@@ -19,6 +19,11 @@ QtObject {
     // Rounds a fresh slot carries; -1 is unlimited.
     property int charges: -1
 
+    // Whether the trigger is a hold rather than a press: an automatic slot
+    // fires every time its cooldown allows while the trigger is down, and
+    // never arms — letting go is the only way to stop it.
+    property bool automatic: false
+
     // The controls this ability ships bound to: a Qt.Key code and an
     // awen.gamepad Gamepad.Button code, -1 for unbound. The keymap seeds from
     // these, so arming a new ability needs no entry in a binding table.

--- a/app/briarthorn/qml/database/Classification.qml
+++ b/app/briarthorn/qml/database/Classification.qml
@@ -15,6 +15,8 @@ QtObject {
         Decoy,
         AircraftFighterLight,
         SiteAntiAir,
+        Bullet,
+        Turret,
         Count
     }
 }

--- a/app/briarthorn/qml/database/Data.qml
+++ b/app/briarthorn/qml/database/Data.qml
@@ -18,4 +18,9 @@ QtObject {
     // An airframe's condition is worth reading straight off the picture; a
     // round in flight, a lure and an unresolved return all plot bare.
     property bool hullGauge: false
+
+    // Whether a resolved mark of this kind carries its contact label. A
+    // cannon stream would caption every tracer in it; a round that small
+    // plots as a bare streak instead.
+    property bool trackLabel: true
 }

--- a/app/briarthorn/qml/database/Database.qml
+++ b/app/briarthorn/qml/database/Database.qml
@@ -15,6 +15,7 @@ QtObject {
     // The registration index. Order is not load-bearing.
     readonly property list<Data> registry: [
         // Perception-only rows, never spawned.
+        DataTurret {},
         DataUnknown {},
         // Spawnable craft.
         DataAircraftFighter {},
@@ -22,6 +23,7 @@ QtObject {
         DataDecoy {},
         DataSiteAntiAir {},
         // Munitions.
+        DataBullet {},
         DataMissileGuided {},
         DataMissileKinetic {}
     ]

--- a/app/briarthorn/qml/database/Names.qml
+++ b/app/briarthorn/qml/database/Names.qml
@@ -36,6 +36,7 @@ QtObject {
         readonly property string abscond: "abscond"
         readonly property string advance: "advance"
         readonly property string bail: "bail"
+        readonly property string brawl: "brawl"
         readonly property string crank: "crank"
         readonly property string defeat: "defeat"
         readonly property string defend: "defend"

--- a/app/briarthorn/qml/database/Stance.qml
+++ b/app/briarthorn/qml/database/Stance.qml
@@ -33,6 +33,10 @@ QtObject {
     property bool holdFire: false
     property real holdoff: -1
 
+    // The launch ability the trigger fires while current, by registry name;
+    // "" keeps the ability the entity was spawned with.
+    property string ability: ""
+
     // Outgoing transitions in priority order, checked after the
     // personality's own.
     property list<Switch> switches

--- a/app/briarthorn/qml/database/SwitchRange.qml
+++ b/app/briarthorn/qml/database/SwitchRange.qml
@@ -10,12 +10,26 @@ Switch {
     property real at: 1
     property int of: Envelope.Kind.OwnWeapon
 
+    // A launch ability, by registry name: when set, the envelope is that
+    // ability's round flight reach — the very span SystemEngage gates the
+    // trigger on — instead of `of`.
+    property string ability: ""
+
     function holds(s: var): bool {
         if (s.target === null)
             return false;
-        const span = root.of === Envelope.Kind.OwnWeapon ? s.reach : root.of === Envelope.Kind.TargetWeapon ? s.targetReach : s.entity.detectionRange;
+        const span = root.spanOf(s);
         if (span <= 0)
             return false;
         return root.inside ? s.range <= root.at * span : s.range > root.at * span;
+    }
+
+    function spanOf(s: var): real {
+        if (root.ability !== "") {
+            const launch = Abilities.defFor(root.ability) as AbilityLaunch;
+            const round = launch !== null ? Database.weaponDataFor(launch.weapon) : null;
+            return round !== null ? round.reach : 0;
+        }
+        return root.of === Envelope.Kind.OwnWeapon ? s.reach : root.of === Envelope.Kind.TargetWeapon ? s.targetReach : s.entity.detectionRange;
     }
 }

--- a/app/briarthorn/qml/database/abilities/AbilityLaunchGun.qml
+++ b/app/briarthorn/qml/database/abilities/AbilityLaunchGun.qml
@@ -1,0 +1,23 @@
+import QtQml
+import awen.gamepad
+import ".."
+
+// The gatling cannon: held down rather than pressed, streaming eight rounds
+// a second off a deep magazine, unguided and short-legged — the close-combat
+// complement to the racks.
+AbilityLaunch {
+    id: root
+
+    name: "gun"
+    label: qsTr("GUN")
+    automatic: true
+    cooldown: 0.125
+    charges: 300
+    weapon: Classification.Kind.Bullet
+    // The station wears the mount rather than the round: one turret glyph
+    // standing for the whole magazine, the way the flare dispensers do.
+    stationKind: Classification.Kind.Turret
+    defaultKey: Qt.Key_G
+    defaultButton: Gamepad.Button.RightStick
+    stations: [Qt.point(0, -0.28)]
+}

--- a/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
+++ b/app/briarthorn/qml/database/entities/DataAircraftFighter.qml
@@ -2,7 +2,8 @@ import QtQuick
 import ".."
 
 // Fast, manoeuvrable combat aircraft — the airframe both sides fly in the
-// duel. Mid-range across the board, with both missile racks and a flare pod.
+// duel. Mid-range across the board, with both missile racks, a nose cannon
+// and a flare pod.
 DataEntity {
     id: root
 
@@ -24,5 +25,5 @@ DataEntity {
         stealth: 5
     }
 
-    abilities: ["guided", "kinetic", "flare"]
+    abilities: ["guided", "kinetic", "gun", "flare"]
 }

--- a/app/briarthorn/qml/database/entities/DataAircraftFighterLight.qml
+++ b/app/briarthorn/qml/database/entities/DataAircraftFighterLight.qml
@@ -19,5 +19,5 @@ DataAircraftFighter {
         stealth: 5
     }
 
-    abilities: ["guided", "flare"]
+    abilities: ["guided", "gun", "flare"]
 }

--- a/app/briarthorn/qml/database/entities/DataTurret.qml
+++ b/app/briarthorn/qml/database/entities/DataTurret.qml
@@ -1,0 +1,16 @@
+import QtQuick
+import ".."
+
+// Presentation-only: the mount the stores page draws the cannon's station
+// with — what sits on the airframe is the turret, not the round it throws.
+// Nothing spawns it and no sensor ever returns it.
+Data {
+    id: root
+
+    classification: Classification.Kind.Turret
+    // A squat housing with the barrel out the nose, on the symbol frame's
+    // own nose-up axis.
+    outline: [Qt.point(-0.06, -0.5), Qt.point(0.06, -0.5), Qt.point(0.06, -0.14), Qt.point(0.3, -0.14), Qt.point(0.3, 0.34), Qt.point(-0.3, 0.34), Qt.point(-0.3, -0.14), Qt.point(-0.06, -0.14)]
+    label: qsTr("GUN")
+    symbolScale: 0.7
+}

--- a/app/briarthorn/qml/database/personalities/PersonalityDuelist.qml
+++ b/app/briarthorn/qml/database/personalities/PersonalityDuelist.qml
@@ -5,7 +5,8 @@ import ".."
 // magazine ever streams. Beams genuine inbounds early enough to watch, flies
 // its flares off once one bites, breaks off dry, and opens a too-close merge
 // back out to launch distance rather than wasting a round that cannot make
-// its turn.
+// its turn — unless the merge has closed inside the gun's envelope, where it
+// takes the knife fight instead.
 Personality {
     name: Names.personality.duelist
 
@@ -25,6 +26,14 @@ Personality {
                     within: 0.45
                     dwell: 0.3
                     to: Names.stance.guard
+                },
+                // Inside the gun's envelope the knife fight beats everything
+                // offensive, so it outranks the exchange rhythm and the
+                // withdraw below.
+                SwitchRange {
+                    inside: true
+                    ability: "gun"
+                    to: Names.stance.brawl
                 },
                 SwitchOutbound {
                     present: true
@@ -51,9 +60,40 @@ Personality {
                     dwell: 0.3
                     to: Names.stance.guard
                 },
+                SwitchRange {
+                    inside: true
+                    ability: "gun"
+                    to: Names.stance.brawl
+                },
                 SwitchOutbound {
                     present: false
                     dwell: 0.5
+                    to: Names.stance.press
+                }
+            ]
+        },
+        // The knife fight: inside the gun's envelope missiles cannot make
+        // their turns, so ride the target's tail and hold the gatling down —
+        // an automatic trigger needs no holdoff, its own cycle is the rate
+        // of fire. Survival still outranks it (an inbound takes the beam),
+        // and the target opening back out past the envelope — a shade past,
+        // dwelled, so the edge never flaps — resumes the missile exchange.
+        Stance {
+            name: Names.stance.brawl
+            maneuver: Names.maneuver.pursue
+            ability: "gun"
+            switches: [
+                SwitchThreat {
+                    present: true
+                    within: 0.45
+                    dwell: 0.3
+                    to: Names.stance.guard
+                },
+                SwitchRange {
+                    inside: false
+                    ability: "gun"
+                    at: 1.1
+                    dwell: 0.75
                     to: Names.stance.press
                 }
             ]
@@ -116,6 +156,14 @@ Personality {
                     within: 0.45
                     dwell: 0.3
                     to: Names.stance.guard
+                },
+                // A pursuer that runs the extension down to gun range has
+                // taken the choice away: turn and fight rather than be shot
+                // in the back.
+                SwitchRange {
+                    inside: true
+                    ability: "gun"
+                    to: Names.stance.brawl
                 },
                 SwitchRange {
                     inside: false

--- a/app/briarthorn/qml/database/weapons/DataBullet.qml
+++ b/app/briarthorn/qml/database/weapons/DataBullet.qml
@@ -1,0 +1,34 @@
+import QtQuick
+import ".."
+
+// The cannon round: a dumb tracer slug, the fastest and shortest-lived thing
+// in the sky — four seconds of flight prices a 10 km envelope, so the gun is
+// a knife-fight weapon for the ranges where a missile cannot make its turn.
+// One round hits light; the gatling wins by putting a stream of them there.
+DataWeapon {
+    id: root
+
+    classification: Classification.Kind.Bullet
+    // A bare line along the flight axis — the polygon degenerates to a
+    // stroked dash, so the stream reads as tracer fire, and its marks plot
+    // without labels for the same reason.
+    outline: [Qt.point(0, -0.5), Qt.point(0, 0.5)]
+    label: qsTr("GUN")
+    symbolScale: 0.35
+    trackLabel: false
+
+    stats: Stats {
+        kinetic: 10 // lifted by the muzzle charge below: 2500 m/s, nothing outruns it
+        maneuver: 0 // it flies where the nose was pointed
+        durable: 0 // too small to frag: a blast passes it by
+        stealth: 8
+    }
+
+    speedMultiplier: 2.5
+    duration: 4
+
+    fuzeRange: 300
+    fuzeTime: 0.05
+    damage: 4
+    blastRadius: 350
+}

--- a/app/briarthorn/qml/input/AbilityInput.qml
+++ b/app/briarthorn/qml/input/AbilityInput.qml
@@ -6,11 +6,12 @@ import "../database"
 
 // The input wiring for one carried ability: the key and the controller button
 // the keymap names fold into a 0..1 axis, and its rising edge posts the
-// invocation once per press. One of these per slot in the loadout — the whole
-// of what an ability used to cost in hand-written blocks in Main.qml. The code
-// lists bind through the keymap, so a rebind re-pushes them onto these very
-// objects rather than rebuilding anything, and the axis is owned here, so a
-// torn-down binding takes its contribution with it.
+// invocation once per press — an automatic ability posts the falling edge
+// too, so the store hears the trigger let go. One of these per slot in the
+// loadout — the whole of what an ability used to cost in hand-written blocks
+// in Main.qml. The code lists bind through the keymap, so a rebind re-pushes
+// them onto these very objects rather than rebuilding anything, and the axis
+// is owned here, so a torn-down binding takes its contribution with it.
 QtObject {
     id: root
 
@@ -24,6 +25,17 @@ QtObject {
     // definition, which then binds nothing and can never fire — a loadout typo
     // must not reach into the keymap or the bus.
     readonly property string ability: root.def ? root.def.name : ""
+
+    // The trigger position the fold reads out: down while any bound control
+    // is. Its falling edge covers a dropped input too — Main's dropInput()
+    // resets the actions, the fold returns to rest, and the release posts,
+    // so a focus loss can never leave an automatic trigger down.
+    readonly property bool down: root.control.value > root.control.band
+
+    onDownChanged: {
+        if (!root.down && root.def && root.def.automatic)
+            root.invoke.post({ active: false });
+    }
 
     readonly property Axis control: Axis {
         minimum: 0

--- a/app/briarthorn/qml/input/Keymap.qml
+++ b/app/briarthorn/qml/input/Keymap.qml
@@ -111,7 +111,8 @@ QtObject {
             [Gamepad.Button.West]: "X",
             [Gamepad.Button.North]: "Y",
             [Gamepad.Button.LeftShoulder]: "LB",
-            [Gamepad.Button.RightShoulder]: "RB"
+            [Gamepad.Button.RightShoulder]: "RB",
+            [Gamepad.Button.RightStick]: "RS"
         })
 
     function keyFor(name: string): int {

--- a/app/briarthorn/qml/model/AbilitySlot.qml
+++ b/app/briarthorn/qml/model/AbilitySlot.qml
@@ -39,6 +39,13 @@ QtObject {
     // (a second press through Entity.invoke).
     property bool armed: false
 
+    // The trigger position of an automatic slot: while down, the consuming
+    // system fires a round every time the cooldown allows, and letting go is
+    // the only way to stop. The pilot writes it through Entity.invoke and
+    // Entity.release; SystemEngage grips and releases it for AI shooters.
+    // Meaningless on a slot whose definition is not automatic.
+    property bool held: false
+
     readonly property bool ready: cooldownRemaining <= 0 && charges !== 0
 
     // The munition this slot launches, and whether that round needs a lock
@@ -80,6 +87,11 @@ QtObject {
     // system checks, in the one place the rack, the scope and the trigger all
     // read it from.
     readonly property bool valid: root.ready && (!root.guided || root.lock !== null)
+
+    // What the controls colour themselves by: valid this instant, or an
+    // automatic slot with rounds left — its hold always streams, and a ready
+    // light strobing at the rate of fire would say nothing.
+    readonly property bool willing: root.valid || (root.def !== null && root.def.automatic && root.charges !== 0)
 
     readonly property int impediment: {
         if (root.charges === 0)

--- a/app/briarthorn/qml/model/Entity.qml
+++ b/app/briarthorn/qml/model/Entity.qml
@@ -57,8 +57,8 @@ QtObject {
 
     // The temperament SystemPersonality flies this entity with, defaulting
     // from its kind; empty opts out. A personality owns maneuvers,
-    // engageHold and engageHoldoff — a director must not share an entity
-    // with one.
+    // engageHold, engageHoldoff and engageAbility — a director must not
+    // share an entity with one.
     property string personality: root.def ? root.def.personality : ""
 
     // The live stance machine, built by SystemPersonality on the first
@@ -73,6 +73,11 @@ QtObject {
     property real engageHoldoff: 6
     property real engageTimer: 0
     property bool engageHold: false
+
+    // The launch ability that trigger fires, by registry name — an aspect,
+    // so a personality stance can put the entity on its gun for the merge
+    // and back on its rack for the standoff.
+    property string engageAbility: "guided"
 
     // Whether this entity's guided locks come from its designated track
     // rather than the radar's automatic pick. The player's craft carries it;
@@ -197,20 +202,23 @@ QtObject {
     }
 
     // A pilot's press on one ability: the second press on an armed slot stands
-    // it down, and arming a slot stands every other one down first. The bare
-    // slot's activate() is the raised-intent primitive behaviour systems use;
-    // this is the only caller that means "again".
+    // it down, and arming a slot stands every other one down first. An
+    // automatic slot takes the press as its trigger going down instead —
+    // nothing arms, and release() is what stops it. The bare slot's
+    // activate() is the raised-intent primitive behaviour systems use; this
+    // is the only caller that means "again".
     function invoke(name: string) {
-        let picked = null;
-        for (let i = 0; i < root.abilities.length; ++i) {
-            const slot = root.abilities[i];
-            if (slot.def !== null && slot.def.name === name) {
-                picked = slot;
-                break;
-            }
-        }
+        const picked = root.slotNamed(name);
         if (picked === null)
             return;
+        if (picked.def.automatic) {
+            if (picked.charges === 0) {
+                picked.refused();
+                return;
+            }
+            picked.held = true;
+            return;
+        }
         if (picked.armed) {
             picked.armed = false;
             return;
@@ -225,6 +233,25 @@ QtObject {
             if (root.abilities[i] !== picked)
                 root.abilities[i].armed = false;
         }
+    }
+
+    // The pilot's trigger coming back up: stands an automatic slot's fire
+    // down. Nothing for any other kind — a discrete press already spent
+    // itself on the way down.
+    function release(name: string) {
+        const picked = root.slotNamed(name);
+        if (picked !== null && picked.def.automatic)
+            picked.held = false;
+    }
+
+    // The live slot carrying the named ability, or null.
+    function slotNamed(name: string): AbilitySlot {
+        for (let i = 0; i < root.abilities.length; ++i) {
+            const slot = root.abilities[i];
+            if (slot.def !== null && slot.def.name === name)
+                return slot;
+        }
+        return null;
     }
 
     // One live slot per named ability. An unregistered name is dropped with a

--- a/app/briarthorn/qml/model/PersonalityState.qml
+++ b/app/briarthorn/qml/model/PersonalityState.qml
@@ -24,6 +24,10 @@ QtObject {
     // that do not repace it.
     property real baseHoldoff: 6
 
+    // The entity's engageAbility captured at attach, restored by stances
+    // that do not name one of their own.
+    property string baseAbility: "guided"
+
     // One live maneuver per stance in definition order, null where a stance
     // flies nothing — a JS array, because a QML list cannot hold the gaps.
     property var maneuvers: []

--- a/app/briarthorn/qml/model/StoreGame.qml
+++ b/app/briarthorn/qml/model/StoreGame.qml
@@ -50,9 +50,16 @@ Store {
     // Ability invocation routes to the named slot as a press: it fires where
     // every check passes, holds the shot armed where one does not yet, stands
     // an already-armed slot back down, and refuses an empty rack outright.
+    // The falling edge — active false, posted for automatic abilities — is
+    // the trigger letting go instead.
     CommandHandler {
         name: Verbs.ability
-        onHandle: payload => root.ownship.invoke(payload.ability)
+        onHandle: payload => {
+            if (payload.active === false)
+                root.ownship.release(payload.ability);
+            else
+                root.ownship.invoke(payload.ability);
+        }
     }
 
     // Designation routes straight onto the craft: the weapon survey is what

--- a/app/briarthorn/qml/scenarios/ScenarioDuel.qml
+++ b/app/briarthorn/qml/scenarios/ScenarioDuel.qml
@@ -58,6 +58,9 @@ Scenario {
                 def: Abilities.defFor("guided")
             },
             AbilitySlot {
+                def: Abilities.defFor("gun")
+            },
+            AbilitySlot {
                 def: Abilities.defFor("flare")
                 charges: 6
             }

--- a/app/briarthorn/qml/systems/SystemCue.qml
+++ b/app/briarthorn/qml/systems/SystemCue.qml
@@ -59,14 +59,16 @@ System {
         root.hadThreat = threatened;
     }
 
-    // Rounds left across the launch racks only. A flare pop spends a charge
-    // too, and a decoy going over the side is not a launch — the pod has its
-    // own sound to earn later, and it is not this one.
+    // Rounds left across the discrete launch racks only. A flare pop spends
+    // a charge too, and a decoy going over the side is not a launch — the pod
+    // has its own sound to earn later — and the gatling is excluded the same
+    // way: a launch whoosh per tracer at eight a second is a siren, and the
+    // gun's voice is its own to earn.
     function roundsLeft(): int {
         let total = 0;
         for (let i = 0; i < root.ownship.abilities.length; ++i) {
             const slot = root.ownship.abilities[i];
-            if (slot.round !== null && slot.charges >= 0)
+            if (slot.round !== null && slot.charges >= 0 && !slot.def.automatic)
                 total += slot.charges;
         }
         return total;

--- a/app/briarthorn/qml/systems/SystemEngage.qml
+++ b/app/briarthorn/qml/systems/SystemEngage.qml
@@ -2,11 +2,14 @@ import awen.entity
 import "../database"
 import "../model"
 
-// AI trigger discipline: every entity carrying an engageTarget invokes its
-// named launch ability when that target is alive, inside the radar cone and
-// within engageRange — paced by the entity's own holdoff on top of the
-// ability's cooldown, so no magazine is dumped in one pass. An entity held
-// by its engageHold flag stands down entirely, its pacing frozen with it.
+// AI trigger discipline: every entity carrying an engageTarget invokes the
+// launch ability its engageAbility names when that target is alive, inside
+// the radar cone and within the named round's flight reach. A discrete
+// launch is paced by the entity's own holdoff on top of the ability's
+// cooldown, so no magazine is dumped in one pass; an automatic one is
+// gripped instead — trigger held while every gate holds, let go the tick one
+// fails — and its own cooldown is the rate of fire. An entity held by its
+// engageHold flag stands down entirely, its pacing frozen with it.
 System {
     id: root
 
@@ -16,48 +19,76 @@ System {
     // The arena geometry radar cannot see through.
     property list<Obstacle> obstacles
 
-    // The launch ability invoked, by registry name, and the round it spawns;
-    // the cast is null for a name that is not a launch at all.
-    property string ability: "guided"
-    readonly property AbilityLaunch def: Abilities.defFor(root.ability) as AbilityLaunch
-    readonly property DataWeapon round: root.def ? Database.weaponDataFor(root.def.weapon) : null
-
-    // Maximum firing range, metres: by default as far as that round can
-    // physically fly, so the envelope tracks the weapon's own tuning.
-    property real engageRange: root.round ? root.round.reach : 0
-
     function update(dt: real) {
         for (let i = 0; i < root.entities.length; ++i) {
             const entity = root.entities[i];
-            if (entity.engageHold)
+            if (entity.engageHold) {
+                root.grip(entity, "");
                 continue;
+            }
             // The pacing runs in wall time, target or none — a sentry that
             // fired just before losing its lock must telegraph a later
             // re-engagement exactly like a first, not fire off the frozen
             // remainder of the old holdoff.
             entity.engageTimer = Math.max(0, entity.engageTimer - dt);
-            if (entity.engageTarget === null || entity.engageTimer > 0 || entity.engageTarget.health <= 0)
+            // A targetless entity is not this system's shooter, and its
+            // slots are never written — the player's craft lives here, its
+            // own trigger held through the command bus.
+            if (entity.engageTarget === null)
                 continue;
-            if (Geo.distance(entity, entity.engageTarget) > root.engageRange)
+            const def = Abilities.defFor(entity.engageAbility) as AbilityLaunch;
+            const open = def !== null && root.cleared(entity, def);
+            root.grip(entity, open && def.automatic ? entity.engageAbility : "");
+            if (def === null || def.automatic)
                 continue;
-            const off = Geo.wrap180(Geo.bearing(entity, entity.engageTarget) - entity.heading);
-            if (Math.abs(off) > entity.radarFov / 2)
-                continue;
-            // A pillar between shooter and target breaks the radar picture
-            // the shot needs, so ducking behind one denies the launch.
-            if (!Geo.lineOfSight(entity, entity.engageTarget, root.obstacles))
+            if (!open || entity.engageTimer > 0)
                 continue;
             root.fire(entity);
         }
     }
 
-    // Raises the named launch on its ready slot, winding the pacing back up.
-    // A slot already holding a shot armed is left alone: it fires itself the
-    // tick its lock appears, and asking again would only re-pace it.
+    // Whether every gate a launch needs is open: the target alive, the
+    // selected round real, the range inside what it can physically fly, the
+    // target inside the radar cone and the line to it clear of the arena's
+    // pillars — ducking behind one denies the shot.
+    function cleared(entity: Entity, def: AbilityLaunch): bool {
+        const target = entity.engageTarget;
+        if (target === null || target.health <= 0)
+            return false;
+        const round = Database.weaponDataFor(def.weapon);
+        if (round === null)
+            return false;
+        if (Geo.distance(entity, target) > round.reach)
+            return false;
+        const off = Geo.wrap180(Geo.bearing(entity, target) - entity.heading);
+        if (Math.abs(off) > entity.radarFov / 2)
+            return false;
+        return Geo.lineOfSight(entity, target, root.obstacles);
+    }
+
+    // Sets the trigger position across the entity's automatic slots: down on
+    // the one carrying the named ability, up on every other — "" releases
+    // them all, which is also what lets go when a stance switches the
+    // selected ability away mid-burst. Written only on change, like every
+    // per-tick mark.
+    function grip(entity: Entity, name: string) {
+        for (let i = 0; i < entity.abilities.length; ++i) {
+            const slot = entity.abilities[i];
+            if (slot.def === null || !slot.def.automatic)
+                continue;
+            const hold = slot.def.name === name;
+            if (slot.held !== hold)
+                slot.held = hold;
+        }
+    }
+
+    // Raises the selected launch on its ready slot, winding the pacing back
+    // up. A slot already holding a shot armed is left alone: it fires itself
+    // the tick its lock appears, and asking again would only re-pace it.
     function fire(entity: Entity) {
         for (let i = 0; i < entity.abilities.length; ++i) {
             const slot = entity.abilities[i];
-            if (slot.def.name === root.ability && slot.ready && !slot.armed) {
+            if (slot.def.name === entity.engageAbility && slot.ready && !slot.armed) {
                 slot.activate();
                 entity.engageTimer = entity.engageHoldoff;
                 return;

--- a/app/briarthorn/qml/systems/SystemPersonality.qml
+++ b/app/briarthorn/qml/systems/SystemPersonality.qml
@@ -39,7 +39,8 @@ System {
         const def = Personalities.defFor(entity.personality);
         entity.mind = root.mindFactory.createObject(entity, {
             def: def,
-            baseHoldoff: entity.engageHoldoff
+            baseHoldoff: entity.engageHoldoff,
+            baseAbility: entity.engageAbility
         }) as PersonalityState;
         if (def === null) {
             console.warn("SystemPersonality: no registered personality named \"" + entity.personality + "\"");
@@ -59,14 +60,18 @@ System {
         root.vet(def);
     }
 
-    // Warns about any switch destination the definition lacks, so a typo'd
-    // stance name surfaces at spawn instead of as a silent hold mid-fight.
+    // Warns about any switch destination the definition lacks and any stance
+    // firing an unregistered launch, so a typo'd name surfaces at spawn
+    // instead of as a silent hold mid-fight.
     function vet(def: Personality) {
         for (let i = 0; i < def.switches.length; ++i)
             root.vetSwitch(def, def.switches[i]);
         for (let i = 0; i < def.stances.length; ++i) {
-            for (let j = 0; j < def.stances[i].switches.length; ++j)
-                root.vetSwitch(def, def.stances[i].switches[j]);
+            const stance = def.stances[i];
+            if (stance.ability !== "" && !(Abilities.defFor(stance.ability) instanceof AbilityLaunch))
+                console.warn("SystemPersonality: personality \"" + def.name + "\" stance \"" + stance.name + "\" fires \"" + stance.ability + "\", which names no registered launch ability");
+            for (let j = 0; j < stance.switches.length; ++j)
+                root.vetSwitch(def, stance.switches[j]);
         }
     }
 
@@ -207,6 +212,7 @@ System {
         }
         entity.engageHold = stance.holdFire;
         entity.engageHoldoff = stance.holdoff >= 0 ? stance.holdoff : mind.baseHoldoff;
+        entity.engageAbility = stance.ability !== "" ? stance.ability : mind.baseAbility;
     }
 
     // What the stance's maneuver flies against: the inbound round or the

--- a/app/briarthorn/qml/systems/SystemWeapon.qml
+++ b/app/briarthorn/qml/systems/SystemWeapon.qml
@@ -175,11 +175,13 @@ System {
         missile.commandedSteer = Math.max(-1, Math.min(1, error / root.cutAngle));
     }
 
-    // Consumes launches: a slot fires on a raised intent or on a shot held
-    // armed, and only where the survey above says every check passes — a
-    // guided round with nothing to lock keeps its charge and stays armed
-    // instead, waiting for the pilot to fix what the scope is showing them.
-    // One arming is one round, so a launch stands the slot back down. The
+    // Consumes launches: a slot fires on a raised intent, on a shot held
+    // armed, or — automatic fire — every time its cooldown allows while the
+    // trigger is held down, and only where the survey above says every check
+    // passes — a guided round with nothing to lock keeps its charge and
+    // stays armed instead, waiting for the pilot to fix what the scope is
+    // showing them. One arming is one round, so a launch stands the slot
+    // back down; a held trigger stands down only when its owner lets go. The
     // spawned missile takes its whole flight envelope from its database row
     // and inherits the launcher's side.
     function consumeLaunches() {
@@ -197,9 +199,10 @@ System {
                     // might.
                     slot.pending = false;
                     slot.armed = false;
+                    slot.held = false;
                     continue;
                 }
-                const raised = slot.pending || slot.armed;
+                const raised = slot.pending || slot.armed || slot.held;
                 slot.pending = false;
                 if (!raised)
                     continue;
@@ -208,8 +211,11 @@ System {
                     // before this one, and the shot can go stale in between.
                     // It is held armed rather than dropped: a press must never
                     // be spent on nothing, which is the whole complaint the
-                    // arming state answers.
-                    slot.armed = true;
+                    // arming state answers. An automatic slot never arms —
+                    // its held trigger re-raises itself every tick it stays
+                    // down, and letting go must stop the fire outright.
+                    if (!slot.def.automatic)
+                        slot.armed = true;
                     continue;
                 }
                 slot.armed = false;

--- a/app/briarthorn/qml/ui/AbilityButton.qml
+++ b/app/briarthorn/qml/ui/AbilityButton.qml
@@ -81,6 +81,10 @@ Item {
     // thumb lands matches the rising edge a key or a pad button fires on.
     signal tapped
 
+    // The thumb coming back off — the falling edge an automatic ability's
+    // trigger stops on.
+    signal released
+
     // Fired with it when the press came from a touchscreen, so the HUD can hand
     // the interface back to the touch controls the moment a thumb lands on one.
     signal touched
@@ -250,10 +254,14 @@ Item {
         id: handler
 
         acceptedButtons: Qt.NoButton
-        onActiveChanged: if (handler.active) {
-            if (handler.point.device.type === PointerDevice.TouchScreen)
-                root.touched();
-            root.tapped();
+        onActiveChanged: {
+            if (handler.active) {
+                if (handler.point.device.type === PointerDevice.TouchScreen)
+                    root.touched();
+                root.tapped();
+            } else {
+                root.released();
+            }
         }
     }
 }

--- a/app/briarthorn/qml/ui/ViewAbilities.qml
+++ b/app/briarthorn/qml/ui/ViewAbilities.qml
@@ -46,9 +46,11 @@ Row {
     }
 
     // Carries the pressed ability's name out, so the row stays a control and
-    // never touches the bus, and reports a press that came from a thumb, so the
-    // HUD can hand the interface back to the touch controls.
+    // never touches the bus, its release for the automatic slots that stop on
+    // it, and reports a press that came from a thumb, so the HUD can hand the
+    // interface back to the touch controls.
     signal invoked(string ability)
+    signal released(string ability)
     signal touched
 
     spacing: 8
@@ -68,7 +70,7 @@ Row {
 
             label: button.modelData.def ? button.modelData.def.label : ""
             charges: button.modelData.charges
-            valid: button.modelData.valid
+            valid: button.modelData.willing
             armed: button.modelData.armed
             impediment: button.modelData.impediment
             cooling: button.modelData.cooling
@@ -86,6 +88,8 @@ Row {
             // a loadout typo must not reach the bus.
             onTapped: if (button.modelData.def)
                 root.invoked(button.ability)
+            onReleased: if (button.modelData.def)
+                root.released(button.ability)
             onTouched: root.touched()
 
             // The refusal beat is raised by the slot, not by the press: an

--- a/app/briarthorn/qml/ui/ViewHudOverlay.qml
+++ b/app/briarthorn/qml/ui/ViewHudOverlay.qml
@@ -40,9 +40,11 @@ Item {
     property string selectedContact: ""
     property string shootableContact: ""
 
-    // The ability rack's press and its touch report, and the scope's
-    // designation tap and its own touch report — Main routes all four.
+    // The ability rack's press, its release and its touch report, and the
+    // scope's designation tap and its own touch report — Main routes them
+    // all.
     signal invoked(string ability)
+    signal released(string ability)
     signal touched
     signal contactChosen(string contactId)
     signal contactTouched
@@ -146,6 +148,7 @@ Item {
         loadout: root.ownship.abilities
         device: root.device
         onInvoked: ability => root.invoked(ability)
+        onReleased: ability => root.released(ability)
         onTouched: root.touched()
 
         anchors {

--- a/app/briarthorn/qml/ui/ViewHudTiled.qml
+++ b/app/briarthorn/qml/ui/ViewHudTiled.qml
@@ -38,10 +38,11 @@ Item {
     property string selectedContact: ""
     property string shootableContact: ""
 
-    // The rack's press and touch report, and the designation pick and its
-    // touch report — from the scope's marks or (later) the track list's
-    // rows, one contract either way. Main routes all four.
+    // The rack's press, release and touch report, and the designation pick
+    // and its touch report — from the scope's marks or (later) the track
+    // list's rows, one contract either way. Main routes them all.
     signal invoked(string ability)
+    signal released(string ability)
     signal touched
     signal contactChosen(string contactId)
     signal contactTouched
@@ -212,6 +213,7 @@ Item {
             device: root.device
             racks: root.racks
             onInvoked: ability => root.invoked(ability)
+            onReleased: ability => root.released(ability)
             onTouched: root.touched()
         }
     }

--- a/app/briarthorn/qml/ui/ViewStatusBars.qml
+++ b/app/briarthorn/qml/ui/ViewStatusBars.qml
@@ -1,3 +1,7 @@
+// The BarRow component reaches the file root's rows column; bound component
+// behaviour is what makes that resolve statically.
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import "../model"
 import "../themes"

--- a/app/briarthorn/qml/ui/ViewStores.qml
+++ b/app/briarthorn/qml/ui/ViewStores.qml
@@ -26,8 +26,10 @@ Item {
     required property ActiveDevice device
     property bool racks: false
 
-    // The rack's press and its touch report, routed by the caller.
+    // The rack's press, its release and its touch report, routed by the
+    // caller.
     signal invoked(string ability)
+    signal released(string ability)
     signal touched
 
     // Rounds in the air across the whole loadout; which rack each came from
@@ -88,7 +90,7 @@ Item {
             // The user's colour language: green would take, caution cannot
             // yet, and the refusal beat below overrides both in the error
             // colour.
-            readonly property color loadedTint: rack.modelData.valid ? Style.theme.armValid : Style.theme.warn
+            readonly property color loadedTint: rack.modelData.willing ? Style.theme.armValid : Style.theme.warn
 
             // The armed breathing, shared by the slot's whole station group;
             // written only by the animation, never bound over.
@@ -214,6 +216,7 @@ Item {
         loadout: root.ownship.abilities
         device: root.device
         onInvoked: ability => root.invoked(ability)
+        onReleased: ability => root.released(ability)
         onTouched: root.touched()
 
         anchors {

--- a/app/briarthorn/qml/ui/ViewTracks.qml
+++ b/app/briarthorn/qml/ui/ViewTracks.qml
@@ -124,7 +124,9 @@ Item {
                 viewRotation: root.viewRotation
                 classification: mark.track ? mark.track.classification : Classification.Kind.Unknown
                 side: mark.track ? mark.track.side : Side.Kind.Unknown
-                showLabel: root.showLabels
+                // Labels ride the view's switch and the kind's own say — a
+                // tracer plots as a bare streak, not a captioned contact.
+                showLabel: root.showLabels && (!mark.track || Database.dataFor(mark.track.classification).trackLabel)
                 label: !mark.track || mark.track.classification === Classification.Kind.Unknown ? "" : mark.track.contactId
                 caption: mark.rangeCaption
                 hasHealth: root.showHealth && mark.track && mark.track.maxHealth > 0


### PR DESCRIPTION
## What

A gatling gun for the fighters: a fourth ability (`gun`, key **G**, pad **RS**) streaming 8 unguided tracer rounds a second while the trigger is held, priced to a 10 km envelope (kinetic 10 x 2.5 muzzle multiplier x 4 s of flight) - the close-combat complement to the missile racks. The SMS stores page draws its station as a turret mount on the nose, and the AI duelist switches to it for a knife fight whenever the merge closes inside the gun's reach.

## How

- **Hold-to-fire (`Ability.automatic`)**: `AbilitySlot.held` is the trigger position. `Entity.invoke()` puts it down (never arms, never toggles), `Entity.release()` lifts it, and `SystemWeapon` fires a round every time the cooldown allows while it is down. The falling edge reaches the store from every input path: the key/pad axis posts `active: false` when its fold returns to rest (so a focus loss releases via the existing `dropInput()`), and the touch rack forwards the button's release through `ViewAbilities`/`ViewStores`/both HUDs. A held trigger deliberately never takes the arm-on-stale branch, or releasing mid-cooldown would leak one round.
- **`engageAbility` moves onto the entity** (the aspect the gameplay audit flagged as a prerequisite for mixed racks): `SystemEngage` prices each entity's selected round per tick, `Stance.ability` retargets it, and `PersonalityState.baseAbility` restores it. For automatic slots the trigger is *gripped*, not paced - held while every gate holds (alive target, reach, cone, line of sight), released the tick one fails or a stance switches weapons. The system never writes a target-less entity's slots: it sweeps the whole roster, and the player's craft lives there with its trigger owned by the command bus.
- **Duelist `brawl` stance** (pursue + gun): entered from press, crank and withdraw at 1.0x the gun round's reach - a new `SwitchRange.ability` envelope, so the band tracks the weapon's own tuning rather than a metre - and exited at 1.1x with dwell so the edge never flaps. A bandit that used to turn tail when you closed on it now turns and fights.
- **Presentation**: bullets plot as bare 2-point tracer lines (`ShapePolygon` strokes the degenerate polyline), unlabelled via a new per-kind `Data.trackLabel`; the turret glyph rides the existing `stationKind` seam (presentation-only `DataTurret` row, zero `ViewStores` edits); controls colour by a new `AbilitySlot.willing` (valid, or automatic with rounds left) because `valid` strobes with the 0.125 s cooldown at 8 Hz; the launch whoosh excludes automatic slots.

## Reviewer notes

- The gun magazine is finite (300) on purpose: an unlimited launch slot makes `SystemPersonality.roundsOf()` Infinity and the duelist's ammo-out disengage switch unreachable.
- Bullets are full entities (durable 0, so blasts pass them by and only the fuze or timeout despawns them). Sustained two-way fire peaks around 30 in the air per shooter; if that ever stutters on weak hardware, rate and duration are the knobs.
- Inbound bullets mark `threatInbound` like any round, so sustained fire pushes the bandit into its defensive guard stance - a deliberate tuning surface, bounded by the finite magazine.
- Fixed in passing: `ViewStatusBars.qml` was missing `pragma ComponentBehavior: Bound` and failing the `qmllint-check` gate on main.
- Verified: a 22-check deterministic qml.exe sim harness (brawl entry/exit, the gripped stream, damage, player hold/release, and the engage-sweep-vs-player-trigger boundary), `qmllint-check` green, debug build, headless smoke boot, and offscreen renders of the stores page and tracer marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)